### PR TITLE
Fix import path for RagService dependency

### DIFF
--- a/src/app/dependencies.py
+++ b/src/app/dependencies.py
@@ -1,1 +1,12 @@
-# src/app/dependencies.py
+"""FastAPI dependencies for the application."""
+
+from src.app.factory import get_rag_service as _get_rag_service
+from src.core.services.rag import RagService
+
+
+def get_rag_service() -> RagService:
+    """Return the singleton :class:`RagService` instance."""
+    return _get_rag_service()
+
+
+__all__ = ["get_rag_service"]


### PR DESCRIPTION
## Summary
- implement missing `src/app/dependencies.get_rag_service`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_683f5508e270832eac5dd0b4d0e31714