### PR TITLE
PR1 (02-2026): Operabilidad y diagnóstico: `/api/ready` estricto + `rag-status` con drift/corrupción

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,3 +212,5 @@ figures/
 
 build_package.py
 concatenate_src.py
+
+/pr

--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ Notes:
 * Retrieval “scores” are normalized to [0,1] in the adapters.
 * The service persists each Q/A with the IDs of the retrieved sources.
 * In dense/hybrid mode, **FAISS is derived state**; use `/api/docs/delete` (or `rag-delete-docs`) instead of deleting rows manually.
+* In dense/hybrid mode, `/api/ready` is intentionally strict and returns `503` when it detects missing/corrupt index files or drift between SQLite documents and the vector index (hinting how to rebuild).
 
 Example:
 

--- a/src/local_rag_backend/app/api_router.py
+++ b/src/local_rag_backend/app/api_router.py
@@ -5,6 +5,7 @@ FastAPI router for the application endpoints.
 
 from __future__ import annotations
 
+import json
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any
@@ -23,6 +24,12 @@ from local_rag_backend.core.services.maintenance import (
     rebuild_index_from_db,
 )
 from local_rag_backend.core.services.rag import RagService
+from local_rag_backend.diagnostics import (
+    get_document_ids,
+    get_documents_count,
+    get_history_count,
+    get_retrieval_index_stats,
+)
 from local_rag_backend.infrastructure.embeddings.openai import OpenAIEmbedder
 from local_rag_backend.infrastructure.embeddings.sentence_transformers import (
     SentenceTransformerEmbedder,
@@ -142,6 +149,7 @@ async def readiness_check() -> dict[str, Any]:
     """Check if all dependencies are ready to handle requests."""
     checks: dict[str, Any] = {}
     is_ready = True
+    docs_count: int | None = None
 
     # 1. Database connectivity
     try:
@@ -151,6 +159,21 @@ async def readiness_check() -> dict[str, Any]:
     except Exception as e:
         checks["database"] = f"failed: {e!s}"
         is_ready = False
+
+    # 1b. Basic DB stats (best-effort)
+    if checks.get("database") == "ok":
+        try:
+            docs_count = get_documents_count(db_base.engine)
+            checks["documents"] = {"count": docs_count}
+        except Exception as e:
+            checks["documents"] = f"failed: {e!s}"
+            is_ready = False
+
+        try:
+            checks["history"] = {"count": get_history_count(db_base.engine)}
+        except Exception as e:
+            checks["history"] = f"failed: {e!s}"
+            # history is non-critical for answering questions; don't force not-ready here
 
     # 2. RAG service (best-effort: do not fail the endpoint before reporting readiness)
     try:
@@ -172,12 +195,56 @@ async def readiness_check() -> dict[str, Any]:
 
     # 4. Retrieval index (for dense/hybrid modes)
     if settings.retrieval_mode in ["dense", "hybrid"]:
-        index_ok = Path(settings.index_path).exists() and Path(settings.id_map_path).exists()
-        if index_ok:
-            checks["retrieval_index"] = "ok"
-        else:
-            checks["retrieval_index"] = "failed: not found"
+        stats = get_retrieval_index_stats(
+            index_path=settings.index_path, id_map_path=settings.id_map_path, dim=None
+        )
+        checks["retrieval_index_stats"] = stats
+
+        if stats.get("status") != "ok":
+            checks["retrieval_index"] = (
+                f"failed: {stats.get('status')} "
+                f"(index_path={stats.get('index_path')}, id_map_path={stats.get('id_map_path')}). "
+                f"Hint: {stats.get('hint')}"
+            )
             is_ready = False
+        else:
+            checks["retrieval_index"] = "ok"
+
+            # Consistency checks vs SQLite (best-effort, but actionable when it fails)
+            if docs_count is not None:
+                vectors = int(stats.get("vectors") or 0)
+                id_map_len = int(stats.get("id_map_len") or 0)
+                if docs_count != id_map_len:
+                    checks["retrieval_index"] = (
+                        f"failed: drift detected (documents={docs_count}, vectors={vectors}). "
+                        "Hint: rebuild the index (`rag-rebuild-index` or POST /api/index/rebuild)."
+                    )
+                    is_ready = False
+                else:
+                    # Optional deep check: compare sets when the corpus is small enough.
+                    # Keep /ready fast for larger corpora.
+                    if docs_count <= 5000:
+                        try:
+                            db_ids = set(get_document_ids(db_base.engine))
+                            index_ids = set(
+                                json.loads(Path(settings.id_map_path).read_text(encoding="utf-8"))
+                            )
+                            stale = sorted(index_ids - db_ids)
+                            missing = sorted(db_ids - index_ids)
+                            if stale or missing:
+                                checks["retrieval_index_drift"] = {
+                                    "stale_in_index": stale[:20],
+                                    "missing_in_index": missing[:20],
+                                    "stale_count": len(stale),
+                                    "missing_count": len(missing),
+                                }
+                                checks["retrieval_index"] = (
+                                    "failed: drift detected (ID set mismatch). "
+                                    "Hint: rebuild the index (`rag-rebuild-index` or POST /api/index/rebuild)."
+                                )
+                                is_ready = False
+                        except Exception as e:
+                            checks["retrieval_index_drift"] = f"failed: {e!s}"
 
     response_payload = {"status": "ready" if is_ready else "not_ready", "checks": checks}
     if not is_ready:

--- a/src/local_rag_backend/cli.py
+++ b/src/local_rag_backend/cli.py
@@ -15,6 +15,11 @@ import click
 import uvicorn
 
 from local_rag_backend import __version__
+from local_rag_backend.diagnostics import (
+    get_documents_count,
+    get_history_count,
+    get_retrieval_index_stats,
+)
 from local_rag_backend.settings import settings
 
 
@@ -164,6 +169,8 @@ def bootstrap() -> None:
 @cli.command()
 def status() -> None:
     """Display system status and configuration."""
+    from local_rag_backend.infrastructure.persistence.sqlalchemy import base as db_base
+
     # Styles
     title_fg = "cyan"
     key_fg = "blue"
@@ -210,6 +217,55 @@ def status() -> None:
         status_icon = "✅ YES" if path.exists() else "❌ NO"
         click.echo(f"  {click.style(name + ':', fg=key_fg, bold=True)} {status_icon}")
         click.echo(f"    Path: {path}")
+
+    # Consistency / counts (best-effort)
+    click.echo()
+    click.secho("📊 Data & Index Diagnostics", fg=title_fg, bold=True)
+
+    docs_count: int | None = None
+    try:
+        docs_count = get_documents_count(db_base.engine)
+        click.echo(f"  {click.style('Documents:', fg=key_fg, bold=True)} {docs_count}")
+    except Exception as e:
+        click.echo(f"  {click.style('Documents:', fg=key_fg, bold=True)} [ERROR] {e!s}")
+
+    try:
+        hist = get_history_count(db_base.engine)
+        click.echo(f"  {click.style('History:', fg=key_fg, bold=True)} {hist}")
+    except Exception as e:
+        click.echo(f"  {click.style('History:', fg=key_fg, bold=True)} [WARN] {e!s}")
+
+    if settings.retrieval_mode in ("dense", "hybrid"):
+        stats = get_retrieval_index_stats(
+            index_path=settings.index_path, id_map_path=settings.id_map_path, dim=None
+        )
+        status_txt = str(stats.get("status"))
+        if status_txt == "ok":
+            click.echo(
+                f"  {click.style('Index:', fg=key_fg, bold=True)} "
+                f"{stats.get('vectors')} vectors "
+                f"(dim={stats.get('dim')}, backend={stats.get('backend')})"
+            )
+            if int(stats.get("duplicates") or 0):
+                click.echo(
+                    f"  {click.style('Index drift:', fg=key_fg, bold=True)} "
+                    f"[ERROR] duplicates={stats.get('duplicates')} "
+                    f"(hint: {stats.get('hint')})"
+                )
+            elif docs_count is not None and int(stats.get("id_map_len") or 0) != docs_count:
+                click.echo(
+                    f"  {click.style('Index drift:', fg=key_fg, bold=True)} "
+                    f"[ERROR] documents={docs_count} id_map={stats.get('id_map_len')} "
+                    "(hint: run `rag-rebuild-index`)"
+                )
+            else:
+                click.echo(f"  {click.style('Index drift:', fg=key_fg, bold=True)} OK")
+        else:
+            click.echo(
+                f"  {click.style('Index:', fg=key_fg, bold=True)} "
+                f"[ERROR] {status_txt} "
+                f"(hint: {stats.get('hint')})"
+            )
 
 
 # Entry point functions for setuptools

--- a/src/local_rag_backend/diagnostics.py
+++ b/src/local_rag_backend/diagnostics.py
@@ -1,0 +1,105 @@
+"""
+Operational diagnostics used by both API readiness and CLI status.
+
+The goal is to expose actionable information (counts, drift, remediation hints)
+without coupling callers to SQLAlchemy sessions or FAISS internals.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import text
+
+if TYPE_CHECKING:
+    from sqlalchemy.engine import Engine
+
+
+def get_documents_count(engine: Engine) -> int:
+    with engine.connect() as conn:
+        return int(conn.execute(text("SELECT COUNT(*) FROM documents")).scalar() or 0)
+
+
+def get_history_count(engine: Engine) -> int:
+    with engine.connect() as conn:
+        return int(conn.execute(text("SELECT COUNT(*) FROM qa_history")).scalar() or 0)
+
+
+def get_document_ids(engine: Engine, *, limit: int | None = None) -> list[int]:
+    sql = "SELECT id FROM documents ORDER BY id"
+    if limit is not None:
+        sql += " LIMIT :limit"
+    with engine.connect() as conn:
+        rows = conn.execute(text(sql), {"limit": limit} if limit is not None else {}).fetchall()
+    return [int(r[0]) for r in rows]
+
+
+def get_retrieval_index_stats(
+    *, index_path: str | Path, id_map_path: str | Path, dim: int | None = None
+) -> dict[str, Any]:
+    """
+    Return best-effort stats for the on-disk retrieval index.
+
+    This is safe to call even when optional deps are missing. It returns:
+      - status: ok|missing|corrupt
+      - hint: remediation hint when not ok
+      - vectors/id_map_len/unique_ids/duplicates/dim/backend when ok (best-effort)
+    """
+    idx_path = Path(index_path)
+    map_path = Path(id_map_path)
+
+    missing: list[str] = []
+    if not idx_path.exists():
+        missing.append(str(idx_path))
+    if not map_path.exists():
+        missing.append(str(map_path))
+    if missing:
+        return {
+            "status": "missing",
+            "missing": missing,
+            "index_path": str(idx_path),
+            "id_map_path": str(map_path),
+            "hint": "Create/rebuild the index (e.g. `rag-rebuild-index` or POST /api/index/rebuild).",
+        }
+
+    try:
+        from local_rag_backend.infrastructure.persistence.faiss.index import FaissIndex
+
+        idx = FaissIndex(idx_path, map_path, dim=dim)
+        id_map_len = len(idx.id_map)
+        unique_ids = len(set(idx.id_map))
+        duplicates = int(id_map_len - unique_ids)
+        vectors = int(idx.ntotal)
+        backend = str(idx.backend)
+
+        payload: dict[str, Any] = {
+            "status": "ok",
+            "index_path": str(idx_path),
+            "id_map_path": str(map_path),
+            "backend": backend,
+            "dim": int(idx.dim),
+            "vectors": vectors,
+            "id_map_len": id_map_len,
+            "unique_ids": unique_ids,
+            "duplicates": duplicates,
+        }
+
+        if vectors != id_map_len:
+            payload["status"] = "corrupt"
+            payload["error"] = "index/id_map length mismatch"
+            payload["hint"] = "Rebuild the index to repair drift (e.g. `rag-rebuild-index`)."
+        elif duplicates:
+            payload["status"] = "corrupt"
+            payload["error"] = "duplicate document IDs in id_map"
+            payload["hint"] = "Rebuild the index to remove duplicates (e.g. `rag-rebuild-index`)."
+
+        return payload
+    except Exception as e:
+        return {
+            "status": "corrupt",
+            "index_path": str(idx_path),
+            "id_map_path": str(map_path),
+            "error": f"{type(e).__name__}: {e}",
+            "hint": "Rebuild the index (e.g. `rag-rebuild-index` or POST /api/index/rebuild).",
+        }

--- a/src/local_rag_backend/infrastructure/persistence/faiss/index.py
+++ b/src/local_rag_backend/infrastructure/persistence/faiss/index.py
@@ -134,6 +134,19 @@ class FaissIndex:
             self.dim = self._infer_dim_or_raise()
         self._load_or_initialize()
 
+    @property
+    def backend(self) -> str:
+        return "faiss" if self._faiss is not None else "numpy"
+
+    @property
+    def ntotal(self) -> int:
+        with self._state_lock:
+            if self._faiss is not None:
+                return int(getattr(self.index, "ntotal", 0) or 0)
+            if self._vectors is None:
+                return 0
+            return int(self._vectors.shape[0])
+
     def _infer_dim_or_raise(self) -> int:
         if not self.index_path.exists():
             raise ValueError("dim is required when creating a new index (no existing index file).")

--- a/tests/unit/app/test_api_router_docs_and_eval.py
+++ b/tests/unit/app/test_api_router_docs_and_eval.py
@@ -118,12 +118,13 @@ async def test_ask_eval_rejects_unsafe_prompt_template(asgi_client, in_memory_sq
     assert "prompt_template" in r.json().get("detail", "")
 
 
-async def test_ready_retrieval_index_present(asgi_client, tmp_path, monkeypatch):
-    # Create dummy index file
+async def test_ready_retrieval_index_present(asgi_client, in_memory_sqlite, tmp_path, monkeypatch):
+    # Create a minimal valid on-disk index + id-map.
+    from local_rag_backend.infrastructure.persistence.faiss.index import FaissIndex
+
     idx = tmp_path / "index.faiss"
-    idx.write_text("")
     id_map = tmp_path / "id_map.json"
-    id_map.write_bytes(b"")  # only need to exist for readiness
+    FaissIndex(idx, id_map, dim=4).rebuild([], [])
     monkeypatch.setattr(settings, "retrieval_mode", "dense", raising=False)
     monkeypatch.setattr(settings, "index_path", str(idx), raising=False)
     monkeypatch.setattr(settings, "id_map_path", str(id_map), raising=False)

--- a/tests/unit/app/test_health_endpoints.py
+++ b/tests/unit/app/test_health_endpoints.py
@@ -58,3 +58,97 @@ async def test_ready_endpoint_503_when_dense_index_missing(asgi_client, tmp_path
     detail = r.json()["detail"]
     assert detail["status"] == "not_ready"
     assert detail["checks"]["retrieval_index"].startswith("failed")
+
+
+async def test_ready_endpoint_503_when_dense_index_drifts_from_sql(
+    asgi_client, in_memory_sqlite, tmp_path, monkeypatch
+):
+    from local_rag_backend.infrastructure.persistence.faiss.index import FaissIndex
+    from local_rag_backend.infrastructure.persistence.sqlalchemy.sql_ import SqlDocumentStorage
+
+    monkeypatch.setattr(settings, "openai_api_key", "DUMMY", raising=False)
+    monkeypatch.setattr(settings, "retrieval_mode", "dense", raising=False)
+
+    idx = tmp_path / "index.faiss"
+    id_map = tmp_path / "id_map.json"
+    FaissIndex(idx, id_map, dim=4).rebuild([], [])
+    monkeypatch.setattr(settings, "index_path", str(idx), raising=False)
+    monkeypatch.setattr(settings, "id_map_path", str(id_map), raising=False)
+
+    # Seed DB with one document, but keep the index empty => drift.
+    SqlDocumentStorage().store_documents(["hello"])
+
+    async def _override():
+        return _DummyRag()
+
+    monkeypatch.setattr(api, "get_rag_service", _override, raising=True)
+    r = await asgi_client.get("/api/ready")
+    assert r.status_code == 503
+    detail = r.json()["detail"]
+    assert detail["status"] == "not_ready"
+    assert detail["checks"]["retrieval_index"].startswith("failed: drift")
+
+
+async def test_ready_endpoint_503_when_dense_index_id_set_mismatch(
+    asgi_client, in_memory_sqlite, tmp_path, monkeypatch
+):
+    """
+    Counts can match while the actual ID set differs (stale vectors + missing docs).
+    /api/ready should catch this for small corpora and return actionable drift details.
+    """
+    from local_rag_backend.infrastructure.persistence.faiss.index import FaissIndex
+    from local_rag_backend.infrastructure.persistence.sqlalchemy.sql_ import SqlDocumentStorage
+
+    monkeypatch.setattr(settings, "openai_api_key", "DUMMY", raising=False)
+    monkeypatch.setattr(settings, "retrieval_mode", "dense", raising=False)
+
+    # DB has ids {1,2}
+    SqlDocumentStorage().store_documents(["d1", "d2"])
+
+    # Index has ids {1,3} (same count, different set)
+    idx = tmp_path / "index.faiss"
+    id_map = tmp_path / "id_map.json"
+    FaissIndex(idx, id_map, dim=4).rebuild([1, 3], [[0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]])
+    monkeypatch.setattr(settings, "index_path", str(idx), raising=False)
+    monkeypatch.setattr(settings, "id_map_path", str(id_map), raising=False)
+
+    async def _override():
+        return _DummyRag()
+
+    monkeypatch.setattr(api, "get_rag_service", _override, raising=True)
+    r = await asgi_client.get("/api/ready")
+    assert r.status_code == 503
+    detail = r.json()["detail"]
+    assert detail["status"] == "not_ready"
+    assert detail["checks"]["retrieval_index"].startswith(
+        "failed: drift detected (ID set mismatch)"
+    )
+    drift = detail["checks"]["retrieval_index_drift"]
+    assert drift["stale_count"] == 1
+    assert drift["missing_count"] == 1
+
+
+async def test_ready_endpoint_503_when_dense_id_map_is_corrupt(
+    asgi_client, in_memory_sqlite, tmp_path, monkeypatch
+):
+    from local_rag_backend.infrastructure.persistence.faiss.index import FaissIndex
+
+    monkeypatch.setattr(settings, "openai_api_key", "DUMMY", raising=False)
+    monkeypatch.setattr(settings, "retrieval_mode", "dense", raising=False)
+
+    idx = tmp_path / "index.faiss"
+    id_map = tmp_path / "id_map.json"
+    FaissIndex(idx, id_map, dim=4).rebuild([], [])
+    id_map.write_bytes(b"")  # invalid/empty format
+    monkeypatch.setattr(settings, "index_path", str(idx), raising=False)
+    monkeypatch.setattr(settings, "id_map_path", str(id_map), raising=False)
+
+    async def _override():
+        return _DummyRag()
+
+    monkeypatch.setattr(api, "get_rag_service", _override, raising=True)
+    r = await asgi_client.get("/api/ready")
+    assert r.status_code == 503
+    detail = r.json()["detail"]
+    assert detail["status"] == "not_ready"
+    assert detail["checks"]["retrieval_index"].startswith("failed: corrupt")

--- a/tests/unit/test_cli_status_diagnostics.py
+++ b/tests/unit/test_cli_status_diagnostics.py
@@ -1,0 +1,29 @@
+# tests/unit/test_cli_status_diagnostics.py
+
+import re
+
+from click.testing import CliRunner
+
+from local_rag_backend.cli import cli
+from local_rag_backend.infrastructure.persistence.sqlalchemy.sql_ import SqlDocumentStorage
+from local_rag_backend.settings import settings
+
+
+def test_rag_status_reports_document_count(in_memory_sqlite, monkeypatch):
+    monkeypatch.setattr(settings, "retrieval_mode", "sparse", raising=False)
+    SqlDocumentStorage().store_documents(["a", "b"])
+
+    r = CliRunner().invoke(cli, ["status"])
+    assert r.exit_code == 0, r.output
+    assert re.search(r"Documents:\s+2\b", r.output)
+
+
+def test_rag_status_reports_missing_index_in_dense_mode(in_memory_sqlite, tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "retrieval_mode", "dense", raising=False)
+    monkeypatch.setattr(settings, "index_path", str(tmp_path / "missing.faiss"), raising=False)
+    monkeypatch.setattr(settings, "id_map_path", str(tmp_path / "missing.json"), raising=False)
+
+    r = CliRunner().invoke(cli, ["status"])
+    assert r.exit_code == 0, r.output
+    assert "Index:" in r.output
+    assert "missing" in r.output


### PR DESCRIPTION

**Summary**
Este PR mejora la operabilidad del MVP añadiendo diagnóstico accionable para evitar deriva entre SQLite (source of truth) y el índice vectorial (FAISS/numpy fallback) en modos `dense/hybrid`.

### Cambios principales:
- `/api/ready` ahora incluye stats de DB (`documents`, `qa_history`) y valida el estado del índice en `dense/hybrid`:
  - `503 not_ready` si faltan ficheros, el `id_map`/índice están corruptos, hay duplicados, mismatch de longitudes, o drift SQL vs índice.
  - Para corpus pequeño (`<= 5000` docs) compara sets de IDs y devuelve `stale/missing` con contadores y ejemplos (hasta 20) para diagnóstico rápido.
  - Incluye hints claros para remediación: `rag-rebuild-index` o `POST /api/index/rebuild`.
- `rag-status` añade sección “Data & Index Diagnostics” con:
  - conteo de documentos e historial
  - stats del índice (vectores/dim/backend) y estado de drift con hint de rebuild.
- Nuevo módulo `src/local_rag_backend/diagnostics.py` para centralizar diagnósticos y reutilizarlos desde API/CLI.
- `FaissIndex` expone `backend` y `ntotal` (para stats sin acoplar callers a internals).

#### Tests:
- Cobertura adicional para readiness: missing index, drift por conteo, drift por mismatch de IDs, `id_map` corrupto.
- Smoke tests de `rag-status` (conteo docs y reporte de índice missing en dense).

#### Docs:
- README: nota de que `/api/ready` es intencionalmente estricto en `dense/hybrid` y devolverá `503` si detecta drift/corrupción, con hints de rebuild.

## **Checklist DoD**
- [x] `rag-status` reporta conteos (docs/history), paths y diagnóstico de índice/drift (dense/hybrid).
- [x] `/api/ready` devuelve `503` con detalle accionable si falta índice, está corrupto o hay drift (dense/hybrid).
- [x] Tests exhaustivos añadidos sin duplicar cobertura existente.
- [x] Suite completa + linters + type checks en verde (`pytest`, `ruff`, `black`, `mypy`).
- [x] Revisión manual de coherencia: criterios de “ready” alineados con consistencia multi-store.
- [x] Docs actualizadas donde era necesario (`README.md`).

**Commits incluidos**
- `0a2d0d7` feat(ops): add readiness/index diagnostics and richer rag-status
- `5c0d00a` test(ops): cover readiness drift/corruption and cli status
- `7f8385f` docs: note strict /api/ready drift detection in dense/hybrid