### PR TITLE
PR2 (02-2026): Identidad de documento + metadata en SQLite (`external_id`, `source_id`, `metadata`, `sha256`, timestamps)

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,18 @@ integer primary keys after deletes unless `AUTOINCREMENT` is used. On startup, t
 best-effort migrate legacy `documents` tables to `AUTOINCREMENT` when the schema matches the expected
 columns (`id`, `content`). If you have a customized schema, the app will refuse to auto-migrate.
 
+### Upgrade notes (Document identity and metadata)
+
+To support idempotent ingestion and future upserts, the app also ensures the `documents` table contains
+stable identity fields and metadata. On startup (SQLite only), it will best-effort add/backfill the
+following columns if missing:
+
+* `external_id` (nullable, unique when set): stable document identity for upserts
+* `source_id` (nullable): traceability (e.g., filename/url)
+* `metadata` (JSON text): structured metadata (best-effort default `{}`)
+* `content_sha256`: content hash used by dedup/update policies
+* `created_at`, `updated_at`: timestamps (best-effort backfilled for legacy rows)
+
 ---
 
 ## Ingestion and indexing flow

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -193,6 +193,20 @@ In dense/hybrid retrieval, the system has **two stores**:
 * **SQLite** (`documents` table) is the source of truth for document text.
 * **FAISS** (`INDEX_PATH` + `ID_MAP_PATH`) is derived state: it maps `document_id -> embedding vector`.
 
+### Document Identity Contract
+
+The `documents` table is designed to support idempotent ingestion and future upserts:
+
+* `id`: internal integer primary key (stable due to SQLite `AUTOINCREMENT`)
+* `external_id`: optional stable identifier for a source document (unique when set)
+* `source_id`: optional provenance identifier (e.g., file path, URL)
+* `metadata`: JSON metadata captured at extraction time (stored as JSON text in SQLite)
+* `content_sha256`: hash of the stored `content` (dedup/update decisions)
+* `created_at`, `updated_at`: timestamps
+
+These fields allow you to track and update documents without relying on brittle “row order” or
+manual deletion. API/CLI upserts will build on this contract in subsequent PRs.
+
 The invariants that matter:
 
 * Document IDs must be stable (SQLite uses `AUTOINCREMENT` to avoid ID reuse after deletes).

--- a/src/local_rag_backend/app/main.py
+++ b/src/local_rag_backend/app/main.py
@@ -47,6 +47,7 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
     # Use the module reference so tests can monkeypatch `db_base.engine` / `db_base.SessionLocal`.
     db_base.Base.metadata.create_all(bind=db_base.engine)
     db_base.ensure_sqlite_documents_autoincrement(engine_to_use=db_base.engine)
+    db_base.ensure_sqlite_documents_identity_columns(engine_to_use=db_base.engine)
     # Best-effort preload: don't prevent the API from starting just because an LLM
     # provider isn't configured yet (readiness endpoint should report not_ready).
     try:

--- a/src/local_rag_backend/core/domain/entities.py
+++ b/src/local_rag_backend/core/domain/entities.py
@@ -7,13 +7,23 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import datetime
 
 
 @dataclass(frozen=True)
 class Document:
     id: int
     content: str
+    # Optional stable identity / traceability fields (may be None for legacy docs).
+    external_id: str | None = None
+    source_id: str | None = None
+    metadata: Mapping[str, Any] | None = None
+    content_sha256: str | None = None
+    created_at: datetime.datetime | None = None
+    updated_at: datetime.datetime | None = None
 
 
 @dataclass(frozen=True)

--- a/src/local_rag_backend/infrastructure/persistence/sqlalchemy/base.py
+++ b/src/local_rag_backend/infrastructure/persistence/sqlalchemy/base.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import datetime
+import hashlib
 import json
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -112,6 +114,93 @@ def ensure_sqlite_documents_autoincrement(
                     text("INSERT INTO sqlite_sequence(name, seq) VALUES ('documents', :seq)"),
                     {"seq": int(max_known)},
                 )
+
+
+def ensure_sqlite_documents_identity_columns(*, engine_to_use: Engine | None = None) -> None:
+    """
+    Ensure the `documents` table contains stable identity + metadata columns.
+
+    This is a best-effort, additive migration intended for SQLite deployments without Alembic.
+    It never drops data. It:
+    - Adds missing columns (external_id, source_id, metadata, content_sha256, created_at, updated_at)
+    - Backfills metadata/content_sha256/timestamps for existing rows when possible
+    - Creates a unique index for external_id (nullable; multiple NULLs allowed)
+    """
+    eng = engine_to_use or engine
+    if eng.dialect.name != "sqlite":
+        return
+
+    required_cols = {
+        "external_id",
+        "source_id",
+        "metadata",
+        "content_sha256",
+        "created_at",
+        "updated_at",
+    }
+
+    with eng.begin() as conn:
+        sql = conn.execute(
+            text("SELECT sql FROM sqlite_master WHERE type='table' AND name='documents'")
+        ).scalar()
+        if not sql:
+            return
+
+        cols = conn.execute(text("PRAGMA table_info(documents)")).fetchall()
+        col_names = {row[1] for row in cols}  # row[1] = name
+
+        missing = required_cols - col_names
+        if "external_id" in missing:
+            conn.execute(text("ALTER TABLE documents ADD COLUMN external_id TEXT"))
+        if "source_id" in missing:
+            conn.execute(text("ALTER TABLE documents ADD COLUMN source_id TEXT"))
+        if "metadata" in missing:
+            conn.execute(text("ALTER TABLE documents ADD COLUMN metadata TEXT"))
+        if "content_sha256" in missing:
+            conn.execute(text("ALTER TABLE documents ADD COLUMN content_sha256 TEXT"))
+        if "created_at" in missing:
+            conn.execute(text("ALTER TABLE documents ADD COLUMN created_at DATETIME"))
+        if "updated_at" in missing:
+            conn.execute(text("ALTER TABLE documents ADD COLUMN updated_at DATETIME"))
+
+        # Indexes (idempotent). Partial index keeps multiple NULLs and enforces uniqueness otherwise.
+        conn.execute(
+            text(
+                "CREATE UNIQUE INDEX IF NOT EXISTS ix_documents_external_id "
+                "ON documents(external_id) WHERE external_id IS NOT NULL"
+            )
+        )
+        conn.execute(
+            text("CREATE INDEX IF NOT EXISTS ix_documents_source_id ON documents(source_id)")
+        )
+
+        # Backfills (idempotent)
+        conn.execute(text("UPDATE documents SET metadata='{}' WHERE metadata IS NULL"))
+
+        now = datetime.datetime.now(datetime.UTC).replace(tzinfo=None)
+        # created_at/updated_at can be NULL for legacy rows: fill them with "now" for consistency.
+        conn.execute(
+            text("UPDATE documents SET created_at=:now WHERE created_at IS NULL"), {"now": now}
+        )
+        conn.execute(
+            text("UPDATE documents SET updated_at=:now WHERE updated_at IS NULL"), {"now": now}
+        )
+
+        # content_sha256: compute in python for rows where missing.
+        rows = conn.execute(
+            text(
+                "SELECT id, content FROM documents "
+                "WHERE content_sha256 IS NULL OR content_sha256 = ''"
+            )
+        ).fetchall()
+        for doc_id, content in rows:
+            if content is None:
+                continue
+            h = hashlib.sha256(str(content).encode("utf-8")).hexdigest()
+            conn.execute(
+                text("UPDATE documents SET content_sha256=:h WHERE id=:id"),
+                {"h": h, "id": int(doc_id)},
+            )
 
 
 async def get_db() -> AsyncGenerator[Session, None]:

--- a/src/local_rag_backend/infrastructure/persistence/sqlalchemy/crud.py
+++ b/src/local_rag_backend/infrastructure/persistence/sqlalchemy/crud.py
@@ -5,6 +5,7 @@ CRUD operations for SQLAlchemy models.
 
 from __future__ import annotations
 
+import hashlib
 from typing import TYPE_CHECKING
 
 from local_rag_backend.infrastructure.persistence.sqlalchemy.models import Document, QaHistory
@@ -22,7 +23,10 @@ def get_documents(db: Session, ids: list[int]) -> Sequence[Document]:
 
 def add_documents(db: Session, texts: list[str]) -> list[int]:
     """Store new documents and return their IDs."""
-    docs = [Document(content=text) for text in texts]
+    docs = [
+        Document(content=text, content_sha256=hashlib.sha256(text.encode("utf-8")).hexdigest())
+        for text in texts
+    ]
     db.add_all(docs)
     db.commit()
     return [doc.id for doc in docs]

--- a/src/local_rag_backend/infrastructure/persistence/sqlalchemy/models.py
+++ b/src/local_rag_backend/infrastructure/persistence/sqlalchemy/models.py
@@ -1,7 +1,7 @@
 # src/infrastructure/persistence/sqlalchemy/models.py
 
 import datetime
-from typing import ClassVar
+from typing import Any, ClassVar
 
 from sqlalchemy import DateTime, Text, func
 from sqlalchemy.orm import Mapped, mapped_column
@@ -22,6 +22,21 @@ class Document(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     content: Mapped[str] = mapped_column(Text, nullable=False)
+    # Stable identity for idempotent ingestion / upsert (PR2+PR3).
+    # Nullable so existing flows that only provide raw text keep working.
+    external_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Optional source identifier (e.g., filename/url) for traceability and grouping.
+    source_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Avoid attribute name `metadata` (reserved by SQLAlchemy declarative); keep DB column name "metadata".
+    metadata_: Mapped[dict[str, Any] | None] = mapped_column("metadata", JSON, nullable=True)
+    # Hash of raw content for dedup/update decisions. Filled best-effort for legacy rows.
+    content_sha256: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
 
 
 class QaHistory(Base):

--- a/src/local_rag_backend/infrastructure/persistence/sqlalchemy/sql_.py
+++ b/src/local_rag_backend/infrastructure/persistence/sqlalchemy/sql_.py
@@ -60,13 +60,37 @@ class SqlDocumentStorage(DocumentRepoPort):
         """Retrieve documents by their IDs."""
         with get_session(self._session_factory) as session:
             db_docs = session.query(DbDocument).filter(DbDocument.id.in_(ids)).all()
-            return [DomainDocument(id=d.id, content=d.content) for d in db_docs]
+            return [
+                DomainDocument(
+                    id=d.id,
+                    content=d.content,
+                    external_id=getattr(d, "external_id", None),
+                    source_id=getattr(d, "source_id", None),
+                    metadata=getattr(d, "metadata_", None),
+                    content_sha256=getattr(d, "content_sha256", None),
+                    created_at=getattr(d, "created_at", None),
+                    updated_at=getattr(d, "updated_at", None),
+                )
+                for d in db_docs
+            ]
 
     def get_all_documents(self) -> Sequence[DomainDocument]:
         """Retrieve all documents from the database."""
         with get_session(self._session_factory) as session:
             db_docs = session.query(DbDocument).order_by(DbDocument.id).all()
-            return [DomainDocument(id=d.id, content=d.content) for d in db_docs]
+            return [
+                DomainDocument(
+                    id=d.id,
+                    content=d.content,
+                    external_id=getattr(d, "external_id", None),
+                    source_id=getattr(d, "source_id", None),
+                    metadata=getattr(d, "metadata_", None),
+                    content_sha256=getattr(d, "content_sha256", None),
+                    created_at=getattr(d, "created_at", None),
+                    updated_at=getattr(d, "updated_at", None),
+                )
+                for d in db_docs
+            ]
 
 
 class HistorySqlStorage(QAHistoryPort):

--- a/tests/unit/infrastructure/persistence/sqlalchemy/test_sqlite_document_identity_columns.py
+++ b/tests/unit/infrastructure/persistence/sqlalchemy/test_sqlite_document_identity_columns.py
@@ -1,0 +1,80 @@
+# tests/unit/infrastructure/persistence/sqlalchemy/test_sqlite_document_identity_columns.py
+
+import hashlib
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import sessionmaker
+
+from local_rag_backend.infrastructure.persistence.sqlalchemy import base as db_base
+from local_rag_backend.infrastructure.persistence.sqlalchemy.models import Document as DbDocument
+from local_rag_backend.infrastructure.persistence.sqlalchemy.sql_ import SqlDocumentStorage
+
+
+def test_ensure_identity_columns_adds_and_backfills(tmp_path):
+    db_path = tmp_path / "app.db"
+    engine = create_engine(f"sqlite:///{db_path}", connect_args={"check_same_thread": False})
+
+    with engine.begin() as conn:
+        # Legacy minimal schema (no identity columns).
+        conn.execute(
+            text("CREATE TABLE documents (id INTEGER PRIMARY KEY NOT NULL, content TEXT NOT NULL)")
+        )
+        conn.execute(text("INSERT INTO documents(id, content) VALUES (1, 'hello')"))
+
+    # Startup order mirrors app lifespan.
+    db_base.ensure_sqlite_documents_autoincrement(engine_to_use=engine)
+    db_base.ensure_sqlite_documents_identity_columns(engine_to_use=engine)
+
+    with engine.begin() as conn:
+        cols = {row[1] for row in conn.execute(text("PRAGMA table_info(documents)")).fetchall()}
+        assert {
+            "external_id",
+            "source_id",
+            "metadata",
+            "content_sha256",
+            "created_at",
+            "updated_at",
+        }.issubset(cols)
+
+        row = conn.execute(
+            text(
+                "SELECT external_id, source_id, metadata, content_sha256, created_at, updated_at "
+                "FROM documents WHERE id=1"
+            )
+        ).fetchone()
+        assert row is not None
+        assert row[0] is None  # external_id
+        assert row[1] is None  # source_id
+        assert row[2] == "{}"  # metadata backfill (JSON text)
+        assert row[3] == hashlib.sha256(b"hello").hexdigest()
+        assert row[4] is not None
+        assert row[5] is not None
+
+
+def test_ensure_identity_columns_creates_unique_index_for_external_id(tmp_path):
+    db_path = tmp_path / "app.db"
+    engine = create_engine(f"sqlite:///{db_path}", connect_args={"check_same_thread": False})
+    SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+    # Create current schema via ORM and then ensure indexes exist (idempotent).
+    db_base.Base.metadata.create_all(bind=engine)
+    db_base.ensure_sqlite_documents_identity_columns(engine_to_use=engine)
+
+    with SessionLocal() as s:
+        s.add(DbDocument(content="a", external_id="X"))
+        s.commit()
+
+        s.add(DbDocument(content="b", external_id="X"))
+        with pytest.raises(IntegrityError):
+            s.commit()
+
+
+def test_store_documents_sets_content_sha256(in_memory_sqlite):
+    repo = SqlDocumentStorage(session_factory=in_memory_sqlite)
+    ids = list(repo.store_documents(["a", "b"]))
+    docs = repo.get(ids)
+    by_content = {d.content: d for d in docs}
+    assert by_content["a"].content_sha256 == hashlib.sha256(b"a").hexdigest()
+    assert by_content["b"].content_sha256 == hashlib.sha256(b"b").hexdigest()


### PR DESCRIPTION
## Summary 

Actualmente los documentos sólo tienen `id` y `content`. Para soportar ingestas idempotentes y futuras operaciones de upsert (PR3) hace falta un contrato de identidad estable y metadata persistida.

En `dense/hybrid`, además, el índice vectorial es estado derivado: la trazabilidad y la gestión segura de cambios requieren poder identificar documentos por una clave estable (`external_id`) y detectar cambios de contenido (`content_sha256`).

### **Cambios principales**
- Schema `documents` ampliado (SQLAlchemy):
  - `external_id` (nullable; único cuando está set)
  - `source_id` (nullable)
  - `metadata` (JSON; en ORM como `metadata_` para evitar conflicto con SQLAlchemy)
  - `content_sha256` (nullable; hash del `content`)
  - `created_at`, `updated_at`
- Migración SQLite best-effort (sin Alembic) en startup:
  - Nueva función `ensure_sqlite_documents_identity_columns(engine_to_use=...)`.
  - Añade columnas vía `ALTER TABLE` si faltan.
  - Backfill idempotente en filas legacy:
    - `metadata='{}'` si NULL
    - `created_at/updated_at` si NULL
    - `content_sha256` si falta (calculado en Python)
  - Índices idempotentes:
    - `ix_documents_external_id`: unique parcial (`WHERE external_id IS NOT NULL`)
    - `ix_documents_source_id`: index simple
- Inserción estándar (`store_documents`) ahora rellena `content_sha256`.
- Dominio: `Document` soporta campos opcionales (no rompe callers actuales).
- Persistencia: `SqlDocumentStorage.get/get_all_documents` devuelven esos campos cuando existan.


### **Tests añadidos / ajustados**
- `tests/unit/infrastructure/persistence/sqlalchemy/test_sqlite_document_identity_columns.py`
  - añade y backfillea columnas en schema legacy
  - verifica índice unique parcial de `external_id`
  - verifica que `store_documents` setea `content_sha256`

### **Docs**
- `README.md`: notas de upgrade sobre identidad/metadata.
- `docs/architecture.md`: "Document Identity Contract" en la sección de consistencia multi-store.

### **Checklist DoD**
- [x] Schema actualizado con identidad/metadata/timestamps.
- [x] Migración SQLite additive (sin pérdida de datos) + backfills idempotentes.
- [x] Unicidad de `external_id` (cuando no es NULL) garantizada por índice.
- [x] Tests específicos para migración + unicidad + sha256.
- [x] Suite completa + linters + type checks en verde (`pytest`, `ruff`, `black`, `mypy`).
- [x] Docs actualizadas (README + architecture) para reflejar el contrato.

### **Notas**
#### **Stacked PR**
Este PR está pensado para abrirse **con base `pr/02-2026-01-ops-diagnostics`** (PR1). Una vez PR1 mergee a `release/02-2026`, este PR se puede retarget/rebasear a `release/02-2026` para mantener el diff limpio.

#### Compatibilidad
- `external_id` es **nullable** para no romper flujos actuales que ingieren textos "raw".
- El endpoint `GET /api/docs` sigue devolviendo `{id, content}` por ahora (no se expone metadata/identity a HTTP en este PR).
- En SQLite, `metadata` queda almacenado como JSON text (columna `metadata`), y el ORM usa el atributo `metadata_`.


## **Commits incluidos**
- `9488953` feat(sql): add document identity columns + best-effort sqlite migration
- `cfb8daa` test(sqlite): cover identity column migration, unique external_id, sha256 fill
- `d29c8f0` docs: document document identity fields (external_id, metadata, hash, timestamps)


