### PR TITLE
PR3 (02-2026): Upsert idempotente por `external_id` (API/CLI) + política de actualización

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,10 @@ rag-rebuild-index
 rag-delete-docs 1 2 3
 
 
+# Upsert documents by external_id (idempotent)
+rag-upsert-docs --external-id doc-1 --content "hello"
+
+
 # Summarized system and files status
 rag-status
 ```
@@ -333,6 +337,7 @@ Notes:
   * Response: list of `{ id, question, answer, created_at, source_ids[] }`
 * FastAPI docs: `GET /docs` and `GET /openapi.json`
 * `POST /api/docs` (ingest texts) and `GET /api/docs` (list docs)
+* `POST /api/docs/upsert` (idempotent upsert by `external_id`)
 * `POST /api/docs/delete` (delete docs by ID; keeps SQL + FAISS consistent when applicable)
 * `POST /api/index/rebuild` (idempotent rebuild of FAISS from SQLite; dense/hybrid only)
 * `POST /api/openrouter/generate` (enabled if OpenRouter configured)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,6 +170,7 @@ rag-build-index = "local_rag_backend.cli:rag_build_index"
 rag-bootstrap   = "local_rag_backend.cli:rag_bootstrap"
 rag-delete-docs = "local_rag_backend.cli:rag_delete_docs"
 rag-rebuild-index = "local_rag_backend.cli:rag_rebuild_index"
+rag-upsert-docs = "local_rag_backend.cli:rag_upsert_docs"
 rag-server      = "local_rag_backend.cli:rag_server"
 rag-status      = "local_rag_backend.cli:rag_status"
 

--- a/src/local_rag_backend/app/api_router.py
+++ b/src/local_rag_backend/app/api_router.py
@@ -60,6 +60,9 @@ from local_rag_backend.models import (
     HistoryItem,
     QueryResult,
     RebuildIndexResponse,
+    UpsertDocResult,
+    UpsertDocsRequest,
+    UpsertDocsResponse,
 )
 from local_rag_backend.prompting import PromptTemplateError, validate_prompt_template
 from local_rag_backend.settings import settings
@@ -431,6 +434,79 @@ async def delete_docs(payload: Annotated[DeleteDocsRequest, Body(...)]) -> Delet
         return DeleteDocsResponse(deleted_sql=deleted_sql, deleted_index=None, rebuilt_index=False)
 
     resp = await run_blocking(_delete_sync)
+    reset_rag_service()
+    return resp
+
+
+@router.post("/docs/upsert", response_model=UpsertDocsResponse)
+async def upsert_docs(payload: Annotated[UpsertDocsRequest, Body(...)]) -> UpsertDocsResponse:
+    # Validate uniqueness early for deterministic behavior.
+    ext_ids = [d.external_id for d in payload.docs]
+    if len(set(ext_ids)) != len(ext_ids):
+        raise HTTPException(
+            status_code=400, detail="external_id values must be unique per request."
+        )
+
+    def _upsert_sync() -> UpsertDocsResponse:
+        doc_repo = SqlDocumentStorage()
+        items = [
+            SqlDocumentStorage.UpsertDoc(
+                external_id=d.external_id,
+                content=d.content,
+                source_id=d.source_id,
+                metadata=d.metadata,
+            )
+            for d in payload.docs
+        ]
+
+        results, changed_content, updated_content_ids = doc_repo.upsert_documents_by_external_id(
+            items
+        )
+        inserted = sum(1 for r in results if r.action == "inserted")
+        updated = sum(1 for r in results if r.action == "updated")
+        unchanged = sum(1 for r in results if r.action == "unchanged")
+
+        rebuilt_index = False
+        if settings.retrieval_mode in ("dense", "hybrid") and changed_content:
+            embedder = _build_embedder_for_dense()
+            vec = FaissVectorStorage(
+                index_path=settings.index_path,
+                id_map_path=settings.id_map_path,
+                dim=embedder.dim,
+            )
+
+            ids = [doc_id for doc_id, _ in changed_content]
+            texts = [text for _, text in changed_content]
+            vectors = embedder.embed(texts)
+            try:
+                # Updates must remove the old vector for that doc_id first.
+                if updated_content_ids:
+                    vec.delete(updated_content_ids)
+                vec.upsert(ids, vectors)
+            except Exception:
+                # Recovery: rebuild full index from DB.
+                rebuilt_index_from_db = rebuild_index_from_db(
+                    doc_repo=doc_repo, vec_repo=vec, embedder=embedder
+                )
+                rebuilt_index = rebuilt_index_from_db >= 0
+
+        return UpsertDocsResponse(
+            inserted=inserted,
+            updated=updated,
+            unchanged=unchanged,
+            rebuilt_index=rebuilt_index,
+            results=[
+                UpsertDocResult(
+                    external_id=r.external_id,
+                    id=r.id,
+                    action=r.action,
+                    content_changed=r.content_changed,
+                )
+                for r in results
+            ],
+        )
+
+    resp = await run_blocking(_upsert_sync)
     reset_rag_service()
     return resp
 

--- a/src/local_rag_backend/cli.py
+++ b/src/local_rag_backend/cli.py
@@ -8,6 +8,7 @@ starting the server, building indices, and bootstrapping data.
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
@@ -146,6 +147,125 @@ def delete_docs(ids: tuple[int, ...]) -> None:
         click.echo(f"[OK] Deleted {deleted_sql} docs from SQL.")
     except Exception as e:
         click.echo(f"[ERROR] Error deleting docs: {e}", err=True)
+        sys.exit(1)
+
+
+@cli.command("upsert-docs")
+@click.option(
+    "--json",
+    "json_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    required=False,
+    help="Path to a JSON file containing a list of {external_id, content, source_id?, metadata?}.",
+)
+@click.option("--external-id", type=str, required=False, help="External ID for a single document.")
+@click.option("--content", type=str, required=False, help="Content for a single document.")
+@click.option("--source-id", type=str, required=False, help="Optional source identifier.")
+@click.option(
+    "--metadata-json",
+    type=str,
+    required=False,
+    help="Optional metadata as JSON string for a single document.",
+)
+def upsert_docs(
+    json_path: Path | None,
+    external_id: str | None,
+    content: str | None,
+    source_id: str | None,
+    metadata_json: str | None,
+) -> None:
+    """Upsert documents by external_id (idempotent)."""
+    try:
+        from typing import Any, cast
+
+        from local_rag_backend.app.factory import reset_rag_service
+        from local_rag_backend.core.services.maintenance import rebuild_index_from_db
+        from local_rag_backend.infrastructure.embeddings.openai import OpenAIEmbedder
+        from local_rag_backend.infrastructure.embeddings.sentence_transformers import (
+            SentenceTransformerEmbedder,
+        )
+        from local_rag_backend.infrastructure.persistence.faiss.faiss_ import FaissVectorStorage
+        from local_rag_backend.infrastructure.persistence.sqlalchemy.sql_ import SqlDocumentStorage
+
+        docs_payload: list[dict[str, object]] = []
+        if json_path is not None:
+            docs_payload = json.loads(json_path.read_text(encoding="utf-8"))
+            if not isinstance(docs_payload, list):
+                raise ValueError("--json must contain a JSON list of documents")
+        else:
+            if not external_id or not content:
+                raise ValueError(
+                    "Provide --json or both --external-id and --content for a single document."
+                )
+            md_single = None
+            if metadata_json:
+                md_single = json.loads(metadata_json)
+                if not isinstance(md_single, dict):
+                    raise ValueError("--metadata-json must be a JSON object")
+            docs_payload = [
+                {
+                    "external_id": external_id,
+                    "content": content,
+                    "source_id": source_id,
+                    "metadata": md_single,
+                }
+            ]
+
+        items = []
+        for d in docs_payload:
+            if not isinstance(d, dict):
+                raise ValueError("Each document must be a JSON object")
+            md_obj = d.get("metadata")
+            md: dict[str, Any] | None = (
+                cast("dict[str, Any]", md_obj) if isinstance(md_obj, dict) else None
+            )
+            items.append(
+                SqlDocumentStorage.UpsertDoc(
+                    external_id=str(d.get("external_id") or "").strip(),
+                    content=str(d.get("content") or "").strip(),
+                    source_id=(str(d.get("source_id")) if d.get("source_id") is not None else None),
+                    metadata=md,
+                )
+            )
+
+        doc_repo = SqlDocumentStorage()
+        results, changed_content, updated_content_ids = doc_repo.upsert_documents_by_external_id(
+            items
+        )
+
+        inserted = sum(1 for r in results if r.action == "inserted")
+        updated = sum(1 for r in results if r.action == "updated")
+        unchanged = sum(1 for r in results if r.action == "unchanged")
+
+        rebuilt = False
+        if settings.retrieval_mode in ("dense", "hybrid") and changed_content:
+            embedder = (
+                OpenAIEmbedder()
+                if settings.openai_api_key
+                else SentenceTransformerEmbedder(model_name=settings.st_embedding_model)
+            )
+            vec = FaissVectorStorage(
+                index_path=settings.index_path,
+                id_map_path=settings.id_map_path,
+                dim=embedder.dim,
+            )
+            ids = [doc_id for doc_id, _ in changed_content]
+            texts = [text for _, text in changed_content]
+            vectors = embedder.embed(texts)
+            try:
+                if updated_content_ids:
+                    vec.delete(updated_content_ids)
+                vec.upsert(ids, vectors)
+            except Exception:
+                n = rebuild_index_from_db(doc_repo=doc_repo, vec_repo=vec, embedder=embedder)
+                rebuilt = n >= 0
+
+        reset_rag_service()
+        click.echo(
+            f"[OK] Upserted docs. inserted={inserted} updated={updated} unchanged={unchanged} rebuilt_index={rebuilt}"
+        )
+    except Exception as e:
+        click.echo(f"[ERROR] Error upserting docs: {e}", err=True)
         sys.exit(1)
 
 
@@ -297,6 +417,11 @@ def rag_rebuild_index() -> None:
 def rag_delete_docs() -> None:
     """Entry point for rag-delete-docs command."""
     cli.main(args=["delete-docs", *sys.argv[1:]], standalone_mode=False)
+
+
+def rag_upsert_docs() -> None:
+    """Entry point for rag-upsert-docs command."""
+    cli.main(args=["upsert-docs", *sys.argv[1:]], standalone_mode=False)
 
 
 if __name__ == "__main__":

--- a/src/local_rag_backend/infrastructure/persistence/sqlalchemy/sql_.py
+++ b/src/local_rag_backend/infrastructure/persistence/sqlalchemy/sql_.py
@@ -5,7 +5,9 @@ SQLAlchemy-based implementation of the document and history repositories.
 
 from __future__ import annotations
 
+import hashlib
 from contextlib import contextmanager, suppress
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from local_rag_backend.core.domain.entities import Document as DomainDocument
@@ -19,7 +21,8 @@ from local_rag_backend.infrastructure.persistence.sqlalchemy.crud import (
 from local_rag_backend.infrastructure.persistence.sqlalchemy.models import Document as DbDocument
 
 if TYPE_CHECKING:
-    from collections.abc import Generator, Sequence
+    from collections.abc import Generator, Mapping, Sequence
+    from typing import Any, Literal
 
     from sqlalchemy.orm import Session, sessionmaker
 
@@ -91,6 +94,129 @@ class SqlDocumentStorage(DocumentRepoPort):
                 )
                 for d in db_docs
             ]
+
+    @dataclass(frozen=True)
+    class UpsertDoc:
+        external_id: str
+        content: str
+        source_id: str | None = None
+        metadata: Mapping[str, Any] | None = None
+
+    @dataclass(frozen=True)
+    class UpsertResult:
+        external_id: str
+        id: int
+        action: Literal["inserted", "updated", "unchanged"]
+        content_changed: bool
+
+    def upsert_documents_by_external_id(
+        self, items: Sequence[UpsertDoc]
+    ) -> tuple[list[UpsertResult], list[tuple[int, str]], list[int]]:
+        """
+        Upsert documents by `external_id` (idempotent).
+
+        Returns:
+            (results, changed_content, updated_content_ids)
+
+        Where:
+            - results: per-item action summary
+            - changed_content: list[(doc_id, new_content)] for inserts + content updates
+            - updated_content_ids: list[doc_id] that existed and had content changed (for index delete)
+        """
+        items_list = list(items)
+        if not items_list:
+            return [], [], []
+
+        ext_ids = [i.external_id.strip() for i in items_list]
+        if any(not x for x in ext_ids):
+            raise ValueError("external_id must not be blank")
+        if len(set(ext_ids)) != len(ext_ids):
+            raise ValueError("external_id values must be unique within the request")
+
+        results: list[SqlDocumentStorage.UpsertResult] = []
+        changed_content: list[tuple[int, str]] = []
+        updated_content_ids: list[int] = []
+
+        with get_session(self._session_factory) as session:
+            existing = session.query(DbDocument).filter(DbDocument.external_id.in_(ext_ids)).all()
+            by_external_id = {d.external_id: d for d in existing if d.external_id is not None}
+
+            for item in items_list:
+                external_id = item.external_id.strip()
+                content = item.content.strip()
+                if not content:
+                    raise ValueError("content must not be blank")
+                sha = hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+                db_doc = by_external_id.get(external_id)
+                if db_doc is None:
+                    new_doc = DbDocument(
+                        content=content,
+                        external_id=external_id,
+                        source_id=item.source_id,
+                        metadata_=dict(item.metadata) if item.metadata is not None else None,
+                        content_sha256=sha,
+                    )
+                    session.add(new_doc)
+                    session.flush()  # allocate PK
+                    assert new_doc.id is not None
+                    results.append(
+                        SqlDocumentStorage.UpsertResult(
+                            external_id=external_id,
+                            id=int(new_doc.id),
+                            action="inserted",
+                            content_changed=True,
+                        )
+                    )
+                    changed_content.append((int(new_doc.id), content))
+                    continue
+
+                old_sha = getattr(db_doc, "content_sha256", None) or ""
+                content_changed = (old_sha != sha) or (getattr(db_doc, "content", "") != content)
+
+                metadata_changed = False
+                if item.metadata is not None:
+                    current_md = getattr(db_doc, "metadata_", None)
+                    metadata_changed = dict(item.metadata) != (current_md or {})
+
+                source_changed = False
+                if item.source_id is not None:
+                    source_changed = item.source_id != getattr(db_doc, "source_id", None)
+
+                if not (content_changed or metadata_changed or source_changed):
+                    results.append(
+                        SqlDocumentStorage.UpsertResult(
+                            external_id=external_id,
+                            id=int(db_doc.id),
+                            action="unchanged",
+                            content_changed=False,
+                        )
+                    )
+                    continue
+
+                if content_changed:
+                    db_doc.content = content
+                    db_doc.content_sha256 = sha
+                    updated_content_ids.append(int(db_doc.id))
+                    changed_content.append((int(db_doc.id), content))
+
+                if item.source_id is not None:
+                    db_doc.source_id = item.source_id
+                if item.metadata is not None:
+                    db_doc.metadata_ = dict(item.metadata)
+
+                results.append(
+                    SqlDocumentStorage.UpsertResult(
+                        external_id=external_id,
+                        id=int(db_doc.id),
+                        action="updated",
+                        content_changed=content_changed,
+                    )
+                )
+
+            session.commit()
+
+        return results, changed_content, updated_content_ids
 
 
 class HistorySqlStorage(QAHistoryPort):

--- a/src/local_rag_backend/models.py
+++ b/src/local_rag_backend/models.py
@@ -5,6 +5,8 @@ Models for the application.
 
 from __future__ import annotations
 
+from typing import Any
+
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
@@ -97,3 +99,45 @@ class DeleteDocsResponse(BaseModel):
 
 class RebuildIndexResponse(BaseModel):
     indexed: int
+
+
+class UpsertDocItem(BaseModel):
+    external_id: str = Field(..., min_length=1, max_length=512)
+    content: str = Field(..., min_length=1, max_length=20000)
+    source_id: str | None = Field(default=None, max_length=1024)
+    metadata: dict[str, Any] | None = None
+
+    @field_validator("external_id")
+    @classmethod
+    def _external_id_not_blank(cls, v: str) -> str:
+        v2 = v.strip()
+        if not v2:
+            raise ValueError("external_id must not be blank")
+        return v2
+
+    @field_validator("content")
+    @classmethod
+    def _content_not_blank(cls, v: str) -> str:
+        v2 = v.strip()
+        if not v2:
+            raise ValueError("content must not be blank")
+        return v2
+
+
+class UpsertDocsRequest(BaseModel):
+    docs: list[UpsertDocItem] = Field(..., min_length=1, max_length=64)
+
+
+class UpsertDocResult(BaseModel):
+    external_id: str
+    id: int
+    action: str
+    content_changed: bool
+
+
+class UpsertDocsResponse(BaseModel):
+    inserted: int
+    updated: int
+    unchanged: int
+    rebuilt_index: bool = False
+    results: list[UpsertDocResult]

--- a/tests/unit/app/test_docs_upsert_endpoint.py
+++ b/tests/unit/app/test_docs_upsert_endpoint.py
@@ -1,0 +1,120 @@
+# tests/unit/app/test_docs_upsert_endpoint.py
+
+import numpy as np
+
+from local_rag_backend.app import api_router as api
+from local_rag_backend.infrastructure.persistence.sqlalchemy.sql_ import SqlDocumentStorage
+from local_rag_backend.settings import settings
+
+
+async def test_upsert_docs_sparse_is_idempotent(asgi_client, in_memory_sqlite, monkeypatch):
+    monkeypatch.setattr(settings, "retrieval_mode", "sparse", raising=False)
+
+    payload = {"docs": [{"external_id": "doc-1", "content": "hello"}]}
+    r1 = await asgi_client.post("/api/docs/upsert", json=payload)
+    assert r1.status_code == 200
+    data1 = r1.json()
+    assert data1["inserted"] == 1
+    assert data1["updated"] == 0
+    assert data1["unchanged"] == 0
+    doc_id = data1["results"][0]["id"]
+
+    # Same payload: unchanged, no new rows
+    r2 = await asgi_client.post("/api/docs/upsert", json=payload)
+    assert r2.status_code == 200
+    data2 = r2.json()
+    assert data2["inserted"] == 0
+    assert data2["updated"] == 0
+    assert data2["unchanged"] == 1
+    assert data2["results"][0]["id"] == doc_id
+
+    # Update content
+    r3 = await asgi_client.post(
+        "/api/docs/upsert", json={"docs": [{"external_id": "doc-1", "content": "hello2"}]}
+    )
+    assert r3.status_code == 200
+    data3 = r3.json()
+    assert data3["inserted"] == 0
+    assert data3["updated"] == 1
+    assert data3["unchanged"] == 0
+    assert data3["results"][0]["id"] == doc_id
+
+    doc = SqlDocumentStorage().get([doc_id])[0]
+    assert doc.content == "hello2"
+
+
+async def test_upsert_docs_rejects_duplicate_external_ids(
+    asgi_client, in_memory_sqlite, monkeypatch
+):
+    monkeypatch.setattr(settings, "retrieval_mode", "sparse", raising=False)
+    payload = {
+        "docs": [
+            {"external_id": "doc-1", "content": "a"},
+            {"external_id": "doc-1", "content": "b"},
+        ]
+    }
+    r = await asgi_client.post("/api/docs/upsert", json=payload)
+    assert r.status_code == 400
+
+
+async def test_upsert_docs_dense_updates_only_changed_content(
+    asgi_client, in_memory_sqlite, monkeypatch
+):
+    class DummyEmbedder:
+        dim = 4
+
+        def __init__(self):
+            self.calls = 0
+
+        def embed(self, texts):
+            self.calls += 1
+            return np.zeros((len(texts), self.dim), dtype="float32").tolist()
+
+    class DummyVec:
+        def __init__(self):
+            self.upserts = []
+            self.deletes = []
+
+        def upsert(self, ids, vectors):
+            self.upserts.append((list(ids), list(vectors)))
+
+        def delete(self, ids):
+            self.deletes.append(list(ids))
+
+        def rebuild(self, ids, vectors):
+            raise AssertionError("rebuild should not be called in this test")
+
+    monkeypatch.setattr(settings, "retrieval_mode", "dense", raising=False)
+    monkeypatch.setattr(settings, "openai_api_key", "DUMMY", raising=False)
+
+    dummy_embedder = DummyEmbedder()
+    dummy_vec = DummyVec()
+
+    monkeypatch.setattr(api, "OpenAIEmbedder", lambda *a, **k: dummy_embedder)
+    monkeypatch.setattr(api, "FaissVectorStorage", lambda *a, **k: dummy_vec)
+
+    payload = {"docs": [{"external_id": "doc-1", "content": "hello"}]}
+    r1 = await asgi_client.post("/api/docs/upsert", json=payload)
+    assert r1.status_code == 200
+    doc_id = r1.json()["results"][0]["id"]
+    assert dummy_embedder.calls == 1
+    assert dummy_vec.deletes == []
+    assert len(dummy_vec.upserts) == 1
+    assert dummy_vec.upserts[0][0] == [doc_id]
+
+    # Idempotent: no embedding, no index operations
+    r2 = await asgi_client.post("/api/docs/upsert", json=payload)
+    assert r2.status_code == 200
+    assert dummy_embedder.calls == 1
+    assert len(dummy_vec.upserts) == 1
+    assert dummy_vec.deletes == []
+
+    # Content change: delete old vector then upsert new
+    r3 = await asgi_client.post(
+        "/api/docs/upsert", json={"docs": [{"external_id": "doc-1", "content": "hello2"}]}
+    )
+    assert r3.status_code == 200
+    assert r3.json()["results"][0]["id"] == doc_id
+    assert dummy_embedder.calls == 2
+    assert dummy_vec.deletes == [[doc_id]]
+    assert len(dummy_vec.upserts) == 2

--- a/tests/unit/infrastructure/persistence/sqlalchemy/test_sql_upsert_documents_by_external_id.py
+++ b/tests/unit/infrastructure/persistence/sqlalchemy/test_sql_upsert_documents_by_external_id.py
@@ -1,0 +1,72 @@
+# tests/unit/infrastructure/persistence/sqlalchemy/test_sql_upsert_documents_by_external_id.py
+
+import hashlib
+
+import pytest
+
+from local_rag_backend.infrastructure.persistence.sqlalchemy.sql_ import SqlDocumentStorage
+
+
+def test_upsert_inserts_and_is_idempotent(in_memory_sqlite):
+    repo = SqlDocumentStorage(session_factory=in_memory_sqlite)
+    items = [
+        SqlDocumentStorage.UpsertDoc(
+            external_id="doc-1",
+            content="hello",
+            source_id="src-a",
+            metadata={"k": "v"},
+        )
+    ]
+
+    res1, changed1, updated_ids1 = repo.upsert_documents_by_external_id(items)
+    assert len(res1) == 1
+    assert res1[0].action == "inserted"
+    assert res1[0].content_changed is True
+    assert changed1 and changed1[0][0] == res1[0].id
+    assert updated_ids1 == []
+
+    # Idempotent: same payload does not create a new row and does not require re-embedding.
+    res2, changed2, updated_ids2 = repo.upsert_documents_by_external_id(items)
+    assert len(res2) == 1
+    assert res2[0].id == res1[0].id
+    assert res2[0].action == "unchanged"
+    assert changed2 == []
+    assert updated_ids2 == []
+
+    doc = repo.get([res1[0].id])[0]
+    assert doc.external_id == "doc-1"
+    assert doc.source_id == "src-a"
+    assert doc.metadata == {"k": "v"}
+    assert doc.content_sha256 == hashlib.sha256(b"hello").hexdigest()
+
+
+def test_upsert_updates_content_and_hash(in_memory_sqlite):
+    repo = SqlDocumentStorage(session_factory=in_memory_sqlite)
+    first, *_ = repo.upsert_documents_by_external_id(
+        [SqlDocumentStorage.UpsertDoc(external_id="doc-1", content="hello")]
+    )
+    doc_id = first[0].id
+
+    res2, changed2, updated_ids2 = repo.upsert_documents_by_external_id(
+        [SqlDocumentStorage.UpsertDoc(external_id="doc-1", content="HELLO2")]
+    )
+    assert res2[0].id == doc_id
+    assert res2[0].action == "updated"
+    assert res2[0].content_changed is True
+    assert changed2 == [(doc_id, "HELLO2")]
+    assert updated_ids2 == [doc_id]
+
+    doc = repo.get([doc_id])[0]
+    assert doc.content == "HELLO2"
+    assert doc.content_sha256 == hashlib.sha256(b"HELLO2").hexdigest()
+
+
+def test_upsert_rejects_duplicate_external_ids(in_memory_sqlite):
+    repo = SqlDocumentStorage(session_factory=in_memory_sqlite)
+    with pytest.raises(ValueError, match="unique within the request"):
+        repo.upsert_documents_by_external_id(
+            [
+                SqlDocumentStorage.UpsertDoc(external_id="doc-1", content="a"),
+                SqlDocumentStorage.UpsertDoc(external_id="doc-1", content="b"),
+            ]
+        )

--- a/tests/unit/test_cli_upsert_docs.py
+++ b/tests/unit/test_cli_upsert_docs.py
@@ -1,0 +1,28 @@
+# tests/unit/test_cli_upsert_docs.py
+
+import json
+
+from click.testing import CliRunner
+
+from local_rag_backend.cli import cli
+from local_rag_backend.infrastructure.persistence.sqlalchemy.sql_ import SqlDocumentStorage
+from local_rag_backend.settings import settings
+
+
+def test_cli_upsert_docs_from_json_file(in_memory_sqlite, tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "retrieval_mode", "sparse", raising=False)
+    p = tmp_path / "docs.json"
+    p.write_text(
+        json.dumps(
+            [{"external_id": "doc-1", "content": "hello"}, {"external_id": "doc-2", "content": "x"}]
+        ),
+        encoding="utf-8",
+    )
+
+    r = CliRunner().invoke(cli, ["upsert-docs", "--json", str(p)])
+    assert r.exit_code == 0, r.output
+    assert "inserted=2" in r.output
+
+    docs = SqlDocumentStorage().get_all_documents()
+    assert len(docs) == 2
+    assert {d.external_id for d in docs} == {"doc-1", "doc-2"}


### PR DESCRIPTION
## Summary 
> **Stacked PR (importante):** este PR está pensado para abrirse con base `pr/02-2026-02-doc-identity` (PR2).

Con PR2 ya existe el contrato de identidad (`external_id`) y metadata en SQLite. Este PR expone operaciones de upsert para:
- re-ingestar la misma fuente sin duplicar filas/vectores
- actualizar contenido de un `external_id` manteniendo consistencia (SQL + índice) en `dense/hybrid`

## **Cambios principales**
- SQL (adapter): `SqlDocumentStorage.upsert_documents_by_external_id(...)`
  - Valida `external_id` único por request
  - Inserta si no existe
  - Actualiza si cambia `content` (detectado por `content_sha256`) y/o si cambia `source_id`/`metadata`
  - Idempotente: mismo payload => `unchanged` y no requiere re-embed
  - Devuelve:
    - `changed_content`: (id, content) para embeddings
    - `updated_content_ids`: ids a borrar del índice antes de re-upsert
- API: `POST /api/docs/upsert`
  - Body: `{ "docs": [{external_id, content, source_id?, metadata?}, ...] }`
  - Respuesta: conteos `inserted/updated/unchanged`, `rebuilt_index`, y resultados por doc
  - `dense/hybrid`: re-embebe SOLO docs con `content_changed`.
    - En updates: `vec.delete([doc_id])` + `vec.upsert([doc_id], [vector])`
    - Si falla, fallback a rebuild completo del índice desde SQLite.
- CLI: `rag-upsert-docs` / `cli upsert-docs`
  - `--json path/to/docs.json` (lista de docs)
  - o `--external-id ... --content ...` (single)
  - `dense/hybrid`: mismo comportamiento incremental + fallback rebuild.
- Docs: `README.md` actualizado con el nuevo endpoint/CLI.



## **Tests añadidos**
- `tests/unit/infrastructure/persistence/sqlalchemy/test_sql_upsert_documents_by_external_id.py`
- `tests/unit/app/test_docs_upsert_endpoint.py`
- `tests/unit/test_cli_upsert_docs.py`

## **Checklist DoD**
- [x] Endpoint/CLI de upsert por `external_id`.
- [x] Re-ingesta misma fuente no duplica (idempotencia).
- [x] Update de contenido sólo re-embebe lo afectado; fallback a rebuild en fallo.
- [x] Tests de idempotencia y update (SQL + API + CLI).
- [x] Suite completa + linters + type checks en verde.


**Commits incluidos**
- `13497f7` feat(docs): idempotent upsert by external_id (API/CLI)
- `9709ca8` test(docs): cover upsert idempotency (api/sql/cli)
- `bfa4c16` docs: document docs upsert endpoint and rag-upsert-docs


