### PR TITLE
PR10: Evaluación + monitoring mínimo + retrieval quality (reranker opcional)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,42 @@ jobs:
           path: pytest-results.xml
           retention-days: 7
 
+  test-windows-smoke:
+    name: Tests (Windows smoke)
+    runs-on: windows-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Set up uv (cached)
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            **/pyproject.toml
+            **/uv.lock
+          cache-suffix: test-windows-smoke
+
+      - name: Create virtualenv
+        run: uv venv
+
+      - name: Install deps
+        run: uv sync --frozen --extra dev --extra test
+
+      - name: Run smoke tests (cross-platform persistence paths)
+        run: >
+          uv run pytest -q
+          tests/unit/infrastructure/persistence/faiss/test_faiss_index.py
+          tests/unit/infrastructure/persistence/faiss/test_faiss_index_race.py
+          tests/unit/infrastructure/persistence/faiss/test_vector_storage_manifest_guard.py
+          tests/unit/core/services/test_maintenance.py
+
   security:
     name: Security Scan (bandit + safety)
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -262,6 +262,10 @@ rag-upsert-docs --external-id doc-1 --content "hello"
 
 # Summarized system and files status
 rag-status
+
+
+# Offline retrieval evaluation (reproducible gate; default dataset is packaged)
+rag-eval --retrieval-mode sparse
 ```
 
 > Retrieval mode is selected via `RETRIEVAL_MODE` (there is no `--mode` flag).
@@ -271,6 +275,22 @@ Optional: better file type detection (best-effort) using `python-magic`:
 ```bash
 uv sync --frozen --extra magic
 # or: pip install rag-prototype[magic]
+```
+
+Optional: Prometheus metrics (`/metrics`) and structured-ish domain metrics:
+
+```bash
+uv sync --frozen --extra monitoring
+# then:
+export ENABLE_MONITORING=true
+rag-server
+```
+
+Optional: reranker (retrieval quality knob, measurable via `rag-eval`):
+
+```bash
+export ENABLE_RERANKER=true
+export RERANKER_CANDIDATE_K=20
 ```
 
 ### Ingestion pipeline

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,7 +17,9 @@
     -- Store
     -- Update (Insert/Upsert) policy
 
-- Retrieval 
+- Search
+
+- Retrieval // Reranking
     -- Bi-Encoders
     -- Cross-Encoders [F]
     -- ColBERT / ColBERTv2 [F]

--- a/docs/custom_usage_guide.md
+++ b/docs/custom_usage_guide.md
@@ -261,3 +261,28 @@ rebuild_index_from_db(doc_repo=doc_repo, vec_repo=vec_repo, embedder=embedder)
 
 Nota (dense/hybrid): al mutar el índice, se mantiene un `index_manifest.json` junto a `INDEX_PATH` para
 detectar drift de configuración (modelo/dim/chunker). Si cambias esos settings, ejecuta un rebuild.
+
+---
+
+## Operabilidad: métricas, evaluación y reranker
+
+Monitoring mínimo (Prometheus):
+
+```bash
+uv sync --frozen --extra monitoring
+export ENABLE_MONITORING=true
+curl -s http://localhost:8000/metrics | head
+```
+
+Evaluación offline reproducible (gate):
+
+```bash
+rag-eval --retrieval-mode sparse
+```
+
+Reranker opcional (mejora de calidad medible con `rag-eval`):
+
+```bash
+export ENABLE_RERANKER=true
+export RERANKER_CANDIDATE_K=20
+```

--- a/pr/02-2026-11.md
+++ b/pr/02-2026-11.md
@@ -101,3 +101,63 @@ Tests:
 - `mypy src` ✅
 - `isort --check-only src tests` ❌
   - Persisten fallos preexistentes fuera del scope crítico.
+
+---
+
+## Auditoría integral (esta iteración)
+Se identificaron y corrigieron 3 hallazgos críticos adicionales de consistencia/concurrencia:
+
+### 6) `/api/docs` ejecutaba ingestión dos veces (segunda pasada fuera del lock)
+Impacto sistémico:
+- Doble ejecución de la ruta mutante (coste duplicado y ventana de interleaving sin lock).
+- Riesgo de respuestas inconsistentes ante concurrencia (segunda pasada fuera de serialización multi-store).
+
+Fix concreto:
+- Eliminada la segunda llamada redundante a `_ingest_sync` en `POST /api/docs`.
+- Archivo: `src/local_rag_backend/app/api_router.py`.
+
+Test:
+- `tests/unit/app/test_multistore_write_lock.py::test_docs_ingest_executes_single_locked_mutation_pass`
+  - Verifica que la ingestión se ejecuta una sola vez y bajo wrapper lockeado.
+
+### 7) `multi_store_write_lock` podía fallar en modo silencioso (fail-open)
+Impacto sistémico:
+- Si fallaba `flock/msvcrt`, la operación mutante continuaba sin lock cross-process.
+- Esto anulaba la garantía de serialización SQL+índice en escenarios degradados.
+
+Fix concreto:
+- `write_lock` ahora falla en modo explícito (`RuntimeError`) cuando no puede adquirir lock OS.
+- Archivo: `src/local_rag_backend/core/services/write_lock.py`.
+
+Test:
+- `tests/unit/core/services/test_write_lock.py::test_exclusive_file_lock_fails_closed_when_os_locking_is_unavailable`
+  - Simula falla de `fcntl`/`msvcrt` y valida comportamiento fail-closed.
+
+### 8) Comandos mutantes de CLI no usaban lock multi-store compartido
+Impacto sistémico:
+- Interleavings entre CLI/API podían dejar drift SQL/vector durante `upsert/delete/rebuild/ingest`.
+- Riesgo especialmente alto en operaciones largas (`rag-ingest`).
+
+Fix concreto:
+- Nuevo helper `_run_with_multi_store_write_lock(...)` en CLI.
+- Aplicado a:
+  - `rag-build-index`
+  - `rag-rebuild-index`
+  - `rag-delete-docs`
+  - `rag-delete-external-ids`
+  - `rag-upsert-docs`
+  - `rag-bootstrap`
+  - `rag-ingest` (tramo mutante por archivo).
+- Archivo: `src/local_rag_backend/cli.py`.
+
+Tests:
+- `tests/unit/test_cli_write_lock.py::test_cli_upsert_docs_runs_under_multi_store_lock`
+- `tests/unit/test_cli_write_lock.py::test_cli_delete_docs_runs_under_multi_store_lock`
+- `tests/unit/test_cli_write_lock.py::test_cli_ingest_runs_each_file_mutation_under_multi_store_lock`
+
+## Verificación (esta iteración)
+- `pytest -q` ✅ (271 passed, cobertura 85.72%)
+- `mypy src` ✅
+- `black --check src tests` ✅
+- `ruff check --no-fix` (scope de archivos tocados) ✅
+- `isort --check-only` (scope de archivos tocados) ✅

--- a/pr/02-2026-11.md
+++ b/pr/02-2026-11.md
@@ -161,3 +161,59 @@ Tests:
 - `black --check src tests` ✅
 - `ruff check --no-fix` (scope de archivos tocados) ✅
 - `isort --check-only` (scope de archivos tocados) ✅
+
+---
+
+## Auditoría integral (esta iteración - continuación)
+Se detectaron y corrigieron 3 riesgos críticos adicionales de consistencia/concurrencia:
+
+### 9) Índice legacy sin manifest podía ser “aceptado” en escrituras incrementales
+Impacto sistémico:
+- Si existía un índice no vacío previo a PR9 (sin `index_manifest.json`), una escritura incremental podía crear manifest “a posteriori” con la config actual.
+- Eso permitía mezclar embeddings históricos de configuración desconocida con embeddings nuevos, ocultando drift semántico y degradando retrieval de forma silenciosa.
+
+Fix concreto:
+- `FaissVectorStorage._ensure_manifest()` ahora falla en modo cerrado cuando:
+  - falta manifest, y
+  - el índice ya contiene vectores/id_map.
+- En ese caso exige rebuild explícito (`rag-rebuild-index` / `POST /api/index/rebuild`).
+- Archivo: `src/local_rag_backend/infrastructure/persistence/faiss/faiss_.py`.
+
+Test:
+- `tests/unit/infrastructure/persistence/faiss/test_vector_storage_manifest_guard.py::test_upsert_fails_closed_when_manifest_is_missing_for_non_empty_legacy_index`
+
+### 10) Invalidación de caché RAG no se ejecutaba en fallos de operaciones mutantes
+Impacto sistémico:
+- Si una operación mutante fallaba después de modificar parcialmente estado (p.ej. SQL mutado + fallo en sync/rebuild de índice), no se emitía `reset_rag_service()`.
+- Riesgo de workers con retriever/corpus stale tras error, empeorando inconsistencia observada por clientes.
+
+Fix concreto:
+- API mutante: `reset_rag_service()` se ejecuta en `finally` para `/api/docs`, `/api/docs/upsert`, `/api/docs/delete*`, `/api/index/rebuild`.
+- CLI mutante: invalidación best-effort en `finally` para `build-index`, `rebuild-index`, `delete-docs`, `delete-external-ids`, `upsert-docs`, `bootstrap`, `ingest`.
+- Archivo principal: `src/local_rag_backend/app/api_router.py`, `src/local_rag_backend/cli.py`.
+
+Tests:
+- `tests/unit/app/test_multistore_write_lock.py::test_upsert_failure_still_invalidates_cached_rag_service`
+- `tests/unit/test_cli_upsert_docs.py::test_cli_upsert_docs_failure_still_invalidates_cached_rag_service`
+
+### 11) Lock de archivo FAISS en modo fail-open
+Impacto sistémico:
+- Si `fcntl/msvcrt` fallaba, `FaissIndex` continuaba operaciones sin lock cross-process.
+- En escenarios degradados/plataforma atípica, podía haber writes concurrentes y corrupción de `index`/`id_map`.
+
+Fix concreto:
+- `_exclusive_file_lock()` de FAISS ahora falla en modo cerrado (`RuntimeError`) cuando no puede adquirir lock OS.
+- Archivo: `src/local_rag_backend/infrastructure/persistence/faiss/index.py`.
+
+Test:
+- `tests/unit/infrastructure/persistence/faiss/test_faiss_index_lock.py::test_exclusive_file_lock_fails_closed_when_os_locking_is_unavailable`
+
+## Verificación (actualizada)
+- `pytest -q` ✅ (275 passed, cobertura 85.83%)
+- `ruff check --no-fix src tests` ✅
+- `black --check src tests` ✅
+- `mypy src` ✅
+- `isort --check-only src tests` ✅
+
+Nota técnica adicional:
+- Se alineó config de `isort` con `ruff.lint.isort` (`combine_as_imports=true`) para eliminar conflicto de formato entre linters y mantener checks deterministas.

--- a/pr/02-2026-11.md
+++ b/pr/02-2026-11.md
@@ -1,0 +1,103 @@
+# PR11: Hardening de consistencia transaccional y invalidación multi-worker
+
+Base: `pr/02-2026-10` (stacked PR).
+
+## Contexto
+Durante la auditoría técnica se detectaron dos riesgos de alta criticidad:
+
+1. En `dense/hybrid`, un fallo del embedder podía dejar cambios en SQLite ya comprometidos sin reflejo en el índice vectorial.
+2. La invalidación del caché RAG multi-worker escribía un `.tmp` fijo para el reload token, con riesgo de colisión entre procesos.
+
+## Cambios principales
+
+### 1) Atomicidad lógica SQL + índice frente a fallos de embedding
+- API:
+  - `POST /api/docs`
+  - `POST /api/docs/upsert`
+- CLI:
+  - `rag-upsert-docs`
+  - `rag-ingest`
+
+Nuevo flujo:
+- Detecta previamente qué `external_id` requieren embedding real (insert o cambio de contenido).
+- Pre-computa embeddings **antes** del `upsert` SQL.
+- Ejecuta `upsert` SQL.
+- Actualiza índice solo para `content_changed`.
+
+Resultado:
+- Si el embedder falla, no hay commit parcial en SQL para esos cambios.
+- Se mantiene idempotencia (sin embeddings en no-op).
+
+### 2) Hardening de `reset_rag_service` multi-worker
+- `app/factory.py` ahora escribe el reload token con `NamedTemporaryFile` único + `fsync` + `os.replace`.
+- Evita colisiones del `.tmp` fijo entre workers/procesos.
+
+### 3) Soporte en repositorio SQL para pre-chequeo de cambios
+- Nuevo helper: `SqlDocumentStorage.get_existing_doc_states_by_external_id(...)`.
+- Permite decidir selectivamente qué documentos necesitan embedding antes de comprometer SQL.
+
+## Tests añadidos
+- `tests/unit/app/test_docs_embedding_atomicity.py`
+  - Valida que `/api/docs` y `/api/docs/upsert` no persisten en SQL si falla embedder.
+- `tests/unit/test_cli_upsert_docs.py`
+  - Valida no persistencia en `rag-upsert-docs` ante fallo de embedder.
+- `tests/unit/test_cli_ingest.py`
+  - Valida no persistencia en `rag-ingest` (dense) ante fallo de embedder.
+- `tests/unit/app/test_factory_cache_invalidation.py`
+  - Valida que `_write_reload_token` no reutiliza rutas temporales.
+
+## Verificación
+- `pytest -q` ✅ (251 passed, cobertura total 85.20%)
+- `ruff check src tests` ✅
+- `black --check src tests` ✅
+- `mypy src` ✅
+- `isort --check-only src tests` ❌
+  - Quedan fallos preexistentes en archivos no tocados por este PR (`app/middleware.py`, `scripts/*`, `tests/conftest.py`, etc.).
+
+## Commits incluidos
+- `5fa6c06` fix: prevent SQL/vector drift when embedding fails
+- `fd412d8` fix: harden rag service reload token writes
+
+---
+
+## Auditoría adicional (continuación)
+Se añadieron dos hardenings críticos adicionales:
+
+### 4) Serialización de escrituras multi-store en API
+Riesgo detectado:
+- Dos `upserts` concurrentes sobre el mismo `external_id` podían intercalar SQL+FAISS y dejar vector stale respecto al contenido final en SQL.
+
+Fix:
+- Nuevo lock cross-process/thread: `core/services/write_lock.py`.
+- Los endpoints mutantes (`/api/docs`, `/api/docs/upsert`, `/api/docs/delete*`, `/api/index/rebuild`) ahora se ejecutan bajo ese lock compartido.
+
+Tests:
+- `tests/unit/app/test_multistore_write_lock.py`
+  - Simula interleaving forzado y valida consistencia final SQL/vector.
+
+### 5) Validación estricta de parámetros de generación (cost/risk guard)
+Riesgo detectado:
+- `top_p`, `temperature` y `max_tokens` no estaban acotados en `/api/openrouter/generate`.
+- `top_p` en `ask_eval` no tenía validación de rango en schema.
+
+Fix:
+- `OpenRouterGenerateRequest` ahora valida:
+  - `temperature` en `[0.0, 2.0]`
+  - `top_p` en `[0.0, 1.0]`
+  - `max_tokens` en `[1, 4096]`
+- `AskEvalConfig.top_p` ahora restringido a `[0.0, 1.0]`.
+- `validate_rag_config()` también valida `top_p` explícitamente.
+
+Tests:
+- `tests/unit/app/test_request_limits.py`
+  - Rechazo de sampling params inválidos en OpenRouter.
+- `tests/unit/app/test_api_router_more.py`
+  - Casos inválidos de `top_p` en `ask_eval`.
+
+## Verificación (actualizada)
+- `pytest -q` ✅ (255 passed, cobertura total 85.29%)
+- `ruff check src tests` ✅
+- `black --check src tests` ✅
+- `mypy src` ✅
+- `isort --check-only src tests` ❌
+  - Persisten fallos preexistentes fuera del scope crítico.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -249,6 +249,7 @@ include_trailing_comma = true
 force_grid_wrap = 0
 use_parentheses = true
 ensure_newline_before_comments = true
+combine_as_imports = true
 
 [tool.mypy]
 python_version = "3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,6 +179,7 @@ rag-rebuild-index = "local_rag_backend.cli:rag_rebuild_index"
 rag-upsert-docs = "local_rag_backend.cli:rag_upsert_docs"
 rag-server      = "local_rag_backend.cli:rag_server"
 rag-status      = "local_rag_backend.cli:rag_status"
+rag-eval        = "local_rag_backend.cli:rag_eval"
 
 [build-system]
 requires = ["setuptools>=68", "wheel"]

--- a/src/local_rag_backend/app/api_router.py
+++ b/src/local_rag_backend/app/api_router.py
@@ -5,10 +5,11 @@ FastAPI router for the application endpoints.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Any
+from typing import TYPE_CHECKING, Annotated, Any, cast
 
 import requests
 from fastapi import APIRouter, Body, Depends, HTTPException, Query
@@ -54,11 +55,9 @@ from local_rag_backend.core.services.maintenance import (
     delete_documents_multi_store,
     rebuild_index_from_db,
 )
-from local_rag_backend.core.services.prompting import (
-    PromptTemplateError,
-    validate_prompt_template,
-)
+from local_rag_backend.core.services.prompting import PromptTemplateError, validate_prompt_template
 from local_rag_backend.core.services.rag import RagService
+from local_rag_backend.core.services.write_lock import multi_store_write_lock
 from local_rag_backend.core.services.reranking import RerankingRetriever
 from local_rag_backend.infrastructure.embeddings.openai import OpenAIEmbedder
 from local_rag_backend.infrastructure.embeddings.sentence_transformers import (
@@ -104,6 +103,8 @@ def validate_rag_config(config: AskEvalConfig) -> list[str]:
         errors.append(f"Invalid hybrid_alpha: {config.hybrid_alpha}. Must be between 0.0 and 1.0")
     if config.temperature is not None and not (0.0 <= config.temperature <= 2.0):
         errors.append(f"Invalid temperature: {config.temperature}. Must be between 0.0 and 2.0")
+    if config.top_p is not None and not (0.0 <= config.top_p <= 1.0):
+        errors.append(f"Invalid top_p: {config.top_p}. Must be between 0.0 and 1.0")
     if config.max_tokens is not None and not (1 <= config.max_tokens <= 4096):
         errors.append(f"Invalid max_tokens: {config.max_tokens}. Must be between 1 and 4096")
     if config.prompt_template is not None:
@@ -144,6 +145,12 @@ def _build_embedder_for_dense() -> EmbedderPort:
 
 
 router = APIRouter()
+
+
+def _run_multi_store_write_locked(fn: Any) -> Any:
+    with multi_store_write_lock():
+        return fn()
+
 
 # --- Health & Readiness --- #
 
@@ -482,25 +489,65 @@ async def ingest_docs(payload: Annotated[IngestRequest, Body(...)]) -> IngestRes
         if not unique_items:
             return []
 
-        results, changed_content, updated_content_ids = doc_repo.upsert_documents_by_external_id(
+        embedder = None
+        vectors_by_external_id: dict[str, list[float]] = {}
+        if settings.retrieval_mode in ("dense", "hybrid"):
+            # Compute embeddings before SQL upsert so provider failures don't leave SQL/index drift.
+            embedder = _build_embedder_for_dense()
+            existing_states = doc_repo.get_existing_doc_states_by_external_id(
+                [it.external_id for it in unique_items]
+            )
+            to_embed = []
+            for it in unique_items:
+                content = it.content.strip()
+                current = existing_states.get(it.external_id)
+                if current is None:
+                    to_embed.append(it)
+                    continue
+                content_sha = hashlib.sha256(content.encode("utf-8")).hexdigest()
+                old_sha = current.content_sha256 or ""
+                if old_sha != content_sha or current.content != content:
+                    to_embed.append(it)
+
+            if to_embed:
+                embedded = embedder.embed([it.content.strip() for it in to_embed])
+                if len(embedded) != len(to_embed):
+                    raise RuntimeError(
+                        f"Embedder returned {len(embedded)} vectors for {len(to_embed)} documents."
+                    )
+                vectors_by_external_id = {
+                    it.external_id: list(vec) for it, vec in zip(to_embed, embedded, strict=False)
+                }
+
+        results, _changed_content, updated_content_ids = doc_repo.upsert_documents_by_external_id(
             unique_items
         )
         id_by_ext = {r.external_id: int(r.id) for r in results}
 
-        if settings.retrieval_mode in ("dense", "hybrid") and changed_content:
-            embedder = _build_embedder_for_dense()
+        if settings.retrieval_mode in ("dense", "hybrid") and embedder is not None:
             vec = FaissVectorStorage(
                 index_path=settings.index_path,
                 id_map_path=settings.id_map_path,
                 dim=embedder.dim,
             )
-            ids = [doc_id for doc_id, _ in changed_content]
-            texts_to_embed = [t for _, t in changed_content]
-            vectors = embedder.embed(texts_to_embed)
+            changed_results = [r for r in results if r.content_changed]
+            missing_vectors = [
+                r.external_id
+                for r in changed_results
+                if r.external_id not in vectors_by_external_id
+            ]
+            if missing_vectors:
+                raise RuntimeError(
+                    "Missing precomputed vectors for changed documents: "
+                    + ", ".join(missing_vectors[:10])
+                )
+            ids = [int(r.id) for r in changed_results]
+            vectors = [vectors_by_external_id[r.external_id] for r in changed_results]
             try:
-                if updated_content_ids:
+                if ids and updated_content_ids:
                     vec.delete(updated_content_ids)
-                vec.upsert(ids, vectors)
+                if ids:
+                    vec.upsert(ids, vectors)
             except Exception:
                 rebuild_index_from_db(doc_repo=doc_repo, vec_repo=vec, embedder=embedder)
 
@@ -509,6 +556,7 @@ async def ingest_docs(payload: Annotated[IngestRequest, Body(...)]) -> IngestRes
     ok = False
     ids: list[int] = []
     try:
+        ids = cast("list[int]", await run_blocking(_run_multi_store_write_locked, _ingest_sync))
         ids = await run_blocking(_ingest_sync)
         ok = True
         return IngestResponse(count=len(ids), ids=ids)
@@ -594,7 +642,10 @@ async def delete_docs_by_external_id(
             rebuilt_index=False,
         )
 
-    resp = await run_blocking(_delete_sync)
+    resp = cast(
+        "DeleteDocsByExternalIdResponse",
+        await run_blocking(_run_multi_store_write_locked, _delete_sync),
+    )
     reset_rag_service()
     return resp
 
@@ -628,7 +679,9 @@ async def delete_docs(payload: Annotated[DeleteDocsRequest, Body(...)]) -> Delet
         deleted_sql, _, _ = delete_documents_multi_store(doc_repo=doc_repo, ids=ids)
         return DeleteDocsResponse(deleted_sql=deleted_sql, deleted_index=None, rebuilt_index=False)
 
-    resp = await run_blocking(_delete_sync)
+    resp = cast(
+        "DeleteDocsResponse", await run_blocking(_run_multi_store_write_locked, _delete_sync)
+    )
     reset_rag_service()
     return resp
 
@@ -660,7 +713,37 @@ async def upsert_docs(payload: Annotated[UpsertDocsRequest, Body(...)]) -> Upser
             for d in payload.docs
         ]
 
-        results, changed_content, updated_content_ids = doc_repo.upsert_documents_by_external_id(
+        embedder = None
+        vectors_by_external_id: dict[str, list[float]] = {}
+        if settings.retrieval_mode in ("dense", "hybrid"):
+            # Compute embeddings before SQL upsert so provider failures don't leave SQL/index drift.
+            embedder = _build_embedder_for_dense()
+            existing_states = doc_repo.get_existing_doc_states_by_external_id(
+                [it.external_id for it in items]
+            )
+            to_embed = []
+            for it in items:
+                content = it.content.strip()
+                current = existing_states.get(it.external_id)
+                if current is None:
+                    to_embed.append(it)
+                    continue
+                content_sha = hashlib.sha256(content.encode("utf-8")).hexdigest()
+                old_sha = current.content_sha256 or ""
+                if old_sha != content_sha or current.content != content:
+                    to_embed.append(it)
+
+            if to_embed:
+                embedded = embedder.embed([it.content.strip() for it in to_embed])
+                if len(embedded) != len(to_embed):
+                    raise RuntimeError(
+                        f"Embedder returned {len(embedded)} vectors for {len(to_embed)} documents."
+                    )
+                vectors_by_external_id = {
+                    it.external_id: list(vec) for it, vec in zip(to_embed, embedded, strict=False)
+                }
+
+        results, _changed_content, updated_content_ids = doc_repo.upsert_documents_by_external_id(
             items
         )
         inserted = sum(1 for r in results if r.action == "inserted")
@@ -668,17 +751,43 @@ async def upsert_docs(payload: Annotated[UpsertDocsRequest, Body(...)]) -> Upser
         unchanged = sum(1 for r in results if r.action == "unchanged")
 
         rebuilt_index = False
-        if settings.retrieval_mode in ("dense", "hybrid") and changed_content:
-            embedder = _build_embedder_for_dense()
+        if settings.retrieval_mode in ("dense", "hybrid") and embedder is not None:
+            changed_results = [r for r in results if r.content_changed]
+            missing_vectors = [
+                r.external_id
+                for r in changed_results
+                if r.external_id not in vectors_by_external_id
+            ]
+            if missing_vectors:
+                raise RuntimeError(
+                    "Missing precomputed vectors for changed documents: "
+                    + ", ".join(missing_vectors[:10])
+                )
+            ids = [int(r.id) for r in changed_results]
+            vectors = [vectors_by_external_id[r.external_id] for r in changed_results]
+
+            if not ids:
+                return UpsertDocsResponse(
+                    inserted=inserted,
+                    updated=updated,
+                    unchanged=unchanged,
+                    rebuilt_index=rebuilt_index,
+                    results=[
+                        UpsertDocResult(
+                            external_id=r.external_id,
+                            id=r.id,
+                            action=r.action,
+                            content_changed=r.content_changed,
+                        )
+                        for r in results
+                    ],
+                )
+
             vec = FaissVectorStorage(
                 index_path=settings.index_path,
                 id_map_path=settings.id_map_path,
                 dim=embedder.dim,
             )
-
-            ids = [doc_id for doc_id, _ in changed_content]
-            texts = [text for _, text in changed_content]
-            vectors = embedder.embed(texts)
             try:
                 # Updates must remove the old vector for that doc_id first.
                 if updated_content_ids:
@@ -707,7 +816,9 @@ async def upsert_docs(payload: Annotated[UpsertDocsRequest, Body(...)]) -> Upser
             ],
         )
 
-    resp = await run_blocking(_upsert_sync)
+    resp = cast(
+        "UpsertDocsResponse", await run_blocking(_run_multi_store_write_locked, _upsert_sync)
+    )
     reset_rag_service()
     return resp
 
@@ -734,7 +845,9 @@ async def rebuild_index() -> RebuildIndexResponse:
         n = rebuild_index_from_db(doc_repo=doc_repo, vec_repo=vec, embedder=embedder)
         return RebuildIndexResponse(indexed=n)
 
-    resp = await run_blocking(_rebuild_sync)
+    resp = cast(
+        "RebuildIndexResponse", await run_blocking(_run_multi_store_write_locked, _rebuild_sync)
+    )
     reset_rag_service()
     return resp
 
@@ -896,9 +1009,9 @@ class OpenRouterGenerateRequest(BaseModel):
     )
     system_instruction: str = Field(..., min_length=1, max_length=8000)
     user_content: str = Field(..., min_length=1, max_length=8000)
-    temperature: float | None = None
-    max_tokens: int | None = None
-    top_p: float | None = None
+    temperature: float | None = Field(default=None, ge=0.0, le=2.0)
+    max_tokens: int | None = Field(default=None, ge=1, le=4096)
+    top_p: float | None = Field(default=None, ge=0.0, le=1.0)
 
 
 class OpenRouterGenerateResponse(BaseModel):

--- a/src/local_rag_backend/app/api_router.py
+++ b/src/local_rag_backend/app/api_router.py
@@ -57,8 +57,8 @@ from local_rag_backend.core.services.maintenance import (
 )
 from local_rag_backend.core.services.prompting import PromptTemplateError, validate_prompt_template
 from local_rag_backend.core.services.rag import RagService
-from local_rag_backend.core.services.write_lock import multi_store_write_lock
 from local_rag_backend.core.services.reranking import RerankingRetriever
+from local_rag_backend.core.services.write_lock import multi_store_write_lock
 from local_rag_backend.infrastructure.embeddings.openai import OpenAIEmbedder
 from local_rag_backend.infrastructure.embeddings.sentence_transformers import (
     SentenceTransformerEmbedder,
@@ -557,7 +557,6 @@ async def ingest_docs(payload: Annotated[IngestRequest, Body(...)]) -> IngestRes
     ids: list[int] = []
     try:
         ids = cast("list[int]", await run_blocking(_run_multi_store_write_locked, _ingest_sync))
-        ids = await run_blocking(_ingest_sync)
         ok = True
         return IngestResponse(count=len(ids), ids=ids)
     except RuntimeError as e:

--- a/src/local_rag_backend/app/api_router.py
+++ b/src/local_rag_backend/app/api_router.py
@@ -581,8 +581,9 @@ async def ingest_docs(payload: Annotated[IngestRequest, Body(...)]) -> IngestRes
             reranker_enabled=bool(settings.enable_reranker),
             duration_ms=int(1000 * t.seconds()),
         )
-        if ok:
-            reset_rag_service()
+        # Always bust cache after a mutating attempt.
+        # Even failed writes can be partially applied in degraded scenarios (e.g. rebuild failure).
+        reset_rag_service()
 
 
 @router.post("/docs/delete_by_external_id", response_model=DeleteDocsByExternalIdResponse)
@@ -641,12 +642,13 @@ async def delete_docs_by_external_id(
             rebuilt_index=False,
         )
 
-    resp = cast(
-        "DeleteDocsByExternalIdResponse",
-        await run_blocking(_run_multi_store_write_locked, _delete_sync),
-    )
-    reset_rag_service()
-    return resp
+    try:
+        return cast(
+            "DeleteDocsByExternalIdResponse",
+            await run_blocking(_run_multi_store_write_locked, _delete_sync),
+        )
+    finally:
+        reset_rag_service()
 
 
 @router.post("/docs/delete", response_model=DeleteDocsResponse)
@@ -678,11 +680,12 @@ async def delete_docs(payload: Annotated[DeleteDocsRequest, Body(...)]) -> Delet
         deleted_sql, _, _ = delete_documents_multi_store(doc_repo=doc_repo, ids=ids)
         return DeleteDocsResponse(deleted_sql=deleted_sql, deleted_index=None, rebuilt_index=False)
 
-    resp = cast(
-        "DeleteDocsResponse", await run_blocking(_run_multi_store_write_locked, _delete_sync)
-    )
-    reset_rag_service()
-    return resp
+    try:
+        return cast(
+            "DeleteDocsResponse", await run_blocking(_run_multi_store_write_locked, _delete_sync)
+        )
+    finally:
+        reset_rag_service()
 
 
 @router.post("/docs/upsert", response_model=UpsertDocsResponse)
@@ -815,11 +818,12 @@ async def upsert_docs(payload: Annotated[UpsertDocsRequest, Body(...)]) -> Upser
             ],
         )
 
-    resp = cast(
-        "UpsertDocsResponse", await run_blocking(_run_multi_store_write_locked, _upsert_sync)
-    )
-    reset_rag_service()
-    return resp
+    try:
+        return cast(
+            "UpsertDocsResponse", await run_blocking(_run_multi_store_write_locked, _upsert_sync)
+        )
+    finally:
+        reset_rag_service()
 
 
 @router.post("/index/rebuild", response_model=RebuildIndexResponse)
@@ -844,11 +848,12 @@ async def rebuild_index() -> RebuildIndexResponse:
         n = rebuild_index_from_db(doc_repo=doc_repo, vec_repo=vec, embedder=embedder)
         return RebuildIndexResponse(indexed=n)
 
-    resp = cast(
-        "RebuildIndexResponse", await run_blocking(_run_multi_store_write_locked, _rebuild_sync)
-    )
-    reset_rag_service()
-    return resp
+    try:
+        return cast(
+            "RebuildIndexResponse", await run_blocking(_run_multi_store_write_locked, _rebuild_sync)
+        )
+    finally:
+        reset_rag_service()
 
 
 def _build_retriever_from_config(

--- a/src/local_rag_backend/app/api_router.py
+++ b/src/local_rag_backend/app/api_router.py
@@ -24,6 +24,13 @@ from local_rag_backend.app.diagnostics import (
     get_history_count,
     get_retrieval_index_stats,
 )
+from local_rag_backend.app.observability import (
+    Timer,
+    fingerprint_question,
+    log_event,
+    observe_ingest,
+    observe_query,
+)
 from local_rag_backend.app.schemas import (
     AskEvalConfig,
     AskEvalRequest,
@@ -52,6 +59,7 @@ from local_rag_backend.core.services.prompting import (
     validate_prompt_template,
 )
 from local_rag_backend.core.services.rag import RagService
+from local_rag_backend.core.services.reranking import RerankingRetriever
 from local_rag_backend.infrastructure.embeddings.openai import OpenAIEmbedder
 from local_rag_backend.infrastructure.embeddings.sentence_transformers import (
     SentenceTransformerEmbedder,
@@ -306,9 +314,24 @@ async def ask(request: AskRequest, service: RagService = Depends(get_rag_service
         AskResponse: Generated answer with source documents
     """
     # Avoid blocking the event loop: the RAG pipeline is synchronous (DB/FAISS + network I/O).
-    rag_result = await run_blocking(service.ask, request.question, request.k)
+    t = Timer()
+    ok = False
+    try:
+        rag_result = await run_blocking(service.ask, request.question, request.k)
+        ok = True
+    finally:
+        observe_query(ok=ok, duration_s=t.seconds())
     docs = rag_result["docs"]
     scores = rag_result["scores"]
+    log_event(
+        "rag_query",
+        **fingerprint_question(request.question),
+        k=int(request.k),
+        retrieval_mode=str(settings.retrieval_mode),
+        reranker_enabled=bool(settings.enable_reranker),
+        sources=len(docs),
+        duration_ms=int(1000 * t.seconds()),
+    )
 
     sources = [
         QueryResult(
@@ -385,6 +408,7 @@ async def ingest_docs(payload: Annotated[IngestRequest, Body(...)]) -> IngestRes
     texts = [t.strip() for t in payload.texts if t and t.strip()]
     if not texts:
         return IngestResponse(count=0, ids=[])
+    t = Timer()
 
     def _embedding_model_name_for_dedup() -> str:
         if settings.retrieval_mode not in ("dense", "hybrid"):
@@ -482,8 +506,12 @@ async def ingest_docs(payload: Annotated[IngestRequest, Body(...)]) -> IngestRes
 
         return [id_by_ext[e] for e in unique_extids if e in id_by_ext]
 
+    ok = False
+    ids: list[int] = []
     try:
         ids = await run_blocking(_ingest_sync)
+        ok = True
+        return IngestResponse(count=len(ids), ids=ids)
     except RuntimeError as e:
         if "sentence-transformers" in str(e) or "Dense/hybrid" in str(e):
             raise HTTPException(
@@ -494,10 +522,20 @@ async def ingest_docs(payload: Annotated[IngestRequest, Body(...)]) -> IngestRes
                 ),
             ) from e
         raise
-
-    # The RAG service is cached; reset it so subsequent queries see the updated DB / index.
-    reset_rag_service()
-    return IngestResponse(count=len(ids), ids=ids)
+    finally:
+        observe_ingest(source="api:/docs", ok=ok, inserted=len(ids))
+        log_event(
+            "rag_ingest",
+            source="api:/docs",
+            ok=ok,
+            input_texts=len(texts),
+            inserted=len(ids),
+            retrieval_mode=str(settings.retrieval_mode),
+            reranker_enabled=bool(settings.enable_reranker),
+            duration_ms=int(1000 * t.seconds()),
+        )
+        if ok:
+            reset_rag_service()
 
 
 @router.post("/docs/delete_by_external_id", response_model=DeleteDocsByExternalIdResponse)
@@ -708,8 +746,16 @@ def _build_retriever_from_config(
     doc_ids: list[int],
 ) -> RetrieverPort:
     """Build a retriever instance based on dynamic configuration."""
+    retriever: RetrieverPort
     if cfg.retrieval_mode == "sparse":
-        return SparseBM25Retriever(documents=corpus, doc_ids=doc_ids, doc_repo=doc_repo)
+        retriever = SparseBM25Retriever(documents=corpus, doc_ids=doc_ids, doc_repo=doc_repo)
+        if settings.enable_reranker:
+            retriever = RerankingRetriever(
+                retriever,
+                candidate_k=settings.reranker_candidate_k,
+                strategy=settings.reranker_strategy,
+            )
+        return retriever
 
     embedder: EmbedderPort = (
         OpenAIEmbedder()
@@ -724,16 +770,26 @@ def _build_retriever_from_config(
     )
 
     if cfg.retrieval_mode == "dense":
-        return dense_retriever
-
-    if cfg.retrieval_mode == "hybrid":
+        retriever = dense_retriever
+    elif cfg.retrieval_mode == "hybrid":
         sparse_retriever = SparseBM25Retriever(documents=corpus, doc_ids=doc_ids, doc_repo=doc_repo)
         alpha = (
             cfg.hybrid_alpha if cfg.hybrid_alpha is not None else settings.hybrid_retrieval_alpha
         )
-        return HybridRetriever(dense=dense_retriever, sparse=sparse_retriever, alpha=alpha)
+        retriever = HybridRetriever(dense=dense_retriever, sparse=sparse_retriever, alpha=alpha)
+    else:
+        raise HTTPException(
+            status_code=400, detail=f"Unsupported retrieval_mode: {cfg.retrieval_mode}"
+        )
 
-    raise HTTPException(status_code=400, detail=f"Unsupported retrieval_mode: {cfg.retrieval_mode}")
+    if settings.enable_reranker:
+        retriever = RerankingRetriever(
+            retriever,
+            candidate_k=settings.reranker_candidate_k,
+            strategy=settings.reranker_strategy,
+        )
+
+    return retriever
 
 
 def _build_generator_from_config(cfg: AskEvalConfig) -> GeneratorPort:

--- a/src/local_rag_backend/app/factory.py
+++ b/src/local_rag_backend/app/factory.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 import os
+import tempfile
 from functools import lru_cache
 from time import time_ns
 from typing import TYPE_CHECKING
@@ -144,9 +145,19 @@ def _read_reload_token() -> str:
 def _write_reload_token(token: str) -> None:
     p = _reload_token_path()
     p.parent.mkdir(parents=True, exist_ok=True)
-    tmp = p.with_name(p.name + ".tmp")
-    tmp.write_text(token, encoding="utf-8")
-    os.replace(tmp, p)
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        prefix=p.name + ".",
+        suffix=".tmp",
+        dir=p.parent,
+        delete=False,
+    ) as tmp:
+        tmp.write(token)
+        tmp.flush()
+        os.fsync(tmp.fileno())
+        tmp_name = tmp.name
+    os.replace(tmp_name, p)
 
 
 @lru_cache(maxsize=1)

--- a/src/local_rag_backend/app/factory.py
+++ b/src/local_rag_backend/app/factory.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 
 from local_rag_backend.core.services.corpus import get_corpus_and_ids
 from local_rag_backend.core.services.rag import RagService
+from local_rag_backend.core.services.reranking import RerankingRetriever
 from local_rag_backend.infrastructure.embeddings.openai import OpenAIEmbedder
 from local_rag_backend.infrastructure.embeddings.sentence_transformers import (
     SentenceTransformerEmbedder,
@@ -102,6 +103,13 @@ def build_rag_service() -> RagService:
                 sparse=sparse_retriever,
                 alpha=settings.hybrid_retrieval_alpha,
             )
+
+    if settings.enable_reranker:
+        retriever = RerankingRetriever(
+            retriever,
+            candidate_k=settings.reranker_candidate_k,
+            strategy=settings.reranker_strategy,
+        )
 
     # 3. Generator Port
     generator: GeneratorPort

--- a/src/local_rag_backend/app/middleware.py
+++ b/src/local_rag_backend/app/middleware.py
@@ -48,10 +48,12 @@ def _noop_generate_latest(*_args: Any, **_kwargs: Any) -> bytes:  # pragma: no c
 
 
 try:  # pragma: no cover
-    from prometheus_client import CONTENT_TYPE_LATEST as _CONTENT_TYPE_LATEST
-    from prometheus_client import Counter as _PromCounter
-    from prometheus_client import Histogram as _PromHistogram
-    from prometheus_client import generate_latest as _prom_generate_latest
+    from prometheus_client import (
+        CONTENT_TYPE_LATEST as _CONTENT_TYPE_LATEST,
+        Counter as _PromCounter,
+        Histogram as _PromHistogram,
+        generate_latest as _prom_generate_latest,
+    )
 
     PROMETHEUS_AVAILABLE = True
     CONTENT_TYPE_LATEST = _CONTENT_TYPE_LATEST

--- a/src/local_rag_backend/app/middleware.py
+++ b/src/local_rag_backend/app/middleware.py
@@ -48,12 +48,10 @@ def _noop_generate_latest(*_args: Any, **_kwargs: Any) -> bytes:  # pragma: no c
 
 
 try:  # pragma: no cover
-    from prometheus_client import (
-        CONTENT_TYPE_LATEST as _CONTENT_TYPE_LATEST,
-        Counter as _PromCounter,
-        Histogram as _PromHistogram,
-        generate_latest as _prom_generate_latest,
-    )
+    from prometheus_client import CONTENT_TYPE_LATEST as _CONTENT_TYPE_LATEST
+    from prometheus_client import Counter as _PromCounter
+    from prometheus_client import Histogram as _PromHistogram
+    from prometheus_client import generate_latest as _prom_generate_latest
 
     PROMETHEUS_AVAILABLE = True
     CONTENT_TYPE_LATEST = _CONTENT_TYPE_LATEST

--- a/src/local_rag_backend/app/observability.py
+++ b/src/local_rag_backend/app/observability.py
@@ -1,0 +1,96 @@
+"""
+Minimal observability primitives: structured-ish logs and domain metrics.
+
+Goals:
+- Keep dependencies optional (prometheus-client may be missing).
+- Avoid high-cardinality labels.
+- Avoid logging raw user content by default (privacy).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import time
+from typing import Any
+
+from local_rag_backend.app import middleware as mw
+from local_rag_backend.settings import settings
+
+logger = logging.getLogger(__name__)
+
+
+def _sha256_short(text: str) -> str:
+    h = hashlib.sha256(text.encode("utf-8", errors="ignore")).hexdigest()
+    return h[:12]
+
+
+def log_event(event: str, **fields: Any) -> None:
+    """
+    Log a single event as a JSON string.
+
+    This intentionally logs a JSON payload rather than relying on optional structlog,
+    keeping behavior stable across installs.
+    """
+    payload = {"event": event, **fields}
+    try:
+        logger.info(json.dumps(payload, ensure_ascii=True, sort_keys=True))
+    except Exception:  # pragma: no cover
+        logger.info("%s %s", event, fields)
+
+
+# --- Domain metrics (optional Prometheus) --- #
+
+_queries_total = mw.Counter(
+    "rag_queries_total",
+    "Total RAG queries processed (ask endpoint).",
+    ["retrieval_mode", "reranker_enabled", "status"],
+)
+_query_latency = mw.Histogram(
+    "rag_query_duration_seconds",
+    "RAG query latency in seconds (ask endpoint).",
+    ["retrieval_mode", "reranker_enabled"],
+)
+_ingest_requests_total = mw.Counter(
+    "rag_ingest_requests_total",
+    "Total ingest requests processed (docs endpoints).",
+    ["source", "status"],
+)
+_ingest_docs_total = mw.Counter(
+    "rag_ingest_docs_total",
+    "Total documents/chunks ingested (docs endpoints).",
+    ["source"],
+)
+
+
+def _labels_retrieval() -> tuple[str, str]:
+    return str(settings.retrieval_mode), "1" if bool(settings.enable_reranker) else "0"
+
+
+class Timer:
+    def __init__(self) -> None:
+        self._start = time.monotonic()
+
+    def seconds(self) -> float:
+        return float(time.monotonic() - self._start)
+
+
+def observe_query(*, ok: bool, duration_s: float) -> None:
+    mode, rerank = _labels_retrieval()
+    _query_latency.labels(retrieval_mode=mode, reranker_enabled=rerank).observe(duration_s)
+    _queries_total.labels(
+        retrieval_mode=mode, reranker_enabled=rerank, status="ok" if ok else "error"
+    ).inc()
+
+
+def observe_ingest(*, source: str, ok: bool, inserted: int) -> None:
+    src = str(source)
+    _ingest_requests_total.labels(source=src, status="ok" if ok else "error").inc()
+    if inserted > 0:
+        _ingest_docs_total.labels(source=src).inc(float(inserted))
+
+
+def fingerprint_question(question: str) -> dict[str, Any]:
+    q = str(question or "")
+    return {"q_sha256": _sha256_short(q), "q_len": len(q)}

--- a/src/local_rag_backend/app/schemas.py
+++ b/src/local_rag_backend/app/schemas.py
@@ -65,7 +65,7 @@ class AskEvalConfig(BaseModel):
     )
     model: str | None = Field(default=None, max_length=256)
     temperature: float | None = None
-    top_p: float | None = None
+    top_p: float | None = Field(default=None, ge=0.0, le=1.0)
     max_tokens: int | None = None
     prompt_template: str | None = Field(default=None, max_length=20000)
 

--- a/src/local_rag_backend/cli.py
+++ b/src/local_rag_backend/cli.py
@@ -62,6 +62,15 @@ def _run_with_multi_store_write_lock(operation: Callable[[], T]) -> T:
         return operation()
 
 
+def _reset_rag_service_best_effort() -> None:
+    from local_rag_backend.app.factory import reset_rag_service
+
+    try:
+        reset_rag_service()
+    except Exception:
+        return None
+
+
 @cli.command()
 def server() -> None:
     """Start the RAG FastAPI server using settings from config file or environment."""
@@ -82,6 +91,7 @@ def server() -> None:
 @cli.command("build-index")
 def build_index() -> None:
     """Build FAISS index from existing documents."""
+    mutation_attempted = False
     try:
         _ensure_sqlite_schema_for_cli()
         # Import here to avoid circular imports
@@ -89,20 +99,24 @@ def build_index() -> None:
 
         click.echo("[INFO] Building FAISS index...")
         with click.progressbar(length=1, label="Building index") as bar:
+            mutation_attempted = True
             _run_with_multi_store_write_lock(build_main)
             bar.update(1)
         click.echo("[OK] Index built successfully!")
     except Exception as e:
         click.echo(f"[ERROR] Error building index: {e}", err=True)
         sys.exit(1)
+    finally:
+        if mutation_attempted:
+            _reset_rag_service_best_effort()
 
 
 @cli.command("rebuild-index")
 def rebuild_index() -> None:
     """Rebuild FAISS index from the current SQLite documents (idempotent)."""
+    mutation_attempted = False
     try:
         _ensure_sqlite_schema_for_cli()
-        from local_rag_backend.app.factory import reset_rag_service
         from local_rag_backend.core.services.maintenance import rebuild_index_from_db
         from local_rag_backend.infrastructure.embeddings.openai import OpenAIEmbedder
         from local_rag_backend.infrastructure.embeddings.sentence_transformers import (
@@ -132,12 +146,15 @@ def rebuild_index() -> None:
             )
             return rebuild_index_from_db(doc_repo=doc_repo, vec_repo=vec, embedder=embedder)
 
+        mutation_attempted = True
         n = _run_with_multi_store_write_lock(_rebuild_sync)
-        reset_rag_service()
         click.echo(f"[OK] Rebuilt index with {n} vectors.")
     except Exception as e:
         click.echo(f"[ERROR] Error rebuilding index: {e}", err=True)
         sys.exit(1)
+    finally:
+        if mutation_attempted:
+            _reset_rag_service_best_effort()
 
 
 @cli.command("delete-docs")
@@ -148,9 +165,9 @@ def delete_docs(ids: tuple[int, ...]) -> None:
         click.echo("[ERROR] Provide one or more document IDs.", err=True)
         sys.exit(2)
 
+    mutation_attempted = False
     try:
         _ensure_sqlite_schema_for_cli()
-        from local_rag_backend.app.factory import reset_rag_service
         from local_rag_backend.core.services.maintenance import delete_documents_multi_store
         from local_rag_backend.infrastructure.embeddings.openai import OpenAIEmbedder
         from local_rag_backend.infrastructure.embeddings.sentence_transformers import (
@@ -182,8 +199,8 @@ def delete_docs(ids: tuple[int, ...]) -> None:
             deleted_sql, _, rebuilt = delete_documents_multi_store(doc_repo=doc_repo, ids=list(ids))
             return deleted_sql, None, rebuilt
 
+        mutation_attempted = True
         deleted_sql, deleted_index, rebuilt = _run_with_multi_store_write_lock(_delete_sync)
-        reset_rag_service()
         if deleted_index is None and settings.retrieval_mode not in ("dense", "hybrid"):
             click.echo(f"[OK] Deleted {deleted_sql} docs from SQL.")
             return
@@ -195,6 +212,9 @@ def delete_docs(ids: tuple[int, ...]) -> None:
     except Exception as e:
         click.echo(f"[ERROR] Error deleting docs: {e}", err=True)
         sys.exit(1)
+    finally:
+        if mutation_attempted:
+            _reset_rag_service_best_effort()
 
 
 @cli.command("delete-external-ids")
@@ -205,9 +225,9 @@ def delete_external_ids(external_ids: tuple[str, ...]) -> None:
         click.echo("[ERROR] Provide one or more external_ids.", err=True)
         sys.exit(2)
 
+    mutation_attempted = False
     try:
         _ensure_sqlite_schema_for_cli()
-        from local_rag_backend.app.factory import reset_rag_service
         from local_rag_backend.core.services.maintenance import rebuild_index_from_db
         from local_rag_backend.infrastructure.embeddings.openai import OpenAIEmbedder
         from local_rag_backend.infrastructure.embeddings.sentence_transformers import (
@@ -243,11 +263,10 @@ def delete_external_ids(external_ids: tuple[str, ...]) -> None:
                     rebuilt = n >= 0
             return deleted_sql, deleted_index, missing, tombstoned, rebuilt
 
+        mutation_attempted = True
         deleted_sql, deleted_index, missing, tombstoned, rebuilt = _run_with_multi_store_write_lock(
             _delete_sync
         )
-
-        reset_rag_service()
         click.echo(
             f"[OK] Deleted {deleted_sql} docs by external_id. "
             f"tombstoned={tombstoned} missing={len(missing)} "
@@ -258,6 +277,9 @@ def delete_external_ids(external_ids: tuple[str, ...]) -> None:
     except Exception as e:
         click.echo(f"[ERROR] Error deleting by external_id: {e}", err=True)
         sys.exit(1)
+    finally:
+        if mutation_attempted:
+            _reset_rag_service_best_effort()
 
 
 @cli.command("upsert-docs")
@@ -285,11 +307,11 @@ def upsert_docs(
     metadata_json: str | None,
 ) -> None:
     """Upsert documents by external_id (idempotent)."""
+    mutation_attempted = False
     try:
         _ensure_sqlite_schema_for_cli()
         from typing import Any, cast
 
-        from local_rag_backend.app.factory import reset_rag_service
         from local_rag_backend.core.services.maintenance import rebuild_index_from_db
         from local_rag_backend.infrastructure.embeddings.openai import OpenAIEmbedder
         from local_rag_backend.infrastructure.embeddings.sentence_transformers import (
@@ -422,19 +444,23 @@ def upsert_docs(
 
             return inserted, updated, unchanged, rebuilt
 
+        mutation_attempted = True
         inserted, updated, unchanged, rebuilt = _run_with_multi_store_write_lock(_upsert_sync)
-        reset_rag_service()
         click.echo(
             f"[OK] Upserted docs. inserted={inserted} updated={updated} unchanged={unchanged} rebuilt_index={rebuilt}"
         )
     except Exception as e:
         click.echo(f"[ERROR] Error upserting docs: {e}", err=True)
         sys.exit(1)
+    finally:
+        if mutation_attempted:
+            _reset_rag_service_best_effort()
 
 
 @cli.command()
 def bootstrap() -> None:
     """Bootstrap database with sample data."""
+    mutation_attempted = False
     try:
         _ensure_sqlite_schema_for_cli()
         # Import here to avoid circular imports
@@ -442,12 +468,16 @@ def bootstrap() -> None:
 
         click.echo("[INFO] Bootstrapping database with sample data...")
         with click.progressbar(length=1, label="Bootstrapping") as bar:
+            mutation_attempted = True
             _run_with_multi_store_write_lock(bootstrap_main)
             bar.update(1)
         click.echo("[OK] Bootstrap completed successfully!")
     except Exception as e:
         click.echo(f"[ERROR] Error bootstrapping: {e}", err=True)
         sys.exit(1)
+    finally:
+        if mutation_attempted:
+            _reset_rag_service_best_effort()
 
 
 @cli.command()
@@ -739,9 +769,9 @@ def ingest(
         click.echo("[ERROR] Provide one or more paths (file or directory).", err=True)
         sys.exit(2)
 
+    mutation_attempted = False
     try:
         _ensure_sqlite_schema_for_cli()
-        from local_rag_backend.app.factory import reset_rag_service
         from local_rag_backend.core.services.chunking import chunk_chars_v1
         from local_rag_backend.core.services.ingestion import (
             build_preprocess_fn_from_settings,
@@ -795,6 +825,9 @@ def ingest(
         if not files:
             click.echo("[WARN] No files found under limits. Nothing to ingest.")
             return
+
+        if not dry_run:
+            mutation_attempted = True
 
         total_inserted = 0
         total_updated = 0
@@ -994,9 +1027,6 @@ def ingest(
             if deleted_stale:
                 click.echo(f"[INFO] Deleted {deleted_stale} stale chunks for {file_path}.")
 
-        if not dry_run:
-            reset_rag_service()
-
         if dry_run:
             click.echo(
                 f"[DRY-RUN] files={total_files} chunks={total_chunks} skipped={total_skipped} "
@@ -1012,6 +1042,9 @@ def ingest(
     except Exception as e:
         click.echo(f"[ERROR] Error ingesting files: {e}", err=True)
         sys.exit(1)
+    finally:
+        if mutation_attempted:
+            _reset_rag_service_best_effort()
 
 
 def rag_ingest() -> None:

--- a/src/local_rag_backend/cli.py
+++ b/src/local_rag_backend/cli.py
@@ -12,6 +12,7 @@ import hashlib
 import json
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING, TypeVar
 
 import click
 import uvicorn
@@ -23,6 +24,11 @@ from local_rag_backend.app.diagnostics import (
     get_retrieval_index_stats,
 )
 from local_rag_backend.settings import settings
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+T = TypeVar("T")
 
 
 def _ensure_sqlite_schema_for_cli() -> None:
@@ -47,6 +53,13 @@ def _ensure_sqlite_schema_for_cli() -> None:
 def cli() -> None:
     """Intrinsical RAG Prototype - Production-ready RAG system with hexagonal architecture."""
     pass
+
+
+def _run_with_multi_store_write_lock(operation: Callable[[], T]) -> T:
+    from local_rag_backend.core.services.write_lock import multi_store_write_lock
+
+    with multi_store_write_lock():
+        return operation()
 
 
 @cli.command()
@@ -76,7 +89,7 @@ def build_index() -> None:
 
         click.echo("[INFO] Building FAISS index...")
         with click.progressbar(length=1, label="Building index") as bar:
-            build_main()
+            _run_with_multi_store_write_lock(build_main)
             bar.update(1)
         click.echo("[OK] Index built successfully!")
     except Exception as e:
@@ -101,22 +114,25 @@ def rebuild_index() -> None:
         if settings.retrieval_mode not in ("dense", "hybrid"):
             raise RuntimeError("rebuild-index requires RETRIEVAL_MODE=dense|hybrid")
 
-        doc_repo = SqlDocumentStorage()
-        embedder = (
-            OpenAIEmbedder()
-            if settings.openai_api_key
-            else SentenceTransformerEmbedder(model_name=settings.st_embedding_model)
-        )
-        # Rebuild must be able to recover from an incompatible on-disk index (e.g. dim drift).
-        from local_rag_backend.infrastructure.persistence.faiss.manifest import (
-            purge_index_artifacts,
-        )
+        def _rebuild_sync() -> int:
+            doc_repo = SqlDocumentStorage()
+            embedder = (
+                OpenAIEmbedder()
+                if settings.openai_api_key
+                else SentenceTransformerEmbedder(model_name=settings.st_embedding_model)
+            )
+            # Rebuild must be able to recover from an incompatible on-disk index (e.g. dim drift).
+            from local_rag_backend.infrastructure.persistence.faiss.manifest import (
+                purge_index_artifacts,
+            )
 
-        purge_index_artifacts(index_path=settings.index_path, id_map_path=settings.id_map_path)
-        vec = FaissVectorStorage(
-            index_path=settings.index_path, id_map_path=settings.id_map_path, dim=embedder.dim
-        )
-        n = rebuild_index_from_db(doc_repo=doc_repo, vec_repo=vec, embedder=embedder)
+            purge_index_artifacts(index_path=settings.index_path, id_map_path=settings.id_map_path)
+            vec = FaissVectorStorage(
+                index_path=settings.index_path, id_map_path=settings.id_map_path, dim=embedder.dim
+            )
+            return rebuild_index_from_db(doc_repo=doc_repo, vec_repo=vec, embedder=embedder)
+
+        n = _run_with_multi_store_write_lock(_rebuild_sync)
         reset_rag_service()
         click.echo(f"[OK] Rebuilt index with {n} vectors.")
     except Exception as e:
@@ -143,35 +159,39 @@ def delete_docs(ids: tuple[int, ...]) -> None:
         from local_rag_backend.infrastructure.persistence.faiss.faiss_ import FaissVectorStorage
         from local_rag_backend.infrastructure.persistence.sqlalchemy.sql_ import SqlDocumentStorage
 
-        doc_repo = SqlDocumentStorage()
-        if settings.retrieval_mode in ("dense", "hybrid"):
-            # For deletion, avoid loading the embedder just to infer dim if the index already exists.
-            vec = FaissVectorStorage(
-                index_path=settings.index_path, id_map_path=settings.id_map_path, dim=None
-            )
-            embedder = (
-                OpenAIEmbedder()
-                if settings.openai_api_key
-                else SentenceTransformerEmbedder(model_name=settings.st_embedding_model)
-            )
-            deleted_sql, deleted_index, rebuilt = delete_documents_multi_store(
-                doc_repo=doc_repo,
-                vec_repo=vec,
-                embedder=embedder,
-                ids=list(ids),
-                rebuild_on_index_failure=True,
-            )
-            reset_rag_service()
-            click.echo(
-                f"[OK] Deleted {deleted_sql} docs from SQL. "
-                f"Index delete={'ok' if deleted_index is not None else 'n/a'} "
-                f"rebuilt={rebuilt}."
-            )
-            return
+        def _delete_sync() -> tuple[int, int | None, bool]:
+            doc_repo = SqlDocumentStorage()
+            if settings.retrieval_mode in ("dense", "hybrid"):
+                # For deletion, avoid loading the embedder just to infer dim if the index exists.
+                vec = FaissVectorStorage(
+                    index_path=settings.index_path, id_map_path=settings.id_map_path, dim=None
+                )
+                embedder = (
+                    OpenAIEmbedder()
+                    if settings.openai_api_key
+                    else SentenceTransformerEmbedder(model_name=settings.st_embedding_model)
+                )
+                return delete_documents_multi_store(
+                    doc_repo=doc_repo,
+                    vec_repo=vec,
+                    embedder=embedder,
+                    ids=list(ids),
+                    rebuild_on_index_failure=True,
+                )
 
-        deleted_sql, _, _ = delete_documents_multi_store(doc_repo=doc_repo, ids=list(ids))
+            deleted_sql, _, rebuilt = delete_documents_multi_store(doc_repo=doc_repo, ids=list(ids))
+            return deleted_sql, None, rebuilt
+
+        deleted_sql, deleted_index, rebuilt = _run_with_multi_store_write_lock(_delete_sync)
         reset_rag_service()
-        click.echo(f"[OK] Deleted {deleted_sql} docs from SQL.")
+        if deleted_index is None and settings.retrieval_mode not in ("dense", "hybrid"):
+            click.echo(f"[OK] Deleted {deleted_sql} docs from SQL.")
+            return
+        click.echo(
+            f"[OK] Deleted {deleted_sql} docs from SQL. "
+            f"Index delete={'ok' if deleted_index is not None else 'n/a'} "
+            f"rebuilt={rebuilt}."
+        )
     except Exception as e:
         click.echo(f"[ERROR] Error deleting docs: {e}", err=True)
         sys.exit(1)
@@ -196,30 +216,36 @@ def delete_external_ids(external_ids: tuple[str, ...]) -> None:
         from local_rag_backend.infrastructure.persistence.faiss.faiss_ import FaissVectorStorage
         from local_rag_backend.infrastructure.persistence.sqlalchemy.sql_ import SqlDocumentStorage
 
-        doc_repo = SqlDocumentStorage()
-        deleted_sql, deleted_ids, missing, tombstoned = doc_repo.delete_by_external_ids(
-            list(external_ids)
-        )
+        def _delete_sync() -> tuple[int, int | None, list[str], int, bool]:
+            doc_repo = SqlDocumentStorage()
+            deleted_sql, deleted_ids, missing, tombstoned = doc_repo.delete_by_external_ids(
+                list(external_ids)
+            )
 
-        rebuilt = False
-        deleted_index: int | None = None
-        if settings.retrieval_mode in ("dense", "hybrid"):
-            vec = FaissVectorStorage(
-                index_path=settings.index_path,
-                id_map_path=settings.id_map_path,
-                dim=None,
-            )
-            embedder = (
-                OpenAIEmbedder()
-                if settings.openai_api_key
-                else SentenceTransformerEmbedder(model_name=settings.st_embedding_model)
-            )
-            try:
-                vec.delete(deleted_ids)
-                deleted_index = len(deleted_ids)
-            except Exception:
-                n = rebuild_index_from_db(doc_repo=doc_repo, vec_repo=vec, embedder=embedder)
-                rebuilt = n >= 0
+            rebuilt = False
+            deleted_index: int | None = None
+            if settings.retrieval_mode in ("dense", "hybrid"):
+                vec = FaissVectorStorage(
+                    index_path=settings.index_path,
+                    id_map_path=settings.id_map_path,
+                    dim=None,
+                )
+                embedder = (
+                    OpenAIEmbedder()
+                    if settings.openai_api_key
+                    else SentenceTransformerEmbedder(model_name=settings.st_embedding_model)
+                )
+                try:
+                    vec.delete(deleted_ids)
+                    deleted_index = len(deleted_ids)
+                except Exception:
+                    n = rebuild_index_from_db(doc_repo=doc_repo, vec_repo=vec, embedder=embedder)
+                    rebuilt = n >= 0
+            return deleted_sql, deleted_index, missing, tombstoned, rebuilt
+
+        deleted_sql, deleted_index, missing, tombstoned, rebuilt = _run_with_multi_store_write_lock(
+            _delete_sync
+        )
 
         reset_rag_service()
         click.echo(
@@ -313,88 +339,90 @@ def upsert_docs(
                 )
             )
 
-        doc_repo = SqlDocumentStorage()
-        tombstoned = doc_repo.get_tombstoned_external_ids([i.external_id for i in items])
-        if tombstoned:
-            raise RuntimeError(
-                "Some external_id values are tombstoned (deleted): "
-                + ", ".join(sorted(tombstoned)[:10])
-            )
-        embedder = None
-        vectors_by_external_id: dict[str, list[float]] = {}
-        if settings.retrieval_mode in ("dense", "hybrid"):
-            embedder = (
-                OpenAIEmbedder()
-                if settings.openai_api_key
-                else SentenceTransformerEmbedder(model_name=settings.st_embedding_model)
-            )
-            existing_states = doc_repo.get_existing_doc_states_by_external_id(
-                [it.external_id for it in items]
-            )
-            to_embed = []
-            for it in items:
-                content = it.content.strip()
-                current = existing_states.get(it.external_id)
-                if current is None:
-                    to_embed.append(it)
-                    continue
-                content_sha = hashlib.sha256(content.encode("utf-8")).hexdigest()
-                old_sha = current.content_sha256 or ""
-                if old_sha != content_sha or current.content != content:
-                    to_embed.append(it)
-
-            if to_embed:
-                embedded = embedder.embed([it.content.strip() for it in to_embed])
-                if len(embedded) != len(to_embed):
-                    raise RuntimeError(
-                        f"Embedder returned {len(embedded)} vectors for {len(to_embed)} documents."
-                    )
-                vectors_by_external_id = {
-                    it.external_id: list(vec) for it, vec in zip(to_embed, embedded, strict=False)
-                }
-
-        results, _changed_content, updated_content_ids = doc_repo.upsert_documents_by_external_id(
-            items
-        )
-
-        inserted = sum(1 for r in results if r.action == "inserted")
-        updated = sum(1 for r in results if r.action == "updated")
-        unchanged = sum(1 for r in results if r.action == "unchanged")
-
-        rebuilt = False
-        if settings.retrieval_mode in ("dense", "hybrid") and embedder is not None:
-            changed_results = [r for r in results if r.content_changed]
-            missing_vectors = [
-                r.external_id
-                for r in changed_results
-                if r.external_id not in vectors_by_external_id
-            ]
-            if missing_vectors:
+        def _upsert_sync() -> tuple[int, int, int, bool]:
+            doc_repo = SqlDocumentStorage()
+            tombstoned = doc_repo.get_tombstoned_external_ids([i.external_id for i in items])
+            if tombstoned:
                 raise RuntimeError(
-                    "Missing precomputed vectors for changed documents: "
-                    + ", ".join(missing_vectors[:10])
+                    "Some external_id values are tombstoned (deleted): "
+                    + ", ".join(sorted(tombstoned)[:10])
                 )
-            ids = [int(r.id) for r in changed_results]
-            vectors = [vectors_by_external_id[r.external_id] for r in changed_results]
-            if not ids:
-                reset_rag_service()
-                click.echo(
-                    f"[OK] Upserted docs. inserted={inserted} updated={updated} unchanged={unchanged} rebuilt_index={rebuilt}"
+            embedder = None
+            vectors_by_external_id: dict[str, list[float]] = {}
+            if settings.retrieval_mode in ("dense", "hybrid"):
+                embedder = (
+                    OpenAIEmbedder()
+                    if settings.openai_api_key
+                    else SentenceTransformerEmbedder(model_name=settings.st_embedding_model)
                 )
-                return
-            vec = FaissVectorStorage(
-                index_path=settings.index_path,
-                id_map_path=settings.id_map_path,
-                dim=embedder.dim,
-            )
-            try:
-                if updated_content_ids:
-                    vec.delete(updated_content_ids)
-                vec.upsert(ids, vectors)
-            except Exception:
-                n = rebuild_index_from_db(doc_repo=doc_repo, vec_repo=vec, embedder=embedder)
-                rebuilt = n >= 0
+                existing_states = doc_repo.get_existing_doc_states_by_external_id(
+                    [it.external_id for it in items]
+                )
+                to_embed = []
+                for it in items:
+                    content = it.content.strip()
+                    current = existing_states.get(it.external_id)
+                    if current is None:
+                        to_embed.append(it)
+                        continue
+                    content_sha = hashlib.sha256(content.encode("utf-8")).hexdigest()
+                    old_sha = current.content_sha256 or ""
+                    if old_sha != content_sha or current.content != content:
+                        to_embed.append(it)
 
+                if to_embed:
+                    embedded = embedder.embed([it.content.strip() for it in to_embed])
+                    if len(embedded) != len(to_embed):
+                        raise RuntimeError(
+                            f"Embedder returned {len(embedded)} vectors for {len(to_embed)} documents."
+                        )
+                    vectors_by_external_id = {
+                        it.external_id: list(vec)
+                        for it, vec in zip(to_embed, embedded, strict=False)
+                    }
+
+            results, _changed_content, updated_content_ids = (
+                doc_repo.upsert_documents_by_external_id(items)
+            )
+
+            inserted = sum(1 for r in results if r.action == "inserted")
+            updated = sum(1 for r in results if r.action == "updated")
+            unchanged = sum(1 for r in results if r.action == "unchanged")
+
+            rebuilt = False
+            if settings.retrieval_mode in ("dense", "hybrid") and embedder is not None:
+                changed_results = [r for r in results if r.content_changed]
+                missing_vectors = [
+                    r.external_id
+                    for r in changed_results
+                    if r.external_id not in vectors_by_external_id
+                ]
+                if missing_vectors:
+                    raise RuntimeError(
+                        "Missing precomputed vectors for changed documents: "
+                        + ", ".join(missing_vectors[:10])
+                    )
+                ids = [int(r.id) for r in changed_results]
+                vectors = [vectors_by_external_id[r.external_id] for r in changed_results]
+                if ids:
+                    vec = FaissVectorStorage(
+                        index_path=settings.index_path,
+                        id_map_path=settings.id_map_path,
+                        dim=embedder.dim,
+                    )
+                    try:
+                        if updated_content_ids:
+                            vec.delete(updated_content_ids)
+                        vec.upsert(ids, vectors)
+                    except Exception:
+                        n = rebuild_index_from_db(
+                            doc_repo=doc_repo, vec_repo=vec, embedder=embedder
+                        )
+                        rebuilt = n >= 0
+
+            return inserted, updated, unchanged, rebuilt
+
+        inserted, updated, unchanged, rebuilt = _run_with_multi_store_write_lock(_upsert_sync)
         reset_rag_service()
         click.echo(
             f"[OK] Upserted docs. inserted={inserted} updated={updated} unchanged={unchanged} rebuilt_index={rebuilt}"
@@ -414,7 +442,7 @@ def bootstrap() -> None:
 
         click.echo("[INFO] Bootstrapping database with sample data...")
         with click.progressbar(length=1, label="Bootstrapping") as bar:
-            bootstrap_main()
+            _run_with_multi_store_write_lock(bootstrap_main)
             bar.update(1)
         click.echo("[OK] Bootstrap completed successfully!")
     except Exception as e:
@@ -840,109 +868,131 @@ def ingest(
                 total_skipped += 1
                 continue
 
-            # Respect tombstones: deleted external_ids must not reappear on future ingestions.
-            tombstoned = doc_repo.get_tombstoned_external_ids(list(desired_external_ids))
-            if tombstoned:
-                desired_external_ids -= tombstoned
-                items = [it for it in items if it.external_id not in tombstoned]
-
-            existing = doc_repo.list_ids_by_external_id_prefix(file_prefix)
-            stale_ids = [doc_id for doc_id, ext in existing if ext not in desired_external_ids]
-
             if dry_run:
                 total_files += 1
                 total_chunks += len(items)
                 continue
 
-            vectors_by_external_id: dict[str, list[float]] = {}
-            if settings.retrieval_mode in ("dense", "hybrid"):
-                assert embedder is not None
-                existing_states = doc_repo.get_existing_doc_states_by_external_id(
-                    [it.external_id for it in items]
-                )
-                to_embed = []
-                for it in items:
-                    content = it.content.strip()
-                    current = existing_states.get(it.external_id)
-                    if current is None:
-                        to_embed.append(it)
-                        continue
-                    content_sha = hashlib.sha256(content.encode("utf-8")).hexdigest()
-                    old_sha = current.content_sha256 or ""
-                    if old_sha != content_sha or current.content != content:
-                        to_embed.append(it)
+            def _ingest_file_sync(
+                desired_external_ids_bound: tuple[str, ...] = tuple(desired_external_ids),
+                items_bound: tuple[SqlDocumentStorage.UpsertDoc, ...] = tuple(items),
+                file_prefix_bound: str = file_prefix,
+            ) -> tuple[int, int, int, bool, int, int]:
+                desired_external_ids_local = set(desired_external_ids_bound)
+                items_local = list(items_bound)
 
-                if to_embed:
-                    embedded = embedder.embed([it.content.strip() for it in to_embed])
-                    if len(embedded) != len(to_embed):
-                        raise RuntimeError(
-                            f"Embedder returned {len(embedded)} vectors for {len(to_embed)} documents."
-                        )
-                    vectors_by_external_id = {
-                        it.external_id: list(vec)
-                        for it, vec in zip(to_embed, embedded, strict=False)
-                    }
+                # Respect tombstones: deleted external_ids must not reappear on future ingestions.
+                tombstoned = doc_repo.get_tombstoned_external_ids(list(desired_external_ids_local))
+                if tombstoned:
+                    desired_external_ids_local -= tombstoned
+                    items_local = [it for it in items_local if it.external_id not in tombstoned]
 
-            results, _changed_content, updated_content_ids = (
-                doc_repo.upsert_documents_by_external_id(items)
-            )
+                existing = doc_repo.list_ids_by_external_id_prefix(file_prefix_bound)
+                stale_ids = [
+                    doc_id for doc_id, ext in existing if ext not in desired_external_ids_local
+                ]
 
-            total_files += 1
-            total_chunks += len(items)
-            total_inserted += sum(1 for r in results if r.action == "inserted")
-            total_updated += sum(1 for r in results if r.action == "updated")
-            total_unchanged += sum(1 for r in results if r.action == "unchanged")
-
-            if settings.retrieval_mode in ("dense", "hybrid"):
-                assert embedder is not None
-                assert vec is not None
-
-                rebuilt = False
-                changed_results = [r for r in results if r.content_changed]
-                if changed_results:
-                    missing_vectors = [
-                        r.external_id
-                        for r in changed_results
-                        if r.external_id not in vectors_by_external_id
-                    ]
-                    if missing_vectors:
-                        raise RuntimeError(
-                            "Missing precomputed vectors for changed documents: "
-                            + ", ".join(missing_vectors[:10])
-                        )
-                    ids = [int(r.id) for r in changed_results]
-                    vectors = [vectors_by_external_id[r.external_id] for r in changed_results]
-                    try:
-                        if updated_content_ids:
-                            vec.delete(updated_content_ids)
-                        vec.upsert(ids, vectors)
-                    except Exception:
-                        n = rebuild_index_from_db(
-                            doc_repo=doc_repo, vec_repo=vec, embedder=embedder
-                        )
-                        rebuilt = n >= 0
-
-                if stale_ids:
-                    deleted_sql, _, rebuilt_del = delete_documents_multi_store(
-                        doc_repo=doc_repo,
-                        ids=stale_ids,
-                        vec_repo=vec,
-                        embedder=embedder,
-                        rebuild_on_index_failure=True,
+                vectors_by_external_id: dict[str, list[float]] = {}
+                if settings.retrieval_mode in ("dense", "hybrid"):
+                    assert embedder is not None
+                    existing_states = doc_repo.get_existing_doc_states_by_external_id(
+                        [it.external_id for it in items_local]
                     )
-                    total_deleted = deleted_sql
-                    if total_deleted:
-                        click.echo(f"[INFO] Deleted {total_deleted} stale chunks for {file_path}.")
-                    rebuilt = rebuilt or rebuilt_del
+                    to_embed = []
+                    for it in items_local:
+                        content = it.content.strip()
+                        current = existing_states.get(it.external_id)
+                        if current is None:
+                            to_embed.append(it)
+                            continue
+                        content_sha = hashlib.sha256(content.encode("utf-8")).hexdigest()
+                        old_sha = current.content_sha256 or ""
+                        if old_sha != content_sha or current.content != content:
+                            to_embed.append(it)
 
-                rebuilt_any = rebuilt_any or rebuilt
-            else:
-                if stale_ids:
+                    if to_embed:
+                        embedded = embedder.embed([it.content.strip() for it in to_embed])
+                        if len(embedded) != len(to_embed):
+                            raise RuntimeError(
+                                f"Embedder returned {len(embedded)} vectors for {len(to_embed)} documents."
+                            )
+                        vectors_by_external_id = {
+                            it.external_id: list(vec)
+                            for it, vec in zip(to_embed, embedded, strict=False)
+                        }
+
+                results, _changed_content, updated_content_ids = (
+                    doc_repo.upsert_documents_by_external_id(items_local)
+                )
+                inserted = sum(1 for r in results if r.action == "inserted")
+                updated = sum(1 for r in results if r.action == "updated")
+                unchanged = sum(1 for r in results if r.action == "unchanged")
+                rebuilt = False
+                deleted_stale = 0
+
+                if settings.retrieval_mode in ("dense", "hybrid"):
+                    assert embedder is not None
+                    assert vec is not None
+
+                    changed_results = [r for r in results if r.content_changed]
+                    if changed_results:
+                        missing_vectors = [
+                            r.external_id
+                            for r in changed_results
+                            if r.external_id not in vectors_by_external_id
+                        ]
+                        if missing_vectors:
+                            raise RuntimeError(
+                                "Missing precomputed vectors for changed documents: "
+                                + ", ".join(missing_vectors[:10])
+                            )
+                        ids = [int(r.id) for r in changed_results]
+                        vectors = [vectors_by_external_id[r.external_id] for r in changed_results]
+                        try:
+                            if updated_content_ids:
+                                vec.delete(updated_content_ids)
+                            vec.upsert(ids, vectors)
+                        except Exception:
+                            n = rebuild_index_from_db(
+                                doc_repo=doc_repo, vec_repo=vec, embedder=embedder
+                            )
+                            rebuilt = n >= 0
+
+                    if stale_ids:
+                        deleted_sql, _, rebuilt_del = delete_documents_multi_store(
+                            doc_repo=doc_repo,
+                            ids=stale_ids,
+                            vec_repo=vec,
+                            embedder=embedder,
+                            rebuild_on_index_failure=True,
+                        )
+                        deleted_stale = int(deleted_sql)
+                        rebuilt = rebuilt or rebuilt_del
+                elif stale_ids:
                     deleted_sql, _, _ = delete_documents_multi_store(
                         doc_repo=doc_repo, ids=stale_ids
                     )
-                    if deleted_sql:
-                        click.echo(f"[INFO] Deleted {deleted_sql} stale chunks for {file_path}.")
+                    deleted_stale = int(deleted_sql)
+
+                return inserted, updated, unchanged, rebuilt, deleted_stale, len(items_local)
+
+            (
+                inserted,
+                updated,
+                unchanged,
+                rebuilt,
+                deleted_stale,
+                ingested_chunks,
+            ) = _run_with_multi_store_write_lock(_ingest_file_sync)
+
+            total_files += 1
+            total_chunks += ingested_chunks
+            total_inserted += inserted
+            total_updated += updated
+            total_unchanged += unchanged
+            rebuilt_any = rebuilt_any or rebuilt
+            if deleted_stale:
+                click.echo(f"[INFO] Deleted {deleted_stale} stale chunks for {file_path}.")
 
         if not dry_run:
             reset_rag_service()

--- a/src/local_rag_backend/cli.py
+++ b/src/local_rag_backend/cli.py
@@ -512,6 +512,72 @@ def status() -> None:
                     )
 
 
+@cli.command("eval")
+@click.option(
+    "--dataset",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=None,
+    help="Path to a JSONL eval dataset. If omitted, uses the packaged rag_eval_v1 dataset.",
+)
+@click.option(
+    "--retrieval-mode",
+    type=click.Choice(["sparse"], case_sensitive=False),
+    default="sparse",
+    show_default=True,
+)
+@click.option("--k", type=int, default=3, show_default=True)
+@click.option("--max-queries", type=int, default=None, help="Evaluate only the first N queries.")
+@click.option("--reranker/--no-reranker", default=False, show_default=True)
+@click.option("--fail-below-hit-rate", type=float, default=1.0, show_default=True)
+@click.option("--fail-below-mrr", type=float, default=0.9, show_default=True)
+@click.option(
+    "--json-out",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help="Optional path to write eval results as JSON.",
+)
+def eval_cmd(
+    dataset: Path | None,
+    retrieval_mode: str,
+    k: int,
+    max_queries: int | None,
+    reranker: bool,
+    fail_below_hit_rate: float,
+    fail_below_mrr: float,
+    json_out: Path | None,
+) -> None:
+    """Offline retrieval evaluation (reproducible, dependency-free by default)."""
+    from local_rag_backend.core.services.evaluation import (
+        eval_result_to_json,
+        format_eval_result,
+        load_eval_dataset,
+        run_retrieval_eval,
+    )
+
+    ds = load_eval_dataset(dataset)
+    res = run_retrieval_eval(
+        dataset=ds,
+        retrieval_mode=retrieval_mode,
+        k=k,
+        reranker_enabled=bool(reranker),
+        reranker_candidate_k=settings.reranker_candidate_k,
+        reranker_strategy=settings.reranker_strategy,
+        max_queries=max_queries,
+    )
+    click.echo(format_eval_result(res))
+
+    if json_out is not None:
+        json_out.write_text(json.dumps(eval_result_to_json(res)), encoding="utf-8")
+
+    if res.hit_rate < float(fail_below_hit_rate) or res.mrr < float(fail_below_mrr):
+        click.echo(
+            f"[ERROR] Eval regression: hit_rate={res.hit_rate:.3f} (min {fail_below_hit_rate}), "
+            f"mrr={res.mrr:.3f} (min {fail_below_mrr})",
+            err=True,
+        )
+        sys.exit(1)
+
+
 # Entry point functions for setuptools
 def rag_server() -> None:
     """Entry point for rag-server command."""
@@ -531,6 +597,11 @@ def rag_bootstrap() -> None:
 def rag_status() -> None:
     """Entry point for rag-status command."""
     cli.main(args=["status", *sys.argv[1:]], standalone_mode=False)
+
+
+def rag_eval() -> None:
+    """Entry point for rag-eval command."""
+    cli.main(args=["eval", *sys.argv[1:]], standalone_mode=False)
 
 
 def rag_rebuild_index() -> None:

--- a/src/local_rag_backend/cli.py
+++ b/src/local_rag_backend/cli.py
@@ -8,6 +8,7 @@ starting the server, building indices, and bootstrapping data.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import sys
 from pathlib import Path
@@ -319,7 +320,40 @@ def upsert_docs(
                 "Some external_id values are tombstoned (deleted): "
                 + ", ".join(sorted(tombstoned)[:10])
             )
-        results, changed_content, updated_content_ids = doc_repo.upsert_documents_by_external_id(
+        embedder = None
+        vectors_by_external_id: dict[str, list[float]] = {}
+        if settings.retrieval_mode in ("dense", "hybrid"):
+            embedder = (
+                OpenAIEmbedder()
+                if settings.openai_api_key
+                else SentenceTransformerEmbedder(model_name=settings.st_embedding_model)
+            )
+            existing_states = doc_repo.get_existing_doc_states_by_external_id(
+                [it.external_id for it in items]
+            )
+            to_embed = []
+            for it in items:
+                content = it.content.strip()
+                current = existing_states.get(it.external_id)
+                if current is None:
+                    to_embed.append(it)
+                    continue
+                content_sha = hashlib.sha256(content.encode("utf-8")).hexdigest()
+                old_sha = current.content_sha256 or ""
+                if old_sha != content_sha or current.content != content:
+                    to_embed.append(it)
+
+            if to_embed:
+                embedded = embedder.embed([it.content.strip() for it in to_embed])
+                if len(embedded) != len(to_embed):
+                    raise RuntimeError(
+                        f"Embedder returned {len(embedded)} vectors for {len(to_embed)} documents."
+                    )
+                vectors_by_external_id = {
+                    it.external_id: list(vec) for it, vec in zip(to_embed, embedded, strict=False)
+                }
+
+        results, _changed_content, updated_content_ids = doc_repo.upsert_documents_by_external_id(
             items
         )
 
@@ -328,20 +362,31 @@ def upsert_docs(
         unchanged = sum(1 for r in results if r.action == "unchanged")
 
         rebuilt = False
-        if settings.retrieval_mode in ("dense", "hybrid") and changed_content:
-            embedder = (
-                OpenAIEmbedder()
-                if settings.openai_api_key
-                else SentenceTransformerEmbedder(model_name=settings.st_embedding_model)
-            )
+        if settings.retrieval_mode in ("dense", "hybrid") and embedder is not None:
+            changed_results = [r for r in results if r.content_changed]
+            missing_vectors = [
+                r.external_id
+                for r in changed_results
+                if r.external_id not in vectors_by_external_id
+            ]
+            if missing_vectors:
+                raise RuntimeError(
+                    "Missing precomputed vectors for changed documents: "
+                    + ", ".join(missing_vectors[:10])
+                )
+            ids = [int(r.id) for r in changed_results]
+            vectors = [vectors_by_external_id[r.external_id] for r in changed_results]
+            if not ids:
+                reset_rag_service()
+                click.echo(
+                    f"[OK] Upserted docs. inserted={inserted} updated={updated} unchanged={unchanged} rebuilt_index={rebuilt}"
+                )
+                return
             vec = FaissVectorStorage(
                 index_path=settings.index_path,
                 id_map_path=settings.id_map_path,
                 dim=embedder.dim,
             )
-            ids = [doc_id for doc_id, _ in changed_content]
-            texts = [text for _, text in changed_content]
-            vectors = embedder.embed(texts)
             try:
                 if updated_content_ids:
                     vec.delete(updated_content_ids)
@@ -809,7 +854,36 @@ def ingest(
                 total_chunks += len(items)
                 continue
 
-            results, changed_content, updated_content_ids = (
+            vectors_by_external_id: dict[str, list[float]] = {}
+            if settings.retrieval_mode in ("dense", "hybrid"):
+                assert embedder is not None
+                existing_states = doc_repo.get_existing_doc_states_by_external_id(
+                    [it.external_id for it in items]
+                )
+                to_embed = []
+                for it in items:
+                    content = it.content.strip()
+                    current = existing_states.get(it.external_id)
+                    if current is None:
+                        to_embed.append(it)
+                        continue
+                    content_sha = hashlib.sha256(content.encode("utf-8")).hexdigest()
+                    old_sha = current.content_sha256 or ""
+                    if old_sha != content_sha or current.content != content:
+                        to_embed.append(it)
+
+                if to_embed:
+                    embedded = embedder.embed([it.content.strip() for it in to_embed])
+                    if len(embedded) != len(to_embed):
+                        raise RuntimeError(
+                            f"Embedder returned {len(embedded)} vectors for {len(to_embed)} documents."
+                        )
+                    vectors_by_external_id = {
+                        it.external_id: list(vec)
+                        for it, vec in zip(to_embed, embedded, strict=False)
+                    }
+
+            results, _changed_content, updated_content_ids = (
                 doc_repo.upsert_documents_by_external_id(items)
             )
 
@@ -824,10 +898,20 @@ def ingest(
                 assert vec is not None
 
                 rebuilt = False
-                if changed_content:
-                    ids = [doc_id for doc_id, _ in changed_content]
-                    texts = [text for _, text in changed_content]
-                    vectors = embedder.embed(texts)
+                changed_results = [r for r in results if r.content_changed]
+                if changed_results:
+                    missing_vectors = [
+                        r.external_id
+                        for r in changed_results
+                        if r.external_id not in vectors_by_external_id
+                    ]
+                    if missing_vectors:
+                        raise RuntimeError(
+                            "Missing precomputed vectors for changed documents: "
+                            + ", ".join(missing_vectors[:10])
+                        )
+                    ids = [int(r.id) for r in changed_results]
+                    vectors = [vectors_by_external_id[r.external_id] for r in changed_results]
                     try:
                         if updated_content_ids:
                             vec.delete(updated_content_ids)

--- a/src/local_rag_backend/core/services/evaluation.py
+++ b/src/local_rag_backend/core/services/evaluation.py
@@ -132,8 +132,8 @@ def _build_ephemeral_doc_repo() -> SqlDocumentStorage:
     session_local = sessionmaker(bind=engine, autocommit=False, autoflush=False)
 
     # Ensure models are registered with Base.metadata.
-    from local_rag_backend.infrastructure.persistence.sqlalchemy import (
-        models as _models,  # noqa: F401
+    from local_rag_backend.infrastructure.persistence.sqlalchemy import (  # noqa: F401
+        models as _models,
     )
 
     db_base.Base.metadata.create_all(bind=engine)

--- a/src/local_rag_backend/core/services/evaluation.py
+++ b/src/local_rag_backend/core/services/evaluation.py
@@ -1,0 +1,245 @@
+"""
+Offline evaluation for retrieval quality.
+
+Focus: reproducible retrieval metrics without requiring an LLM provider.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from importlib import resources
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from local_rag_backend.core.services.corpus import get_corpus_and_ids
+from local_rag_backend.core.services.reranking import RerankingRetriever
+from local_rag_backend.infrastructure.persistence.sqlalchemy import base as db_base
+from local_rag_backend.infrastructure.persistence.sqlalchemy.sql_ import SqlDocumentStorage
+from local_rag_backend.infrastructure.retrieval.sparse_bm25 import SparseBM25Retriever
+
+if TYPE_CHECKING:
+
+    from local_rag_backend.core.ports import RetrieverPort
+
+
+@dataclass(frozen=True)
+class EvalDoc:
+    external_id: str
+    content: str
+    source_id: str | None = None
+
+
+@dataclass(frozen=True)
+class EvalQuery:
+    query: str
+    relevant_external_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class EvalDataset:
+    dataset_id: str
+    schema_version: int
+    docs: tuple[EvalDoc, ...]
+    queries: tuple[EvalQuery, ...]
+
+
+def load_eval_dataset(path: str | Path | None = None) -> EvalDataset:
+    content: str
+    if path is None:
+        p = resources.files("local_rag_backend.datasets").joinpath("rag_eval_v1.jsonl")
+        # Traversable (works for editable installs and packaged resources).
+        content = p.read_text(encoding="utf-8")
+    else:
+        p = Path(path)
+        if not p.is_file():
+            raise FileNotFoundError(f"Dataset not found: {p}")
+        content = p.read_text(encoding="utf-8")
+
+    dataset_id = "unknown"
+    schema_version = 0
+    docs: list[EvalDoc] = []
+    queries: list[EvalQuery] = []
+
+    for lineno, line in enumerate(content.splitlines(), 1):
+        s = line.strip()
+        if not s:
+            continue
+        obj = json.loads(s)
+        if not isinstance(obj, dict):
+            raise ValueError(f"Invalid dataset line {lineno}: expected JSON object.")
+        t = obj.get("type")
+        if t == "meta":
+            dataset_id = str(obj.get("dataset_id") or dataset_id)
+            schema_version = int(obj.get("schema_version") or 0)
+        elif t == "doc":
+            docs.append(
+                EvalDoc(
+                    external_id=str(obj["external_id"]),
+                    content=str(obj["content"]),
+                    source_id=(
+                        str(obj.get("source_id")) if obj.get("source_id") is not None else None
+                    ),
+                )
+            )
+        elif t == "query":
+            rel = obj.get("relevant_external_ids") or []
+            if not isinstance(rel, list) or not all(isinstance(x, str) for x in rel):
+                raise ValueError(
+                    f"Invalid dataset line {lineno}: relevant_external_ids must be list[str]."
+                )
+            queries.append(EvalQuery(query=str(obj["query"]), relevant_external_ids=tuple(rel)))
+        else:
+            raise ValueError(f"Invalid dataset line {lineno}: unknown type={t!r}")
+
+    if schema_version != 1:
+        raise ValueError(f"Unsupported schema_version={schema_version} (expected 1).")
+    if not docs:
+        raise ValueError("Dataset contains no docs.")
+    if not queries:
+        raise ValueError("Dataset contains no queries.")
+
+    return EvalDataset(
+        dataset_id=str(dataset_id),
+        schema_version=int(schema_version),
+        docs=tuple(docs),
+        queries=tuple(queries),
+    )
+
+
+@dataclass(frozen=True)
+class EvalResult:
+    dataset_id: str
+    retrieval_mode: str
+    reranker_enabled: bool
+    k: int
+    queries: int
+    hit_rate: float
+    mrr: float
+
+
+def _build_ephemeral_doc_repo() -> SqlDocumentStorage:
+    # StaticPool ensures all sessions share the same in-memory DB connection.
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    session_local = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+    # Ensure models are registered with Base.metadata.
+    from local_rag_backend.infrastructure.persistence.sqlalchemy import (
+        models as _models,  # noqa: F401
+    )
+
+    db_base.Base.metadata.create_all(bind=engine)
+    db_base.ensure_sqlite_documents_autoincrement(engine_to_use=engine)
+    db_base.ensure_sqlite_documents_identity_columns(engine_to_use=engine)
+    return SqlDocumentStorage(session_factory=session_local)
+
+
+def _build_sparse_retriever(
+    *, doc_repo: SqlDocumentStorage, reranker_enabled: bool, candidate_k: int, strategy: str
+) -> RetrieverPort:
+    corpus, doc_ids = get_corpus_and_ids(doc_repo)
+    base: RetrieverPort = SparseBM25Retriever(documents=corpus, doc_ids=doc_ids, doc_repo=doc_repo)
+    if reranker_enabled:
+        return RerankingRetriever(base, candidate_k=candidate_k, strategy=strategy)
+    return base
+
+
+def run_retrieval_eval(
+    *,
+    dataset: EvalDataset,
+    retrieval_mode: str = "sparse",
+    k: int = 3,
+    reranker_enabled: bool = False,
+    reranker_candidate_k: int = 20,
+    reranker_strategy: str = "overlap_v1",
+    max_queries: int | None = None,
+) -> EvalResult:
+    if retrieval_mode != "sparse":
+        raise ValueError(
+            "This eval currently supports retrieval_mode=sparse only (dependency-free)."
+        )
+    if k <= 0:
+        raise ValueError("k must be positive")
+
+    doc_repo = _build_ephemeral_doc_repo()
+    items = [
+        SqlDocumentStorage.UpsertDoc(
+            external_id=d.external_id,
+            content=d.content,
+            source_id=d.source_id,
+            metadata={"dataset_id": dataset.dataset_id},
+        )
+        for d in dataset.docs
+    ]
+    results, _changed, _updated = doc_repo.upsert_documents_by_external_id(items)
+    id_by_external_id = {r.external_id: int(r.id) for r in results}
+
+    retriever = _build_sparse_retriever(
+        doc_repo=doc_repo,
+        reranker_enabled=reranker_enabled,
+        candidate_k=reranker_candidate_k,
+        strategy=reranker_strategy,
+    )
+
+    qs: list[EvalQuery] = list(dataset.queries)
+    if max_queries is not None:
+        qs = qs[: max(0, int(max_queries))]
+    if not qs:
+        raise ValueError("No queries to evaluate after max_queries.")
+
+    hits = 0
+    rr_sum = 0.0
+    for q in qs:
+        relevant = {eid for eid in q.relevant_external_ids if eid in id_by_external_id}
+        docs, _scores = retriever.retrieve(q.query, k)
+        retrieved_ext = [d.external_id for d in docs if getattr(d, "external_id", None)]
+
+        hit = any(eid in relevant for eid in retrieved_ext)
+        if hit:
+            hits += 1
+
+        rank = None
+        for i, eid in enumerate(retrieved_ext, 1):
+            if eid in relevant:
+                rank = i
+                break
+        if rank is not None:
+            rr_sum += 1.0 / float(rank)
+
+    n = len(qs)
+    return EvalResult(
+        dataset_id=dataset.dataset_id,
+        retrieval_mode=str(retrieval_mode),
+        reranker_enabled=bool(reranker_enabled),
+        k=int(k),
+        queries=n,
+        hit_rate=float(hits / n),
+        mrr=float(rr_sum / n),
+    )
+
+
+def format_eval_result(result: EvalResult) -> str:
+    return (
+        f"dataset={result.dataset_id} mode={result.retrieval_mode} reranker={result.reranker_enabled} "
+        f"k={result.k} queries={result.queries} hit_rate={result.hit_rate:.3f} mrr={result.mrr:.3f}"
+    )
+
+
+def eval_result_to_json(result: EvalResult) -> dict[str, Any]:
+    return {
+        "dataset_id": result.dataset_id,
+        "retrieval_mode": result.retrieval_mode,
+        "reranker_enabled": result.reranker_enabled,
+        "k": result.k,
+        "queries": result.queries,
+        "hit_rate": result.hit_rate,
+        "mrr": result.mrr,
+    }

--- a/src/local_rag_backend/core/services/maintenance.py
+++ b/src/local_rag_backend/core/services/maintenance.py
@@ -72,5 +72,11 @@ def delete_documents_multi_store(
             raise
         if embedder is None:
             raise
-        rebuilt = rebuild_index_from_db(doc_repo=doc_repo, vec_repo=vec_repo, embedder=embedder)
-        return deleted_sql, None, rebuilt >= 0
+        try:
+            rebuilt = rebuild_index_from_db(doc_repo=doc_repo, vec_repo=vec_repo, embedder=embedder)
+            return deleted_sql, None, rebuilt >= 0
+        except Exception as rebuild_err:
+            raise RuntimeError(
+                "Multi-store inconsistency risk: SQL delete succeeded but vector index sync failed. "
+                "Run `rag-rebuild-index` / POST /api/index/rebuild to repair."
+            ) from rebuild_err

--- a/src/local_rag_backend/core/services/reranking.py
+++ b/src/local_rag_backend/core/services/reranking.py
@@ -1,0 +1,82 @@
+"""
+Deterministic reranking helpers.
+
+This is intentionally dependency-free. It exists to improve retrieval quality cheaply and
+to provide a measurable knob for offline evaluation.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from local_rag_backend.core.services.text_processing import preprocess_text
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from local_rag_backend.core.domain.entities import Document
+    from local_rag_backend.core.ports import RetrieverPort
+
+
+def _tokens(text: str) -> set[str]:
+    # Keep tokenization aligned with the sparse retriever (preprocess_text + \\w+).
+    return set(re.findall(r"\w+", preprocess_text(text)))
+
+
+@dataclass(frozen=True)
+class OverlapV1Reranker:
+    """
+    Token overlap reranker (cheap heuristic).
+
+    Score: |tokens(query) ∩ tokens(doc)| / max(1, |tokens(query)|)
+    """
+
+    def score(self, *, query: str, doc_text: str) -> float:
+        qt = _tokens(query)
+        if not qt:
+            return 0.0
+        dt = _tokens(doc_text)
+        if not dt:
+            return 0.0
+        return float(len(qt & dt) / max(1, len(qt)))
+
+
+class RerankingRetriever:
+    """Wraps another RetrieverPort, reranking its top-N candidates before returning top-k."""
+
+    def __init__(
+        self,
+        base: RetrieverPort,
+        *,
+        candidate_k: int,
+        strategy: str = "overlap_v1",
+    ) -> None:
+        if candidate_k <= 0:
+            raise ValueError("candidate_k must be positive")
+        self.base = base
+        self.candidate_k = int(candidate_k)
+        if strategy != "overlap_v1":
+            raise ValueError(f"Unsupported reranker strategy: {strategy}")
+        self._reranker = OverlapV1Reranker()
+
+    def retrieve(self, query: str, k: int = 5) -> tuple[Sequence[Document], Sequence[float]]:
+        if k <= 0:
+            return [], []
+        cand_k = max(int(k), int(self.candidate_k))
+        docs, _scores = self.base.retrieve(query, cand_k)
+        if not docs:
+            return [], []
+
+        scored = [(doc, self._reranker.score(query=query, doc_text=doc.content)) for doc in docs]
+        # Sort by reranker score, stable on the original order (Python sort is stable).
+        scored.sort(key=lambda t: t[1], reverse=True)
+
+        top = scored[:k]
+        if not top:
+            return [], []
+
+        docs_out = [d for d, _ in top]
+        scores_out = [float(s) for _, s in top]
+        return docs_out, scores_out

--- a/src/local_rag_backend/core/services/write_lock.py
+++ b/src/local_rag_backend/core/services/write_lock.py
@@ -53,6 +53,12 @@ def _exclusive_file_lock(lock_path: Path) -> Iterator[None]:
             except Exception:  # pragma: no cover
                 locked = False  # pragma: no cover
 
+        if not locked:
+            raise RuntimeError(
+                f"Unable to acquire multi-store write lock at {lock_path}. "
+                "Refusing to run mutating operation without a cross-process lock."
+            )
+
         yield
     finally:
         if locked:

--- a/src/local_rag_backend/core/services/write_lock.py
+++ b/src/local_rag_backend/core/services/write_lock.py
@@ -1,0 +1,81 @@
+"""
+Cross-process lock for multi-store write operations.
+
+Why:
+- SQL + vector index updates are not transactional across both stores.
+- Concurrent writers can interleave commits and leave SQL/vector drift.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from contextlib import contextmanager, suppress
+from typing import TYPE_CHECKING, Any
+
+from local_rag_backend.settings import settings
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+_LOCAL_WRITE_LOCK = threading.RLock()
+
+
+@contextmanager
+def _exclusive_file_lock(lock_path: Path) -> Iterator[None]:
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    f = lock_path.open("a+b")
+    locked = False
+    try:
+        try:  # POSIX
+            import fcntl
+
+            fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+            locked = True
+        except Exception:  # pragma: no cover
+            locked = False
+
+        if not locked:  # pragma: no cover
+            try:  # Windows
+                import msvcrt  # pragma: no cover
+
+                msvcrt_any: Any = msvcrt  # pragma: no cover
+                f.seek(0, os.SEEK_END)  # pragma: no cover
+                if f.tell() == 0:  # pragma: no cover
+                    f.write(b"0")  # pragma: no cover
+                    f.flush()  # pragma: no cover
+                f.seek(0)  # pragma: no cover
+                msvcrt_any.locking(  # pragma: no cover
+                    f.fileno(), getattr(msvcrt_any, "LK_LOCK", 1), 1
+                )
+                locked = True  # pragma: no cover
+            except Exception:  # pragma: no cover
+                locked = False  # pragma: no cover
+
+        yield
+    finally:
+        if locked:
+            with suppress(Exception):  # pragma: no cover
+                import fcntl
+
+                fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+            with suppress(Exception):  # pragma: no cover
+                import msvcrt  # pragma: no cover
+
+                msvcrt_mod: Any = msvcrt  # pragma: no cover
+                f.seek(0)  # pragma: no cover
+                msvcrt_mod.locking(  # pragma: no cover
+                    f.fileno(), getattr(msvcrt_mod, "LK_UNLCK", 0), 1
+                )
+        f.close()
+
+
+@contextmanager
+def multi_store_write_lock() -> Iterator[None]:
+    """
+    Serialize mutating multi-store operations (SQL + FAISS) across threads/processes.
+    """
+    lock_path = settings.data_dir / ".rag_multi_store_write.lock"
+    with _LOCAL_WRITE_LOCK, _exclusive_file_lock(lock_path):
+        yield

--- a/src/local_rag_backend/datasets/__init__.py
+++ b/src/local_rag_backend/datasets/__init__.py
@@ -1,0 +1,3 @@
+"""
+Versioned evaluation datasets shipped with the package.
+"""

--- a/src/local_rag_backend/datasets/rag_eval_v1.jsonl
+++ b/src/local_rag_backend/datasets/rag_eval_v1.jsonl
@@ -1,0 +1,11 @@
+{"type":"meta","dataset_id":"rag_eval_v1","schema_version":1,"created_at":"2026-02-16"}
+{"type":"doc","external_id":"doc:paris","source_id":"eval:v1","content":"France's capital city is Paris."}
+{"type":"doc","external_id":"doc:madrid","source_id":"eval:v1","content":"Spain's capital city is Madrid."}
+{"type":"doc","external_id":"doc:berlin","source_id":"eval:v1","content":"Germany's capital city is Berlin."}
+{"type":"doc","external_id":"doc:lisbon","source_id":"eval:v1","content":"Portugal's capital city is Lisbon."}
+{"type":"doc","external_id":"doc:rome","source_id":"eval:v1","content":"Italy's capital city is Rome."}
+{"type":"query","query":"What is the capital of France?","relevant_external_ids":["doc:paris"]}
+{"type":"query","query":"Capital of Spain?","relevant_external_ids":["doc:madrid"]}
+{"type":"query","query":"What is Germany's capital city?","relevant_external_ids":["doc:berlin"]}
+{"type":"query","query":"Which city is the capital of Portugal?","relevant_external_ids":["doc:lisbon"]}
+{"type":"query","query":"Capital city of Italy?","relevant_external_ids":["doc:rome"]}

--- a/src/local_rag_backend/infrastructure/persistence/faiss/faiss_.py
+++ b/src/local_rag_backend/infrastructure/persistence/faiss/faiss_.py
@@ -73,6 +73,20 @@ class FaissVectorStorage(VectorRepoPort):
             )
             return
 
+        manifest_path = manifest_path_for(idx_path)
+        manifest = read_manifest(manifest_path)
+        if manifest is None:
+            vectors = int(getattr(self.faiss_index, "ntotal", 0) or 0)
+            id_map = getattr(self.faiss_index, "id_map", [])
+            id_map_len = len(id_map) if isinstance(id_map, list) else 0
+            # Fail closed for legacy non-empty indexes without manifest.
+            # Auto-creating here would "bless" unknown historical config and hide drift.
+            if vectors > 0 or id_map_len > 0:
+                raise RuntimeError(
+                    "Index manifest missing for a non-empty index; rebuild is required "
+                    "(hint: run `rag-rebuild-index` or POST /api/index/rebuild)."
+                )
+
         create_manifest_if_missing_for_settings(
             index_path=idx_path,
             expected=expected,
@@ -80,7 +94,7 @@ class FaissVectorStorage(VectorRepoPort):
             index_backend=backend,
         )
 
-        manifest = read_manifest(manifest_path_for(idx_path))
+        manifest = read_manifest(manifest_path)
         if manifest is None:  # pragma: no cover
             raise RuntimeError("Index manifest is missing after creation attempt.")
         mismatches, errors = validate_manifest(

--- a/src/local_rag_backend/infrastructure/persistence/faiss/faiss_.py
+++ b/src/local_rag_backend/infrastructure/persistence/faiss/faiss_.py
@@ -97,13 +97,15 @@ class FaissVectorStorage(VectorRepoPort):
 
     def upsert(self, ids: Sequence[int], vectors: Sequence[Sequence[float]]) -> None:
         """Add vectors to the FAISS index."""
-        self.faiss_index.add_to_index(list(ids), list(vectors))
+        # Guard first: if manifest drifts from current settings, fail before mutating index files.
         self._ensure_manifest(overwrite=False)
+        self.faiss_index.add_to_index(list(ids), list(vectors))
 
     def delete(self, ids: Sequence[int]) -> None:
         """Delete vectors from the index (may rebuild the underlying index)."""
-        self.faiss_index.delete_ids(list(ids))
+        # Guard first: if manifest drifts from current settings, fail before mutating index files.
         self._ensure_manifest(overwrite=False)
+        self.faiss_index.delete_ids(list(ids))
 
     def rebuild(self, ids: Sequence[int], vectors: Sequence[Sequence[float]]) -> None:
         """Rebuild the full index from scratch (idempotent)."""

--- a/src/local_rag_backend/infrastructure/persistence/faiss/index.py
+++ b/src/local_rag_backend/infrastructure/persistence/faiss/index.py
@@ -58,7 +58,7 @@ def _exclusive_file_lock(lock_path: Path) -> Iterator[None]:
 
     - POSIX: fcntl.flock
     - Windows: msvcrt.locking
-    - Else: no-op (still keeps atomic replaces)
+    - Else: fail-closed
     """
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     f = lock_path.open("a+b")
@@ -90,6 +90,12 @@ def _exclusive_file_lock(lock_path: Path) -> Iterator[None]:
                 locked = True  # pragma: no cover
             except Exception:  # pragma: no cover
                 locked = False  # pragma: no cover
+
+        if not locked:
+            raise RuntimeError(
+                f"Unable to acquire FAISS file lock at {lock_path}. "
+                "Refusing to mutate index state without a cross-process lock."
+            )
 
         yield
     finally:

--- a/src/local_rag_backend/infrastructure/persistence/sqlalchemy/sql_.py
+++ b/src/local_rag_backend/infrastructure/persistence/sqlalchemy/sql_.py
@@ -18,8 +18,8 @@ from local_rag_backend.infrastructure.persistence.sqlalchemy.crud import (
     add_history,
     delete_documents,
 )
+from local_rag_backend.infrastructure.persistence.sqlalchemy.models import Document as DbDocument
 from local_rag_backend.infrastructure.persistence.sqlalchemy.models import (
-    Document as DbDocument,
     DocumentTombstone as DbDocumentTombstone,
 )
 
@@ -112,6 +112,43 @@ class SqlDocumentStorage(DocumentRepoPort):
         id: int
         action: Literal["inserted", "updated", "unchanged"]
         content_changed: bool
+
+    @dataclass(frozen=True)
+    class ExistingDocState:
+        id: int
+        external_id: str
+        content: str
+        content_sha256: str | None
+
+    def get_existing_doc_states_by_external_id(
+        self, external_ids: Sequence[str]
+    ) -> dict[str, ExistingDocState]:
+        ext_ids = [str(x).strip() for x in external_ids if str(x).strip()]
+        if not ext_ids:
+            return {}
+        with get_session(self._session_factory) as session:
+            rows = (
+                session.query(
+                    DbDocument.id,
+                    DbDocument.external_id,
+                    DbDocument.content,
+                    DbDocument.content_sha256,
+                )
+                .filter(DbDocument.external_id.is_not(None))
+                .filter(DbDocument.external_id.in_(ext_ids))
+                .all()
+            )
+            out: dict[str, SqlDocumentStorage.ExistingDocState] = {}
+            for doc_id, ext_id, content, content_sha in rows:
+                if ext_id is None:
+                    continue
+                out[str(ext_id)] = SqlDocumentStorage.ExistingDocState(
+                    id=int(doc_id),
+                    external_id=str(ext_id),
+                    content=str(content or ""),
+                    content_sha256=(str(content_sha) if content_sha is not None else None),
+                )
+            return out
 
     def upsert_documents_by_external_id(
         self, items: Sequence[UpsertDoc]

--- a/src/local_rag_backend/infrastructure/persistence/sqlalchemy/sql_.py
+++ b/src/local_rag_backend/infrastructure/persistence/sqlalchemy/sql_.py
@@ -18,8 +18,8 @@ from local_rag_backend.infrastructure.persistence.sqlalchemy.crud import (
     add_history,
     delete_documents,
 )
-from local_rag_backend.infrastructure.persistence.sqlalchemy.models import Document as DbDocument
 from local_rag_backend.infrastructure.persistence.sqlalchemy.models import (
+    Document as DbDocument,
     DocumentTombstone as DbDocumentTombstone,
 )
 

--- a/src/local_rag_backend/scripts/bootstrap.py
+++ b/src/local_rag_backend/scripts/bootstrap.py
@@ -25,13 +25,16 @@ from local_rag_backend.infrastructure.embeddings.sentence_transformers import (
 )
 from local_rag_backend.infrastructure.ingestion.loaders.csv_loader import CSVLoader
 from local_rag_backend.infrastructure.persistence.faiss.faiss_ import FaissVectorStorage
-from local_rag_backend.infrastructure.persistence.sqlalchemy import base as db_base
-from local_rag_backend.infrastructure.persistence.sqlalchemy import models  # noqa: F401
+from local_rag_backend.infrastructure.persistence.sqlalchemy import (
+    base as db_base,
+    models as _models,
+)
 from local_rag_backend.infrastructure.persistence.sqlalchemy.base import Base
 from local_rag_backend.infrastructure.persistence.sqlalchemy.sql_ import SqlDocumentStorage
 from local_rag_backend.settings import settings as default_settings
 
 DELIMITER = ";"
+_ = _models
 
 if TYPE_CHECKING:
     from local_rag_backend.core.ports import EmbedderPort

--- a/src/local_rag_backend/scripts/bootstrap.py
+++ b/src/local_rag_backend/scripts/bootstrap.py
@@ -25,10 +25,8 @@ from local_rag_backend.infrastructure.embeddings.sentence_transformers import (
 )
 from local_rag_backend.infrastructure.ingestion.loaders.csv_loader import CSVLoader
 from local_rag_backend.infrastructure.persistence.faiss.faiss_ import FaissVectorStorage
-from local_rag_backend.infrastructure.persistence.sqlalchemy import (
-    base as db_base,
-    models,  # noqa: F401
-)
+from local_rag_backend.infrastructure.persistence.sqlalchemy import base as db_base
+from local_rag_backend.infrastructure.persistence.sqlalchemy import models  # noqa: F401
 from local_rag_backend.infrastructure.persistence.sqlalchemy.base import Base
 from local_rag_backend.infrastructure.persistence.sqlalchemy.sql_ import SqlDocumentStorage
 from local_rag_backend.settings import settings as default_settings

--- a/src/local_rag_backend/scripts/build_index.py
+++ b/src/local_rag_backend/scripts/build_index.py
@@ -22,10 +22,8 @@ from local_rag_backend.infrastructure.embeddings.sentence_transformers import (
 
 # Import models to ensure they are registered with Base.metadata
 # To ensure table creation
-from local_rag_backend.infrastructure.persistence.sqlalchemy import (
-    base as db_base,
-    models,  # noqa: F401
-)
+from local_rag_backend.infrastructure.persistence.sqlalchemy import base as db_base
+from local_rag_backend.infrastructure.persistence.sqlalchemy import models  # noqa: F401
 from local_rag_backend.infrastructure.persistence.sqlalchemy.base import Base as AppDeclarativeBase
 from local_rag_backend.settings import settings
 

--- a/src/local_rag_backend/scripts/build_index.py
+++ b/src/local_rag_backend/scripts/build_index.py
@@ -22,12 +22,15 @@ from local_rag_backend.infrastructure.embeddings.sentence_transformers import (
 
 # Import models to ensure they are registered with Base.metadata
 # To ensure table creation
-from local_rag_backend.infrastructure.persistence.sqlalchemy import base as db_base
-from local_rag_backend.infrastructure.persistence.sqlalchemy import models  # noqa: F401
+from local_rag_backend.infrastructure.persistence.sqlalchemy import (
+    base as db_base,
+    models as _models,
+)
 from local_rag_backend.infrastructure.persistence.sqlalchemy.base import Base as AppDeclarativeBase
 from local_rag_backend.settings import settings
 
 logger = logging.getLogger(__name__)
+_ = _models
 # Configure logging to see script and data_loader output
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"

--- a/src/local_rag_backend/settings.py
+++ b/src/local_rag_backend/settings.py
@@ -41,6 +41,9 @@ class Settings(BaseSettings):
         "INFO", description="Logging level."
     )
     enable_monitoring: bool = Field(False, description="Enable Prometheus metrics.")
+    enable_reranker: bool = Field(
+        False, description="Enable reranking of retrieved documents (best-effort)."
+    )
 
     # --- Security / HTTP --- #
     api_key: str | None = Field(
@@ -132,6 +135,17 @@ class Settings(BaseSettings):
         True, description="Collapse whitespace during cleaning."
     )
     ingest_clean_strip: bool = Field(True, description="Strip leading/trailing whitespace first.")
+
+    # --- Retrieval quality (optional) --- #
+    reranker_strategy: Literal["overlap_v1"] = Field(
+        "overlap_v1", description="Reranker strategy identifier."
+    )
+    reranker_candidate_k: int = Field(
+        20,
+        ge=3,
+        le=200,
+        description="Candidates to fetch before reranking (top-k is returned).",
+    )
 
     # --- Prompt Templates --- #
     openai_prompt_template: str = Field(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,8 +7,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
 # Import models to ensure they are registered with Base.metadata
-from local_rag_backend.infrastructure.persistence.sqlalchemy import base as db_base
-from local_rag_backend.infrastructure.persistence.sqlalchemy import sql_
+from local_rag_backend.infrastructure.persistence.sqlalchemy import base as db_base, sql_
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,8 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
 # Import models to ensure they are registered with Base.metadata
-from local_rag_backend.infrastructure.persistence.sqlalchemy import base as db_base, sql_
+from local_rag_backend.infrastructure.persistence.sqlalchemy import base as db_base
+from local_rag_backend.infrastructure.persistence.sqlalchemy import sql_
 
 
 @pytest.fixture()

--- a/tests/unit/app/test_api_router_more.py
+++ b/tests/unit/app/test_api_router_more.py
@@ -2,8 +2,7 @@
 
 import pytest
 
-from local_rag_backend.app import api_router as api
-from local_rag_backend.app import dependencies as deps
+from local_rag_backend.app import api_router as api, dependencies as deps
 from local_rag_backend.settings import settings
 
 

--- a/tests/unit/app/test_api_router_more.py
+++ b/tests/unit/app/test_api_router_more.py
@@ -2,7 +2,8 @@
 
 import pytest
 
-from local_rag_backend.app import api_router as api, dependencies as deps
+from local_rag_backend.app import api_router as api
+from local_rag_backend.app import dependencies as deps
 from local_rag_backend.settings import settings
 
 
@@ -100,6 +101,8 @@ async def test_ask_eval_invalid_config(asgi_client, monkeypatch):
         ({"retrieval_mode": "hybrid", "k": 3, "hybrid_alpha": 1.1}, 422),  # schema
         ({"retrieval_mode": "sparse", "k": 3, "temperature": -0.5}, 400),  # runtime validation
         ({"retrieval_mode": "sparse", "k": 3, "temperature": 2.5}, 400),  # runtime validation
+        ({"retrieval_mode": "sparse", "k": 3, "top_p": -0.1}, 422),  # schema
+        ({"retrieval_mode": "sparse", "k": 3, "top_p": 1.1}, 422),  # schema
         ({"retrieval_mode": "sparse", "k": 3, "max_tokens": 0}, 400),  # runtime validation
         ({"retrieval_mode": "sparse", "k": 3, "max_tokens": 999999}, 400),  # runtime validation
     ],

--- a/tests/unit/app/test_dependencies.py
+++ b/tests/unit/app/test_dependencies.py
@@ -1,7 +1,8 @@
 # tests/unit/app/test_dependencies.py
 from types import SimpleNamespace
 
-from local_rag_backend.app import dependencies as deps, factory
+from local_rag_backend.app import dependencies as deps
+from local_rag_backend.app import factory
 from local_rag_backend.settings import settings
 
 

--- a/tests/unit/app/test_dependencies.py
+++ b/tests/unit/app/test_dependencies.py
@@ -1,8 +1,7 @@
 # tests/unit/app/test_dependencies.py
 from types import SimpleNamespace
 
-from local_rag_backend.app import dependencies as deps
-from local_rag_backend.app import factory
+from local_rag_backend.app import dependencies as deps, factory
 from local_rag_backend.settings import settings
 
 

--- a/tests/unit/app/test_docs_embedding_atomicity.py
+++ b/tests/unit/app/test_docs_embedding_atomicity.py
@@ -1,0 +1,43 @@
+import pytest
+
+from local_rag_backend.app import api_router as api
+from local_rag_backend.infrastructure.persistence.sqlalchemy.sql_ import SqlDocumentStorage
+from local_rag_backend.settings import settings
+
+
+async def test_docs_dense_embed_failure_does_not_persist_sql(
+    asgi_client, in_memory_sqlite, monkeypatch
+):
+    class BadEmbedder:
+        dim = 4
+
+        def embed(self, texts):
+            raise RuntimeError("embed fail")
+
+    monkeypatch.setattr(settings, "retrieval_mode", "dense", raising=False)
+    monkeypatch.setattr(settings, "openai_api_key", "k", raising=False)
+    monkeypatch.setattr(api, "OpenAIEmbedder", lambda *a, **k: BadEmbedder(), raising=True)
+
+    with pytest.raises(RuntimeError, match="embed fail"):
+        await asgi_client.post("/api/docs", json={"texts": ["hello world"]})
+    assert SqlDocumentStorage().get_all_documents() == []
+
+
+async def test_upsert_dense_embed_failure_does_not_persist_sql(
+    asgi_client, in_memory_sqlite, monkeypatch
+):
+    class BadEmbedder:
+        dim = 4
+
+        def embed(self, texts):
+            raise RuntimeError("embed fail")
+
+    monkeypatch.setattr(settings, "retrieval_mode", "dense", raising=False)
+    monkeypatch.setattr(settings, "openai_api_key", "k", raising=False)
+    monkeypatch.setattr(api, "OpenAIEmbedder", lambda *a, **k: BadEmbedder(), raising=True)
+
+    with pytest.raises(RuntimeError, match="embed fail"):
+        await asgi_client.post(
+            "/api/docs/upsert", json={"docs": [{"external_id": "doc-1", "content": "hello"}]}
+        )
+    assert SqlDocumentStorage().get_all_documents() == []

--- a/tests/unit/app/test_factory_cache_invalidation.py
+++ b/tests/unit/app/test_factory_cache_invalidation.py
@@ -39,3 +39,25 @@ async def test_get_rag_service_cache_is_invalidated_by_reload_token(tmp_path, mo
 
     svc4 = await factory.get_rag_service()
     assert svc4 is svc3
+
+
+def test_write_reload_token_uses_unique_tmp_paths(tmp_path, monkeypatch):
+    monkeypatch.setattr(factory.settings, "data_dir", tmp_path, raising=False)
+    token_path = tmp_path / ".rag_service_reload_token"
+
+    seen_sources: set[str] = set()
+    real_replace = factory.os.replace
+
+    def _replace(src, dst):
+        src_s = str(src)
+        if src_s in seen_sources:
+            raise FileNotFoundError("duplicate temporary path")
+        seen_sources.add(src_s)
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(factory.os, "replace", _replace, raising=True)
+
+    factory._write_reload_token("v1")
+    factory._write_reload_token("v2")
+
+    assert token_path.read_text(encoding="utf-8") == "v2"

--- a/tests/unit/app/test_metrics_endpoint_enabled.py
+++ b/tests/unit/app/test_metrics_endpoint_enabled.py
@@ -1,0 +1,16 @@
+# tests/unit/app/test_metrics_endpoint_enabled.py
+
+from local_rag_backend.app import middleware as mw
+from local_rag_backend.settings import settings
+
+
+async def test_metrics_endpoint_enabled_returns_metrics(asgi_client, monkeypatch):
+    monkeypatch.setattr(settings, "enable_monitoring", True, raising=False)
+    monkeypatch.setattr(mw, "PROMETHEUS_AVAILABLE", True, raising=False)
+    monkeypatch.setattr(mw, "CONTENT_TYPE_LATEST", "text/plain; version=0.0.4; charset=utf-8")
+    monkeypatch.setattr(mw, "generate_latest", lambda: b"rag_queries_total 1\n", raising=False)
+
+    r = await asgi_client.get("/metrics")
+    assert r.status_code == 200
+    assert r.headers.get("content-type", "").startswith("text/plain")
+    assert "rag_queries_total" in r.text

--- a/tests/unit/app/test_multistore_write_lock.py
+++ b/tests/unit/app/test_multistore_write_lock.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import threading
+import time
+from dataclasses import dataclass
+
+from local_rag_backend.app import api_router as api
+from local_rag_backend.settings import settings
+
+
+async def test_concurrent_upserts_are_serialized_and_keep_sql_vector_consistent(
+    asgi_client, in_memory_sqlite, monkeypatch
+):
+    @dataclass(frozen=True)
+    class _UpsertDoc:
+        external_id: str
+        content: str
+        source_id: str | None = None
+        metadata: dict[str, object] | None = None
+        chunk_dedup_sha256: str | None = None
+
+    @dataclass(frozen=True)
+    class _UpsertResult:
+        external_id: str
+        id: int
+        action: str
+        content_changed: bool
+
+    @dataclass(frozen=True)
+    class _ExistingDocState:
+        id: int
+        external_id: str
+        content: str
+        content_sha256: str | None
+
+    class FakeRepo:
+        UpsertDoc = _UpsertDoc
+
+        _lock = threading.Lock()
+        _next_id = 1
+        _by_external_id: dict[str, tuple[int, str, str]] = {}
+        _a_sql_done = threading.Event()
+
+        def get_tombstoned_external_ids(self, external_ids):
+            return set()
+
+        def get_existing_doc_states_by_external_id(self, external_ids):
+            with self._lock:
+                out: dict[str, _ExistingDocState] = {}
+                for ext in external_ids:
+                    row = self._by_external_id.get(ext)
+                    if row is None:
+                        continue
+                    doc_id, content, sha = row
+                    out[ext] = _ExistingDocState(
+                        id=doc_id, external_id=ext, content=content, content_sha256=sha
+                    )
+                return out
+
+        def upsert_documents_by_external_id(self, items):
+            results = []
+            changed = []
+            updated_ids = []
+
+            with self._lock:
+                for item in items:
+                    ext = item.external_id
+                    content = item.content.strip()
+                    sha = hashlib.sha256(content.encode("utf-8")).hexdigest()
+                    row = self._by_external_id.get(ext)
+                    if row is None:
+                        doc_id = self._next_id
+                        self._next_id += 1
+                        self._by_external_id[ext] = (doc_id, content, sha)
+                        results.append(_UpsertResult(ext, doc_id, "inserted", True))
+                        changed.append((doc_id, content))
+                        if content == "A":
+                            self._a_sql_done.set()
+                        continue
+
+                    doc_id, old_content, old_sha = row
+                    if content == "B":
+                        # Forces the B request to update SQL while A still sleeps in vector upsert.
+                        self._a_sql_done.wait(timeout=2)
+                    content_changed = old_sha != sha or old_content != content
+                    if content_changed:
+                        self._by_external_id[ext] = (doc_id, content, sha)
+                        results.append(_UpsertResult(ext, doc_id, "updated", True))
+                        changed.append((doc_id, content))
+                        updated_ids.append(doc_id)
+                    else:
+                        results.append(_UpsertResult(ext, doc_id, "unchanged", False))
+
+            return results, changed, updated_ids
+
+    class FakeEmbedder:
+        dim = 1
+
+        def embed(self, texts):
+            return [[1.0 if "A" in text else 2.0] for text in texts]
+
+    class FakeVec:
+        def __init__(self):
+            self.by_id: dict[int, list[float]] = {}
+            self._lock = threading.Lock()
+
+        def delete(self, ids):
+            with self._lock:
+                for i in ids:
+                    self.by_id.pop(int(i), None)
+
+        def upsert(self, ids, vectors):
+            # Force an interleaving window where request A sleeps after SQL commit.
+            if vectors and float(vectors[0][0]) == 1.0:
+                time.sleep(0.2)
+            with self._lock:
+                for i, v in zip(ids, vectors, strict=False):
+                    self.by_id[int(i)] = list(v)
+
+    fake_vec = FakeVec()
+    monkeypatch.setattr(settings, "retrieval_mode", "dense", raising=False)
+    monkeypatch.setattr(settings, "openai_api_key", "k", raising=False)
+    monkeypatch.setattr(api, "SqlDocumentStorage", FakeRepo, raising=True)
+    monkeypatch.setattr(api, "OpenAIEmbedder", lambda *a, **k: FakeEmbedder(), raising=True)
+    monkeypatch.setattr(api, "FaissVectorStorage", lambda *a, **k: fake_vec, raising=True)
+    monkeypatch.setattr(api, "reset_rag_service", lambda: None, raising=True)
+
+    task_a = asyncio.create_task(
+        asgi_client.post(
+            "/api/docs/upsert",
+            json={"docs": [{"external_id": "doc-1", "content": "A"}]},
+        )
+    )
+    await asyncio.sleep(0.02)
+    task_b = asyncio.create_task(
+        asgi_client.post(
+            "/api/docs/upsert",
+            json={"docs": [{"external_id": "doc-1", "content": "B"}]},
+        )
+    )
+    ra, rb = await asyncio.gather(task_a, task_b)
+
+    assert ra.status_code == 200
+    assert rb.status_code == 200
+    # Final SQL state must match final vector state (latest content = B -> vector 2.0).
+    assert FakeRepo._by_external_id["doc-1"][1] == "B"
+    assert fake_vec.by_id[1] == [2.0]

--- a/tests/unit/app/test_multistore_write_lock.py
+++ b/tests/unit/app/test_multistore_write_lock.py
@@ -147,3 +147,26 @@ async def test_concurrent_upserts_are_serialized_and_keep_sql_vector_consistent(
     # Final SQL state must match final vector state (latest content = B -> vector 2.0).
     assert FakeRepo._by_external_id["doc-1"][1] == "B"
     assert fake_vec.by_id[1] == [2.0]
+
+
+async def test_docs_ingest_executes_single_locked_mutation_pass(
+    asgi_client, in_memory_sqlite, monkeypatch
+):
+    called_funcs: list[str] = []
+
+    async def _fake_run_blocking(func, /, *args, **kwargs):
+        called_funcs.append(getattr(func, "__name__", repr(func)))
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(settings, "retrieval_mode", "sparse", raising=False)
+    monkeypatch.setattr(api, "run_blocking", _fake_run_blocking, raising=True)
+    monkeypatch.setattr(api, "reset_rag_service", lambda: None, raising=True)
+
+    resp = await asgi_client.post("/api/docs", json={"texts": ["  hello world  "]})
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["count"] >= 1
+
+    # Regression guard: /api/docs must run exactly one sync ingestion path under the lock wrapper.
+    assert called_funcs.count("_run_multi_store_write_locked") == 1
+    assert "_ingest_sync" not in called_funcs

--- a/tests/unit/app/test_multistore_write_lock.py
+++ b/tests/unit/app/test_multistore_write_lock.py
@@ -6,6 +6,8 @@ import threading
 import time
 from dataclasses import dataclass
 
+import pytest
+
 from local_rag_backend.app import api_router as api
 from local_rag_backend.settings import settings
 
@@ -170,3 +172,83 @@ async def test_docs_ingest_executes_single_locked_mutation_pass(
     # Regression guard: /api/docs must run exactly one sync ingestion path under the lock wrapper.
     assert called_funcs.count("_run_multi_store_write_locked") == 1
     assert "_ingest_sync" not in called_funcs
+
+
+async def test_upsert_failure_still_invalidates_cached_rag_service(
+    asgi_client, in_memory_sqlite, monkeypatch
+):
+    @dataclass(frozen=True)
+    class _UpsertDoc:
+        external_id: str
+        content: str
+        source_id: str | None = None
+        metadata: dict[str, object] | None = None
+        chunk_dedup_sha256: str | None = None
+
+    @dataclass(frozen=True)
+    class _UpsertResult:
+        external_id: str
+        id: int
+        action: str
+        content_changed: bool
+
+    class FakeRepo:
+        UpsertDoc = _UpsertDoc
+
+        def get_tombstoned_external_ids(self, external_ids):
+            return set()
+
+        def get_existing_doc_states_by_external_id(self, external_ids):
+            return {}
+
+        def upsert_documents_by_external_id(self, items):
+            return (
+                [
+                    _UpsertResult(
+                        external_id=items[0].external_id,
+                        id=1,
+                        action="inserted",
+                        content_changed=True,
+                    )
+                ],
+                [(1, items[0].content)],
+                [],
+            )
+
+    class FakeEmbedder:
+        dim = 1
+
+        def embed(self, texts):
+            return [[1.0] for _ in texts]
+
+    class FailingVec:
+        def delete(self, ids):
+            return None
+
+        def upsert(self, ids, vectors):
+            raise RuntimeError("vec upsert failed")
+
+    reset_calls = 0
+
+    def _count_reset() -> None:
+        nonlocal reset_calls
+        reset_calls += 1
+
+    def _rebuild_fail(**_kwargs):
+        raise RuntimeError("rebuild failed")
+
+    monkeypatch.setattr(settings, "retrieval_mode", "dense", raising=False)
+    monkeypatch.setattr(settings, "openai_api_key", "k", raising=False)
+    monkeypatch.setattr(api, "SqlDocumentStorage", FakeRepo, raising=True)
+    monkeypatch.setattr(api, "OpenAIEmbedder", lambda *a, **k: FakeEmbedder(), raising=True)
+    monkeypatch.setattr(api, "FaissVectorStorage", lambda *a, **k: FailingVec(), raising=True)
+    monkeypatch.setattr(api, "rebuild_index_from_db", _rebuild_fail, raising=True)
+    monkeypatch.setattr(api, "reset_rag_service", _count_reset, raising=True)
+
+    with pytest.raises(RuntimeError, match="rebuild failed"):
+        await asgi_client.post(
+            "/api/docs/upsert",
+            json={"docs": [{"external_id": "doc-1", "content": "hello"}]},
+        )
+
+    assert reset_calls == 1

--- a/tests/unit/app/test_request_limits.py
+++ b/tests/unit/app/test_request_limits.py
@@ -35,3 +35,36 @@ async def test_openrouter_generate_rejects_overlong_fields(asgi_client, in_memor
         },
     )
     assert r.status_code == 422
+
+
+@pytest.mark.unit
+async def test_openrouter_generate_rejects_invalid_sampling_params(asgi_client, in_memory_sqlite):
+    r1 = await asgi_client.post(
+        "/api/openrouter/generate",
+        json={
+            "system_instruction": "sys",
+            "user_content": "hi",
+            "top_p": 1.5,
+        },
+    )
+    assert r1.status_code == 422
+
+    r2 = await asgi_client.post(
+        "/api/openrouter/generate",
+        json={
+            "system_instruction": "sys",
+            "user_content": "hi",
+            "temperature": -0.1,
+        },
+    )
+    assert r2.status_code == 422
+
+    r3 = await asgi_client.post(
+        "/api/openrouter/generate",
+        json={
+            "system_instruction": "sys",
+            "user_content": "hi",
+            "max_tokens": 0,
+        },
+    )
+    assert r3.status_code == 422

--- a/tests/unit/core/services/test_evaluation.py
+++ b/tests/unit/core/services/test_evaluation.py
@@ -1,0 +1,44 @@
+# tests/unit/core/services/test_evaluation.py
+
+from pathlib import Path
+
+import pytest
+
+from local_rag_backend.core.services.evaluation import (
+    EvalDataset,
+    load_eval_dataset,
+    run_retrieval_eval,
+)
+
+
+def test_load_eval_dataset_missing_file_raises(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        load_eval_dataset(tmp_path / "missing.jsonl")
+
+
+def test_load_eval_dataset_rejects_unknown_type(tmp_path: Path) -> None:
+    p = tmp_path / "ds.jsonl"
+    p.write_text(
+        "\n".join(
+            [
+                '{"type":"meta","dataset_id":"x","schema_version":1}',
+                '{"type":"nope"}',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="unknown type"):
+        load_eval_dataset(p)
+
+
+def test_run_retrieval_eval_rejects_non_sparse_mode() -> None:
+    ds = load_eval_dataset()
+    with pytest.raises(ValueError, match="sparse only"):
+        run_retrieval_eval(dataset=ds, retrieval_mode="dense")
+
+
+def test_run_retrieval_eval_max_queries_zero_raises() -> None:
+    ds: EvalDataset = load_eval_dataset()
+    with pytest.raises(ValueError, match="No queries"):
+        run_retrieval_eval(dataset=ds, retrieval_mode="sparse", max_queries=0)

--- a/tests/unit/core/services/test_maintenance.py
+++ b/tests/unit/core/services/test_maintenance.py
@@ -41,12 +41,15 @@ class DummyEmbedder:
 
 
 class DummyVecRepo:
-    def __init__(self, fail_delete=False) -> None:
+    def __init__(self, fail_delete=False, fail_rebuild=False) -> None:
         self.rebuild_calls = []
         self.delete_calls = []
         self.fail_delete = fail_delete
+        self.fail_rebuild = fail_rebuild
 
     def rebuild(self, ids, vectors):
+        if self.fail_rebuild:
+            raise RuntimeError("fail-rebuild")
         self.rebuild_calls.append((list(ids), list(vectors)))
 
     def delete(self, ids):
@@ -105,4 +108,19 @@ def test_delete_documents_index_failure_no_rebuild_raises():
             embedder=None,
             ids=[1],
             rebuild_on_index_failure=False,
+        )
+
+
+def test_delete_documents_index_and_rebuild_failure_raises_consistency_error():
+    doc_repo = DummyDocRepo([_Doc(1, "a"), _Doc(2, "b")])
+    vec_repo = DummyVecRepo(fail_delete=True, fail_rebuild=True)
+    embedder = DummyEmbedder()
+
+    with pytest.raises(RuntimeError, match="Multi-store inconsistency risk"):
+        delete_documents_multi_store(
+            doc_repo=doc_repo,
+            vec_repo=vec_repo,
+            embedder=embedder,
+            ids=[1],
+            rebuild_on_index_failure=True,
         )

--- a/tests/unit/core/services/test_reranking.py
+++ b/tests/unit/core/services/test_reranking.py
@@ -1,0 +1,44 @@
+# tests/unit/core/services/test_reranking.py
+
+import pytest
+
+from local_rag_backend.core.domain.entities import Document
+from local_rag_backend.core.services.reranking import RerankingRetriever
+
+
+class _DummyRetriever:
+    def __init__(self, docs):
+        self._docs = docs
+
+    def retrieve(self, query: str, k: int = 5):
+        # Return docs in the given order, same score for all.
+        return self._docs[:k], [0.1] * min(k, len(self._docs))
+
+
+def test_overlap_reranker_moves_more_relevant_doc_first():
+    docs = [
+        Document(id=1, content="zzz zzz zzz", external_id="d1"),
+        Document(id=2, content="capital france paris", external_id="d2"),
+    ]
+    base = _DummyRetriever(docs)
+    rr = RerankingRetriever(base, candidate_k=10, strategy="overlap_v1")
+    out_docs, out_scores = rr.retrieve("capital of france", 2)
+    assert [d.external_id for d in out_docs] == ["d2", "d1"]
+    assert out_scores[0] >= out_scores[1]
+
+
+def test_reranking_retriever_rejects_invalid_strategy():
+    with pytest.raises(ValueError, match="Unsupported reranker strategy"):
+        RerankingRetriever(_DummyRetriever([]), candidate_k=3, strategy="nope")
+
+
+def test_reranking_retriever_candidate_k_must_be_positive():
+    with pytest.raises(ValueError, match="candidate_k must be positive"):
+        RerankingRetriever(_DummyRetriever([]), candidate_k=0, strategy="overlap_v1")
+
+
+def test_reranking_retriever_k_zero_returns_empty():
+    rr = RerankingRetriever(_DummyRetriever([]), candidate_k=3, strategy="overlap_v1")
+    docs, scores = rr.retrieve("q", 0)
+    assert docs == []
+    assert scores == []

--- a/tests/unit/core/services/test_write_lock.py
+++ b/tests/unit/core/services/test_write_lock.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from local_rag_backend.core.services.write_lock import _exclusive_file_lock
+
+
+def test_exclusive_file_lock_fails_closed_when_os_locking_is_unavailable(tmp_path, monkeypatch):
+    def _raise_lock_error(*_args, **_kwargs):
+        raise OSError("locking unavailable")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "fcntl",
+        SimpleNamespace(LOCK_EX=1, LOCK_UN=2, flock=_raise_lock_error),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "msvcrt",
+        SimpleNamespace(LK_LOCK=1, LK_UNLCK=0, locking=_raise_lock_error),
+    )
+
+    with (
+        pytest.raises(RuntimeError, match="Unable to acquire multi-store write lock"),
+        _exclusive_file_lock(tmp_path / "write.lock"),
+    ):
+        pass

--- a/tests/unit/infrastructure/persistence/faiss/test_faiss_index_lock.py
+++ b/tests/unit/infrastructure/persistence/faiss/test_faiss_index_lock.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from local_rag_backend.infrastructure.persistence.faiss.index import _exclusive_file_lock
+
+
+def test_exclusive_file_lock_fails_closed_when_os_locking_is_unavailable(tmp_path, monkeypatch):
+    def _raise_lock_error(*_args, **_kwargs):
+        raise OSError("locking unavailable")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "fcntl",
+        SimpleNamespace(LOCK_EX=1, LOCK_UN=2, flock=_raise_lock_error),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "msvcrt",
+        SimpleNamespace(LK_LOCK=1, LK_UNLCK=0, locking=_raise_lock_error),
+    )
+
+    with (
+        pytest.raises(RuntimeError, match="Unable to acquire FAISS file lock"),
+        _exclusive_file_lock(tmp_path / "faiss.lock"),
+    ):
+        pass

--- a/tests/unit/infrastructure/persistence/faiss/test_vector_storage_manifest_guard.py
+++ b/tests/unit/infrastructure/persistence/faiss/test_vector_storage_manifest_guard.py
@@ -1,0 +1,58 @@
+# tests/unit/infrastructure/persistence/faiss/test_vector_storage_manifest_guard.py
+
+import pytest
+
+from local_rag_backend.infrastructure.persistence.faiss.faiss_ import FaissVectorStorage
+from local_rag_backend.infrastructure.persistence.faiss.index import FaissIndex
+from local_rag_backend.infrastructure.persistence.faiss.manifest import (
+    manifest_path_for,
+    read_manifest,
+    write_manifest,
+)
+from local_rag_backend.settings import settings
+
+
+def test_upsert_does_not_mutate_index_when_manifest_drifts(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "openai_api_key", None, raising=False)
+    monkeypatch.setattr(settings, "st_embedding_model", "all-MiniLM-L6-v2", raising=False)
+
+    index_path = tmp_path / "index.faiss"
+    id_map_path = tmp_path / "id_map.json"
+    vec = FaissVectorStorage(str(index_path), str(id_map_path), dim=4)
+    vec.rebuild([], [])
+
+    mpath = manifest_path_for(index_path)
+    manifest = read_manifest(mpath)
+    assert isinstance(manifest, dict)
+    manifest["embedding_model"] = "different-model"
+    write_manifest(mpath, manifest)
+
+    with pytest.raises(RuntimeError, match="drift"):
+        vec.upsert([1], [[0.0, 0.0, 0.0, 0.0]])
+
+    idx = FaissIndex(index_path, id_map_path, dim=4)
+    assert idx.ntotal == 0
+    assert idx.id_map == []
+
+
+def test_delete_does_not_mutate_index_when_manifest_drifts(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "openai_api_key", None, raising=False)
+    monkeypatch.setattr(settings, "st_embedding_model", "all-MiniLM-L6-v2", raising=False)
+
+    index_path = tmp_path / "index.faiss"
+    id_map_path = tmp_path / "id_map.json"
+    vec = FaissVectorStorage(str(index_path), str(id_map_path), dim=4)
+    vec.rebuild([1], [[0.0, 0.0, 0.0, 0.0]])
+
+    mpath = manifest_path_for(index_path)
+    manifest = read_manifest(mpath)
+    assert isinstance(manifest, dict)
+    manifest["chunker_version"] = "other-version"
+    write_manifest(mpath, manifest)
+
+    with pytest.raises(RuntimeError, match="drift"):
+        vec.delete([1])
+
+    idx = FaissIndex(index_path, id_map_path, dim=4)
+    assert idx.ntotal == 1
+    assert idx.id_map == [1]

--- a/tests/unit/infrastructure/persistence/faiss/test_vector_storage_manifest_guard.py
+++ b/tests/unit/infrastructure/persistence/faiss/test_vector_storage_manifest_guard.py
@@ -56,3 +56,27 @@ def test_delete_does_not_mutate_index_when_manifest_drifts(tmp_path, monkeypatch
     idx = FaissIndex(index_path, id_map_path, dim=4)
     assert idx.ntotal == 1
     assert idx.id_map == [1]
+
+
+def test_upsert_fails_closed_when_manifest_is_missing_for_non_empty_legacy_index(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(settings, "openai_api_key", None, raising=False)
+    monkeypatch.setattr(settings, "st_embedding_model", "all-MiniLM-L6-v2", raising=False)
+
+    index_path = tmp_path / "index.faiss"
+    id_map_path = tmp_path / "id_map.json"
+
+    # Simulate a legacy pre-manifest index with existing vectors.
+    legacy = FaissIndex(index_path, id_map_path, dim=4)
+    legacy.rebuild([101], [[0.1, 0.2, 0.3, 0.4]])
+    assert manifest_path_for(index_path).exists() is False
+
+    vec = FaissVectorStorage(str(index_path), str(id_map_path), dim=4)
+    with pytest.raises(RuntimeError, match="manifest missing for a non-empty index"):
+        vec.upsert([102], [[0.5, 0.6, 0.7, 0.8]])
+
+    # Guard: no mutation should happen when we fail closed.
+    idx = FaissIndex(index_path, id_map_path, dim=4)
+    assert idx.ntotal == 1
+    assert idx.id_map == [101]

--- a/tests/unit/test_cli_eval.py
+++ b/tests/unit/test_cli_eval.py
@@ -1,0 +1,47 @@
+# tests/unit/test_cli_eval.py
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from local_rag_backend.cli import cli
+
+
+def test_rag_eval_passes_on_packaged_dataset() -> None:
+    # Use the packaged dataset by default (no args).
+    r = CliRunner().invoke(cli, ["eval", "--retrieval-mode", "sparse", "--reranker"])
+    assert r.exit_code == 0, r.output
+    assert "hit_rate=" in r.output
+
+
+def test_rag_eval_fails_below_threshold(tmp_path: Path) -> None:
+    # Minimal dataset where the relevant_external_ids don't exist => hit_rate=0.
+    ds = tmp_path / "ds.jsonl"
+    ds.write_text(
+        "\n".join(
+            [
+                '{"type":"meta","dataset_id":"x","schema_version":1,"created_at":"2026-02-16"}',
+                '{"type":"doc","external_id":"doc:1","source_id":"eval","content":"alpha beta gamma"}',
+                '{"type":"query","query":"alpha","relevant_external_ids":["doc:missing"]}',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    r = CliRunner().invoke(
+        cli,
+        [
+            "eval",
+            "--dataset",
+            str(ds),
+            "--retrieval-mode",
+            "sparse",
+            "--k",
+            "1",
+            "--fail-below-hit-rate",
+            "0.5",
+        ],
+    )
+    assert r.exit_code == 1, r.output
+    assert "Eval regression" in r.output

--- a/tests/unit/test_cli_ingest.py
+++ b/tests/unit/test_cli_ingest.py
@@ -56,3 +56,48 @@ def test_cli_ingest_dir_mixed_is_idempotent_and_deletes_stale_chunks(
     docs3 = SqlDocumentStorage().get_all_documents()
     assert len(docs3) == 4  # 1 (txt) + 1 (md) + 2 (csv)
     assert sum(1 for d in docs3 if (d.source_id or "").endswith("a.txt")) == 1
+
+
+def test_cli_ingest_dense_embed_failure_does_not_persist_sql(
+    in_memory_sqlite, tmp_path, monkeypatch
+):
+    class BadEmbedder:
+        dim = 4
+
+        def embed(self, texts):
+            raise RuntimeError("embed fail")
+
+    class DummyVec:
+        def __init__(self, *a, **k):
+            return None
+
+        def delete(self, ids):
+            return None
+
+        def upsert(self, ids, vectors):
+            return None
+
+        def rebuild(self, ids, vectors):
+            return None
+
+    monkeypatch.setattr(settings, "retrieval_mode", "dense", raising=False)
+    monkeypatch.setattr(settings, "openai_api_key", "k", raising=False)
+    monkeypatch.setattr(
+        "local_rag_backend.infrastructure.embeddings.openai.OpenAIEmbedder",
+        lambda *a, **k: BadEmbedder(),
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "local_rag_backend.infrastructure.persistence.faiss.faiss_.FaissVectorStorage",
+        lambda *a, **k: DummyVec(),
+        raising=True,
+    )
+
+    root = tmp_path / "in"
+    root.mkdir()
+    (root / "a.txt").write_text("hello", encoding="utf-8")
+
+    r = CliRunner().invoke(cli, ["ingest", str(root), "--no-magic"])
+    assert r.exit_code == 1
+    assert "embed fail" in r.output
+    assert SqlDocumentStorage().get_all_documents() == []

--- a/tests/unit/test_cli_upsert_docs.py
+++ b/tests/unit/test_cli_upsert_docs.py
@@ -50,3 +50,38 @@ def test_cli_upsert_docs_dense_embed_failure_does_not_persist_sql(in_memory_sqli
     assert r.exit_code == 1
     assert "embed fail" in r.output
     assert SqlDocumentStorage().get_all_documents() == []
+
+
+def test_cli_upsert_docs_failure_still_invalidates_cached_rag_service(
+    in_memory_sqlite, monkeypatch
+):
+    class BadEmbedder:
+        dim = 4
+
+        def embed(self, texts):
+            raise RuntimeError("embed fail")
+
+    reset_calls = 0
+
+    def _count_reset() -> None:
+        nonlocal reset_calls
+        reset_calls += 1
+
+    monkeypatch.setattr(settings, "retrieval_mode", "dense", raising=False)
+    monkeypatch.setattr(settings, "openai_api_key", "k", raising=False)
+    monkeypatch.setattr(
+        "local_rag_backend.infrastructure.embeddings.openai.OpenAIEmbedder",
+        lambda *a, **k: BadEmbedder(),
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "local_rag_backend.cli._reset_rag_service_best_effort", _count_reset, raising=True
+    )
+
+    r = CliRunner().invoke(
+        cli,
+        ["upsert-docs", "--external-id", "doc-1", "--content", "hello"],
+    )
+    assert r.exit_code == 1
+    assert "embed fail" in r.output
+    assert reset_calls == 1

--- a/tests/unit/test_cli_upsert_docs.py
+++ b/tests/unit/test_cli_upsert_docs.py
@@ -26,3 +26,27 @@ def test_cli_upsert_docs_from_json_file(in_memory_sqlite, tmp_path, monkeypatch)
     docs = SqlDocumentStorage().get_all_documents()
     assert len(docs) == 2
     assert {d.external_id for d in docs} == {"doc-1", "doc-2"}
+
+
+def test_cli_upsert_docs_dense_embed_failure_does_not_persist_sql(in_memory_sqlite, monkeypatch):
+    class BadEmbedder:
+        dim = 4
+
+        def embed(self, texts):
+            raise RuntimeError("embed fail")
+
+    monkeypatch.setattr(settings, "retrieval_mode", "dense", raising=False)
+    monkeypatch.setattr(settings, "openai_api_key", "k", raising=False)
+    monkeypatch.setattr(
+        "local_rag_backend.infrastructure.embeddings.openai.OpenAIEmbedder",
+        lambda *a, **k: BadEmbedder(),
+        raising=True,
+    )
+
+    r = CliRunner().invoke(
+        cli,
+        ["upsert-docs", "--external-id", "doc-1", "--content", "hello"],
+    )
+    assert r.exit_code == 1
+    assert "embed fail" in r.output
+    assert SqlDocumentStorage().get_all_documents() == []

--- a/tests/unit/test_cli_write_lock.py
+++ b/tests/unit/test_cli_write_lock.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+from click.testing import CliRunner
+
+from local_rag_backend.cli import cli
+from local_rag_backend.infrastructure.persistence.sqlalchemy.sql_ import SqlDocumentStorage
+from local_rag_backend.settings import settings
+
+
+def test_cli_upsert_docs_runs_under_multi_store_lock(in_memory_sqlite, monkeypatch):
+    lock_entries = 0
+
+    @contextmanager
+    def _fake_lock():
+        nonlocal lock_entries
+        lock_entries += 1
+        yield
+
+    monkeypatch.setattr(settings, "retrieval_mode", "sparse", raising=False)
+    monkeypatch.setattr(
+        "local_rag_backend.core.services.write_lock.multi_store_write_lock",
+        _fake_lock,
+        raising=True,
+    )
+
+    result = CliRunner().invoke(
+        cli, ["upsert-docs", "--external-id", "doc-1", "--content", "hello"]
+    )
+    assert result.exit_code == 0, result.output
+    assert lock_entries == 1
+
+
+def test_cli_delete_docs_runs_under_multi_store_lock(in_memory_sqlite, monkeypatch):
+    lock_entries = 0
+
+    @contextmanager
+    def _fake_lock():
+        nonlocal lock_entries
+        lock_entries += 1
+        yield
+
+    monkeypatch.setattr(settings, "retrieval_mode", "sparse", raising=False)
+    monkeypatch.setattr(
+        "local_rag_backend.core.services.write_lock.multi_store_write_lock",
+        _fake_lock,
+        raising=True,
+    )
+
+    doc_id = SqlDocumentStorage().store_documents(["to-delete"])[0]
+    result = CliRunner().invoke(cli, ["delete-docs", str(doc_id)])
+    assert result.exit_code == 0, result.output
+    assert lock_entries == 1
+
+
+def test_cli_ingest_runs_each_file_mutation_under_multi_store_lock(
+    in_memory_sqlite, tmp_path, monkeypatch
+):
+    lock_entries = 0
+
+    @contextmanager
+    def _fake_lock():
+        nonlocal lock_entries
+        lock_entries += 1
+        yield
+
+    monkeypatch.setattr(settings, "retrieval_mode", "sparse", raising=False)
+    monkeypatch.setattr(
+        "local_rag_backend.core.services.write_lock.multi_store_write_lock",
+        _fake_lock,
+        raising=True,
+    )
+
+    root = tmp_path / "in"
+    root.mkdir()
+    (root / "a.txt").write_text("hello world", encoding="utf-8")
+
+    result = CliRunner().invoke(cli, ["ingest", str(root), "--no-magic"])
+    assert result.exit_code == 0, result.output
+    assert lock_entries == 1


### PR DESCRIPTION

Base: `pr/02-2026-09-index-manifest` (stacked PR).

## Contexto
Necesitamos un “gate” reproducible para detectar regresiones de retrieval sin depender de proveedores LLM,
y un mínimo de observabilidad (métricas + logs) para operar el sistema local.

Además, queremos un knob opcional de “retrieval quality” (reranker) activable por flag, solo si se puede medir.

## Cambios principales
- Evaluación offline (`rag-eval`):
  - Nuevo comando CLI `eval` + entrypoint `rag-eval`.
  - Dataset versionado empaquetado: `src/local_rag_backend/datasets/rag_eval_v1.jsonl`.
  - Métricas: `hit_rate@k` y `MRR@k`.
  - Gate: exit code 1 si cae por debajo de umbrales (`--fail-below-*`).
- Monitoring mínimo:
  - `src/local_rag_backend/app/observability.py`:
    - logs JSON (sin contenido raw por defecto; fingerprint SHA256+len).
    - contadores/histogramas Prometheus (si `ENABLE_MONITORING=true` y está instalado el extra).
  - Instrumentación en endpoints:
    - `/api/ask`: métrica + log de query con latencia y número de sources.
    - `/api/docs`: métrica + log de ingesta (n inputs, n insertados, latencia).
- Retrieval quality (reranker):
  - Nuevo `RerankingRetriever` (heurística `overlap_v1`) detrás de `ENABLE_RERANKER=true`.
  - Integrado en composition root y en `ask_eval` builder.

## DoD checklist
- [x] `rag-eval` reproducible, dataset versionado y gate por regresión.
- [x] `/metrics` consistente cuando habilitado + smoke test.
- [x] Reranker toggle seguro (`ENABLE_RERANKER`) + tests.
- [x] Suite completa + `ruff` + `black` + `mypy` en verde.

## Tests añadidos
- `tests/unit/test_cli_eval.py`
- `tests/unit/core/services/test_evaluation.py`
- `tests/unit/core/services/test_reranking.py`
- `tests/unit/app/test_metrics_endpoint_enabled.py`

## Notas
- `rag-eval` está diseñado para ser dependency-free por defecto (eval sparse). Dense/hybrid eval no se activa aquí.
