### PR TITLE
PR11: Hardening de consistencia transaccional y concurrencia (SQL + índice)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,42 @@ jobs:
           path: pytest-results.xml
           retention-days: 7
 
+  test-windows-smoke:
+    name: Tests (Windows smoke)
+    runs-on: windows-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Set up uv (cached)
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            **/pyproject.toml
+            **/uv.lock
+          cache-suffix: test-windows-smoke
+
+      - name: Create virtualenv
+        run: uv venv
+
+      - name: Install deps
+        run: uv sync --frozen --extra dev --extra test
+
+      - name: Run smoke tests (cross-platform persistence paths)
+        run: >
+          uv run pytest -q
+          tests/unit/infrastructure/persistence/faiss/test_faiss_index.py
+          tests/unit/infrastructure/persistence/faiss/test_faiss_index_race.py
+          tests/unit/infrastructure/persistence/faiss/test_vector_storage_manifest_guard.py
+          tests/unit/core/services/test_maintenance.py
+
   security:
     name: Security Scan (bandit + safety)
     runs-on: ubuntu-latest

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,7 +17,9 @@
     -- Store
     -- Update (Insert/Upsert) policy
 
-- Retrieval 
+- Search
+
+- Retrieval // Reranking
     -- Bi-Encoders
     -- Cross-Encoders [F]
     -- ColBERT / ColBERTv2 [F]

--- a/pr/02-2026-11.md
+++ b/pr/02-2026-11.md
@@ -57,3 +57,47 @@ Resultado:
 ## Commits incluidos
 - `5fa6c06` fix: prevent SQL/vector drift when embedding fails
 - `fd412d8` fix: harden rag service reload token writes
+
+---
+
+## Auditoría adicional (continuación)
+Se añadieron dos hardenings críticos adicionales:
+
+### 4) Serialización de escrituras multi-store en API
+Riesgo detectado:
+- Dos `upserts` concurrentes sobre el mismo `external_id` podían intercalar SQL+FAISS y dejar vector stale respecto al contenido final en SQL.
+
+Fix:
+- Nuevo lock cross-process/thread: `core/services/write_lock.py`.
+- Los endpoints mutantes (`/api/docs`, `/api/docs/upsert`, `/api/docs/delete*`, `/api/index/rebuild`) ahora se ejecutan bajo ese lock compartido.
+
+Tests:
+- `tests/unit/app/test_multistore_write_lock.py`
+  - Simula interleaving forzado y valida consistencia final SQL/vector.
+
+### 5) Validación estricta de parámetros de generación (cost/risk guard)
+Riesgo detectado:
+- `top_p`, `temperature` y `max_tokens` no estaban acotados en `/api/openrouter/generate`.
+- `top_p` en `ask_eval` no tenía validación de rango en schema.
+
+Fix:
+- `OpenRouterGenerateRequest` ahora valida:
+  - `temperature` en `[0.0, 2.0]`
+  - `top_p` en `[0.0, 1.0]`
+  - `max_tokens` en `[1, 4096]`
+- `AskEvalConfig.top_p` ahora restringido a `[0.0, 1.0]`.
+- `validate_rag_config()` también valida `top_p` explícitamente.
+
+Tests:
+- `tests/unit/app/test_request_limits.py`
+  - Rechazo de sampling params inválidos en OpenRouter.
+- `tests/unit/app/test_api_router_more.py`
+  - Casos inválidos de `top_p` en `ask_eval`.
+
+## Verificación (actualizada)
+- `pytest -q` ✅ (255 passed, cobertura total 85.29%)
+- `ruff check src tests` ✅
+- `black --check src tests` ✅
+- `mypy src` ✅
+- `isort --check-only src tests` ❌
+  - Persisten fallos preexistentes fuera del scope crítico.

--- a/pr/02-2026-11.md
+++ b/pr/02-2026-11.md
@@ -1,0 +1,59 @@
+# PR11: Hardening de consistencia transaccional y invalidación multi-worker
+
+Base: `pr/02-2026-10` (stacked PR).
+
+## Contexto
+Durante la auditoría técnica se detectaron dos riesgos de alta criticidad:
+
+1. En `dense/hybrid`, un fallo del embedder podía dejar cambios en SQLite ya comprometidos sin reflejo en el índice vectorial.
+2. La invalidación del caché RAG multi-worker escribía un `.tmp` fijo para el reload token, con riesgo de colisión entre procesos.
+
+## Cambios principales
+
+### 1) Atomicidad lógica SQL + índice frente a fallos de embedding
+- API:
+  - `POST /api/docs`
+  - `POST /api/docs/upsert`
+- CLI:
+  - `rag-upsert-docs`
+  - `rag-ingest`
+
+Nuevo flujo:
+- Detecta previamente qué `external_id` requieren embedding real (insert o cambio de contenido).
+- Pre-computa embeddings **antes** del `upsert` SQL.
+- Ejecuta `upsert` SQL.
+- Actualiza índice solo para `content_changed`.
+
+Resultado:
+- Si el embedder falla, no hay commit parcial en SQL para esos cambios.
+- Se mantiene idempotencia (sin embeddings en no-op).
+
+### 2) Hardening de `reset_rag_service` multi-worker
+- `app/factory.py` ahora escribe el reload token con `NamedTemporaryFile` único + `fsync` + `os.replace`.
+- Evita colisiones del `.tmp` fijo entre workers/procesos.
+
+### 3) Soporte en repositorio SQL para pre-chequeo de cambios
+- Nuevo helper: `SqlDocumentStorage.get_existing_doc_states_by_external_id(...)`.
+- Permite decidir selectivamente qué documentos necesitan embedding antes de comprometer SQL.
+
+## Tests añadidos
+- `tests/unit/app/test_docs_embedding_atomicity.py`
+  - Valida que `/api/docs` y `/api/docs/upsert` no persisten en SQL si falla embedder.
+- `tests/unit/test_cli_upsert_docs.py`
+  - Valida no persistencia en `rag-upsert-docs` ante fallo de embedder.
+- `tests/unit/test_cli_ingest.py`
+  - Valida no persistencia en `rag-ingest` (dense) ante fallo de embedder.
+- `tests/unit/app/test_factory_cache_invalidation.py`
+  - Valida que `_write_reload_token` no reutiliza rutas temporales.
+
+## Verificación
+- `pytest -q` ✅ (251 passed, cobertura total 85.20%)
+- `ruff check src tests` ✅
+- `black --check src tests` ✅
+- `mypy src` ✅
+- `isort --check-only src tests` ❌
+  - Quedan fallos preexistentes en archivos no tocados por este PR (`app/middleware.py`, `scripts/*`, `tests/conftest.py`, etc.).
+
+## Commits incluidos
+- `5fa6c06` fix: prevent SQL/vector drift when embedding fails
+- `fd412d8` fix: harden rag service reload token writes

--- a/src/local_rag_backend/app/api_router.py
+++ b/src/local_rag_backend/app/api_router.py
@@ -5,6 +5,7 @@ FastAPI router for the application endpoints.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import time
 from pathlib import Path
@@ -47,10 +48,7 @@ from local_rag_backend.core.services.maintenance import (
     delete_documents_multi_store,
     rebuild_index_from_db,
 )
-from local_rag_backend.core.services.prompting import (
-    PromptTemplateError,
-    validate_prompt_template,
-)
+from local_rag_backend.core.services.prompting import PromptTemplateError, validate_prompt_template
 from local_rag_backend.core.services.rag import RagService
 from local_rag_backend.infrastructure.embeddings.openai import OpenAIEmbedder
 from local_rag_backend.infrastructure.embeddings.sentence_transformers import (
@@ -458,25 +456,65 @@ async def ingest_docs(payload: Annotated[IngestRequest, Body(...)]) -> IngestRes
         if not unique_items:
             return []
 
-        results, changed_content, updated_content_ids = doc_repo.upsert_documents_by_external_id(
+        embedder = None
+        vectors_by_external_id: dict[str, list[float]] = {}
+        if settings.retrieval_mode in ("dense", "hybrid"):
+            # Compute embeddings before SQL upsert so provider failures don't leave SQL/index drift.
+            embedder = _build_embedder_for_dense()
+            existing_states = doc_repo.get_existing_doc_states_by_external_id(
+                [it.external_id for it in unique_items]
+            )
+            to_embed = []
+            for it in unique_items:
+                content = it.content.strip()
+                current = existing_states.get(it.external_id)
+                if current is None:
+                    to_embed.append(it)
+                    continue
+                content_sha = hashlib.sha256(content.encode("utf-8")).hexdigest()
+                old_sha = current.content_sha256 or ""
+                if old_sha != content_sha or current.content != content:
+                    to_embed.append(it)
+
+            if to_embed:
+                embedded = embedder.embed([it.content.strip() for it in to_embed])
+                if len(embedded) != len(to_embed):
+                    raise RuntimeError(
+                        f"Embedder returned {len(embedded)} vectors for {len(to_embed)} documents."
+                    )
+                vectors_by_external_id = {
+                    it.external_id: list(vec) for it, vec in zip(to_embed, embedded, strict=False)
+                }
+
+        results, _changed_content, updated_content_ids = doc_repo.upsert_documents_by_external_id(
             unique_items
         )
         id_by_ext = {r.external_id: int(r.id) for r in results}
 
-        if settings.retrieval_mode in ("dense", "hybrid") and changed_content:
-            embedder = _build_embedder_for_dense()
+        if settings.retrieval_mode in ("dense", "hybrid") and embedder is not None:
             vec = FaissVectorStorage(
                 index_path=settings.index_path,
                 id_map_path=settings.id_map_path,
                 dim=embedder.dim,
             )
-            ids = [doc_id for doc_id, _ in changed_content]
-            texts_to_embed = [t for _, t in changed_content]
-            vectors = embedder.embed(texts_to_embed)
+            changed_results = [r for r in results if r.content_changed]
+            missing_vectors = [
+                r.external_id
+                for r in changed_results
+                if r.external_id not in vectors_by_external_id
+            ]
+            if missing_vectors:
+                raise RuntimeError(
+                    "Missing precomputed vectors for changed documents: "
+                    + ", ".join(missing_vectors[:10])
+                )
+            ids = [int(r.id) for r in changed_results]
+            vectors = [vectors_by_external_id[r.external_id] for r in changed_results]
             try:
-                if updated_content_ids:
+                if ids and updated_content_ids:
                     vec.delete(updated_content_ids)
-                vec.upsert(ids, vectors)
+                if ids:
+                    vec.upsert(ids, vectors)
             except Exception:
                 rebuild_index_from_db(doc_repo=doc_repo, vec_repo=vec, embedder=embedder)
 
@@ -622,7 +660,37 @@ async def upsert_docs(payload: Annotated[UpsertDocsRequest, Body(...)]) -> Upser
             for d in payload.docs
         ]
 
-        results, changed_content, updated_content_ids = doc_repo.upsert_documents_by_external_id(
+        embedder = None
+        vectors_by_external_id: dict[str, list[float]] = {}
+        if settings.retrieval_mode in ("dense", "hybrid"):
+            # Compute embeddings before SQL upsert so provider failures don't leave SQL/index drift.
+            embedder = _build_embedder_for_dense()
+            existing_states = doc_repo.get_existing_doc_states_by_external_id(
+                [it.external_id for it in items]
+            )
+            to_embed = []
+            for it in items:
+                content = it.content.strip()
+                current = existing_states.get(it.external_id)
+                if current is None:
+                    to_embed.append(it)
+                    continue
+                content_sha = hashlib.sha256(content.encode("utf-8")).hexdigest()
+                old_sha = current.content_sha256 or ""
+                if old_sha != content_sha or current.content != content:
+                    to_embed.append(it)
+
+            if to_embed:
+                embedded = embedder.embed([it.content.strip() for it in to_embed])
+                if len(embedded) != len(to_embed):
+                    raise RuntimeError(
+                        f"Embedder returned {len(embedded)} vectors for {len(to_embed)} documents."
+                    )
+                vectors_by_external_id = {
+                    it.external_id: list(vec) for it, vec in zip(to_embed, embedded, strict=False)
+                }
+
+        results, _changed_content, updated_content_ids = doc_repo.upsert_documents_by_external_id(
             items
         )
         inserted = sum(1 for r in results if r.action == "inserted")
@@ -630,17 +698,43 @@ async def upsert_docs(payload: Annotated[UpsertDocsRequest, Body(...)]) -> Upser
         unchanged = sum(1 for r in results if r.action == "unchanged")
 
         rebuilt_index = False
-        if settings.retrieval_mode in ("dense", "hybrid") and changed_content:
-            embedder = _build_embedder_for_dense()
+        if settings.retrieval_mode in ("dense", "hybrid") and embedder is not None:
+            changed_results = [r for r in results if r.content_changed]
+            missing_vectors = [
+                r.external_id
+                for r in changed_results
+                if r.external_id not in vectors_by_external_id
+            ]
+            if missing_vectors:
+                raise RuntimeError(
+                    "Missing precomputed vectors for changed documents: "
+                    + ", ".join(missing_vectors[:10])
+                )
+            ids = [int(r.id) for r in changed_results]
+            vectors = [vectors_by_external_id[r.external_id] for r in changed_results]
+
+            if not ids:
+                return UpsertDocsResponse(
+                    inserted=inserted,
+                    updated=updated,
+                    unchanged=unchanged,
+                    rebuilt_index=rebuilt_index,
+                    results=[
+                        UpsertDocResult(
+                            external_id=r.external_id,
+                            id=r.id,
+                            action=r.action,
+                            content_changed=r.content_changed,
+                        )
+                        for r in results
+                    ],
+                )
+
             vec = FaissVectorStorage(
                 index_path=settings.index_path,
                 id_map_path=settings.id_map_path,
                 dim=embedder.dim,
             )
-
-            ids = [doc_id for doc_id, _ in changed_content]
-            texts = [text for _, text in changed_content]
-            vectors = embedder.embed(texts)
             try:
                 # Updates must remove the old vector for that doc_id first.
                 if updated_content_ids:

--- a/src/local_rag_backend/app/api_router.py
+++ b/src/local_rag_backend/app/api_router.py
@@ -9,7 +9,7 @@ import hashlib
 import json
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Any
+from typing import TYPE_CHECKING, Annotated, Any, cast
 
 import requests
 from fastapi import APIRouter, Body, Depends, HTTPException, Query
@@ -50,6 +50,7 @@ from local_rag_backend.core.services.maintenance import (
 )
 from local_rag_backend.core.services.prompting import PromptTemplateError, validate_prompt_template
 from local_rag_backend.core.services.rag import RagService
+from local_rag_backend.core.services.write_lock import multi_store_write_lock
 from local_rag_backend.infrastructure.embeddings.openai import OpenAIEmbedder
 from local_rag_backend.infrastructure.embeddings.sentence_transformers import (
     SentenceTransformerEmbedder,
@@ -94,6 +95,8 @@ def validate_rag_config(config: AskEvalConfig) -> list[str]:
         errors.append(f"Invalid hybrid_alpha: {config.hybrid_alpha}. Must be between 0.0 and 1.0")
     if config.temperature is not None and not (0.0 <= config.temperature <= 2.0):
         errors.append(f"Invalid temperature: {config.temperature}. Must be between 0.0 and 2.0")
+    if config.top_p is not None and not (0.0 <= config.top_p <= 1.0):
+        errors.append(f"Invalid top_p: {config.top_p}. Must be between 0.0 and 1.0")
     if config.max_tokens is not None and not (1 <= config.max_tokens <= 4096):
         errors.append(f"Invalid max_tokens: {config.max_tokens}. Must be between 1 and 4096")
     if config.prompt_template is not None:
@@ -134,6 +137,12 @@ def _build_embedder_for_dense() -> EmbedderPort:
 
 
 router = APIRouter()
+
+
+def _run_multi_store_write_locked(fn: Any) -> Any:
+    with multi_store_write_lock():
+        return fn()
+
 
 # --- Health & Readiness --- #
 
@@ -521,7 +530,7 @@ async def ingest_docs(payload: Annotated[IngestRequest, Body(...)]) -> IngestRes
         return [id_by_ext[e] for e in unique_extids if e in id_by_ext]
 
     try:
-        ids = await run_blocking(_ingest_sync)
+        ids = cast("list[int]", await run_blocking(_run_multi_store_write_locked, _ingest_sync))
     except RuntimeError as e:
         if "sentence-transformers" in str(e) or "Dense/hybrid" in str(e):
             raise HTTPException(
@@ -594,7 +603,10 @@ async def delete_docs_by_external_id(
             rebuilt_index=False,
         )
 
-    resp = await run_blocking(_delete_sync)
+    resp = cast(
+        "DeleteDocsByExternalIdResponse",
+        await run_blocking(_run_multi_store_write_locked, _delete_sync),
+    )
     reset_rag_service()
     return resp
 
@@ -628,7 +640,9 @@ async def delete_docs(payload: Annotated[DeleteDocsRequest, Body(...)]) -> Delet
         deleted_sql, _, _ = delete_documents_multi_store(doc_repo=doc_repo, ids=ids)
         return DeleteDocsResponse(deleted_sql=deleted_sql, deleted_index=None, rebuilt_index=False)
 
-    resp = await run_blocking(_delete_sync)
+    resp = cast(
+        "DeleteDocsResponse", await run_blocking(_run_multi_store_write_locked, _delete_sync)
+    )
     reset_rag_service()
     return resp
 
@@ -763,7 +777,9 @@ async def upsert_docs(payload: Annotated[UpsertDocsRequest, Body(...)]) -> Upser
             ],
         )
 
-    resp = await run_blocking(_upsert_sync)
+    resp = cast(
+        "UpsertDocsResponse", await run_blocking(_run_multi_store_write_locked, _upsert_sync)
+    )
     reset_rag_service()
     return resp
 
@@ -790,7 +806,9 @@ async def rebuild_index() -> RebuildIndexResponse:
         n = rebuild_index_from_db(doc_repo=doc_repo, vec_repo=vec, embedder=embedder)
         return RebuildIndexResponse(indexed=n)
 
-    resp = await run_blocking(_rebuild_sync)
+    resp = cast(
+        "RebuildIndexResponse", await run_blocking(_run_multi_store_write_locked, _rebuild_sync)
+    )
     reset_rag_service()
     return resp
 
@@ -934,9 +952,9 @@ class OpenRouterGenerateRequest(BaseModel):
     )
     system_instruction: str = Field(..., min_length=1, max_length=8000)
     user_content: str = Field(..., min_length=1, max_length=8000)
-    temperature: float | None = None
-    max_tokens: int | None = None
-    top_p: float | None = None
+    temperature: float | None = Field(default=None, ge=0.0, le=2.0)
+    max_tokens: int | None = Field(default=None, ge=1, le=4096)
+    top_p: float | None = Field(default=None, ge=0.0, le=1.0)
 
 
 class OpenRouterGenerateResponse(BaseModel):

--- a/src/local_rag_backend/app/factory.py
+++ b/src/local_rag_backend/app/factory.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 import os
+import tempfile
 from functools import lru_cache
 from time import time_ns
 from typing import TYPE_CHECKING
@@ -136,9 +137,19 @@ def _read_reload_token() -> str:
 def _write_reload_token(token: str) -> None:
     p = _reload_token_path()
     p.parent.mkdir(parents=True, exist_ok=True)
-    tmp = p.with_name(p.name + ".tmp")
-    tmp.write_text(token, encoding="utf-8")
-    os.replace(tmp, p)
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        prefix=p.name + ".",
+        suffix=".tmp",
+        dir=p.parent,
+        delete=False,
+    ) as tmp:
+        tmp.write(token)
+        tmp.flush()
+        os.fsync(tmp.fileno())
+        tmp_name = tmp.name
+    os.replace(tmp_name, p)
 
 
 @lru_cache(maxsize=1)

--- a/src/local_rag_backend/app/middleware.py
+++ b/src/local_rag_backend/app/middleware.py
@@ -48,12 +48,10 @@ def _noop_generate_latest(*_args: Any, **_kwargs: Any) -> bytes:  # pragma: no c
 
 
 try:  # pragma: no cover
-    from prometheus_client import (
-        CONTENT_TYPE_LATEST as _CONTENT_TYPE_LATEST,
-        Counter as _PromCounter,
-        Histogram as _PromHistogram,
-        generate_latest as _prom_generate_latest,
-    )
+    from prometheus_client import CONTENT_TYPE_LATEST as _CONTENT_TYPE_LATEST
+    from prometheus_client import Counter as _PromCounter
+    from prometheus_client import Histogram as _PromHistogram
+    from prometheus_client import generate_latest as _prom_generate_latest
 
     PROMETHEUS_AVAILABLE = True
     CONTENT_TYPE_LATEST = _CONTENT_TYPE_LATEST

--- a/src/local_rag_backend/app/schemas.py
+++ b/src/local_rag_backend/app/schemas.py
@@ -65,7 +65,7 @@ class AskEvalConfig(BaseModel):
     )
     model: str | None = Field(default=None, max_length=256)
     temperature: float | None = None
-    top_p: float | None = None
+    top_p: float | None = Field(default=None, ge=0.0, le=1.0)
     max_tokens: int | None = None
     prompt_template: str | None = Field(default=None, max_length=20000)
 

--- a/src/local_rag_backend/cli.py
+++ b/src/local_rag_backend/cli.py
@@ -8,6 +8,7 @@ starting the server, building indices, and bootstrapping data.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import sys
 from pathlib import Path
@@ -319,7 +320,40 @@ def upsert_docs(
                 "Some external_id values are tombstoned (deleted): "
                 + ", ".join(sorted(tombstoned)[:10])
             )
-        results, changed_content, updated_content_ids = doc_repo.upsert_documents_by_external_id(
+        embedder = None
+        vectors_by_external_id: dict[str, list[float]] = {}
+        if settings.retrieval_mode in ("dense", "hybrid"):
+            embedder = (
+                OpenAIEmbedder()
+                if settings.openai_api_key
+                else SentenceTransformerEmbedder(model_name=settings.st_embedding_model)
+            )
+            existing_states = doc_repo.get_existing_doc_states_by_external_id(
+                [it.external_id for it in items]
+            )
+            to_embed = []
+            for it in items:
+                content = it.content.strip()
+                current = existing_states.get(it.external_id)
+                if current is None:
+                    to_embed.append(it)
+                    continue
+                content_sha = hashlib.sha256(content.encode("utf-8")).hexdigest()
+                old_sha = current.content_sha256 or ""
+                if old_sha != content_sha or current.content != content:
+                    to_embed.append(it)
+
+            if to_embed:
+                embedded = embedder.embed([it.content.strip() for it in to_embed])
+                if len(embedded) != len(to_embed):
+                    raise RuntimeError(
+                        f"Embedder returned {len(embedded)} vectors for {len(to_embed)} documents."
+                    )
+                vectors_by_external_id = {
+                    it.external_id: list(vec) for it, vec in zip(to_embed, embedded, strict=False)
+                }
+
+        results, _changed_content, updated_content_ids = doc_repo.upsert_documents_by_external_id(
             items
         )
 
@@ -328,20 +362,31 @@ def upsert_docs(
         unchanged = sum(1 for r in results if r.action == "unchanged")
 
         rebuilt = False
-        if settings.retrieval_mode in ("dense", "hybrid") and changed_content:
-            embedder = (
-                OpenAIEmbedder()
-                if settings.openai_api_key
-                else SentenceTransformerEmbedder(model_name=settings.st_embedding_model)
-            )
+        if settings.retrieval_mode in ("dense", "hybrid") and embedder is not None:
+            changed_results = [r for r in results if r.content_changed]
+            missing_vectors = [
+                r.external_id
+                for r in changed_results
+                if r.external_id not in vectors_by_external_id
+            ]
+            if missing_vectors:
+                raise RuntimeError(
+                    "Missing precomputed vectors for changed documents: "
+                    + ", ".join(missing_vectors[:10])
+                )
+            ids = [int(r.id) for r in changed_results]
+            vectors = [vectors_by_external_id[r.external_id] for r in changed_results]
+            if not ids:
+                reset_rag_service()
+                click.echo(
+                    f"[OK] Upserted docs. inserted={inserted} updated={updated} unchanged={unchanged} rebuilt_index={rebuilt}"
+                )
+                return
             vec = FaissVectorStorage(
                 index_path=settings.index_path,
                 id_map_path=settings.id_map_path,
                 dim=embedder.dim,
             )
-            ids = [doc_id for doc_id, _ in changed_content]
-            texts = [text for _, text in changed_content]
-            vectors = embedder.embed(texts)
             try:
                 if updated_content_ids:
                     vec.delete(updated_content_ids)
@@ -738,7 +783,36 @@ def ingest(
                 total_chunks += len(items)
                 continue
 
-            results, changed_content, updated_content_ids = (
+            vectors_by_external_id: dict[str, list[float]] = {}
+            if settings.retrieval_mode in ("dense", "hybrid"):
+                assert embedder is not None
+                existing_states = doc_repo.get_existing_doc_states_by_external_id(
+                    [it.external_id for it in items]
+                )
+                to_embed = []
+                for it in items:
+                    content = it.content.strip()
+                    current = existing_states.get(it.external_id)
+                    if current is None:
+                        to_embed.append(it)
+                        continue
+                    content_sha = hashlib.sha256(content.encode("utf-8")).hexdigest()
+                    old_sha = current.content_sha256 or ""
+                    if old_sha != content_sha or current.content != content:
+                        to_embed.append(it)
+
+                if to_embed:
+                    embedded = embedder.embed([it.content.strip() for it in to_embed])
+                    if len(embedded) != len(to_embed):
+                        raise RuntimeError(
+                            f"Embedder returned {len(embedded)} vectors for {len(to_embed)} documents."
+                        )
+                    vectors_by_external_id = {
+                        it.external_id: list(vec)
+                        for it, vec in zip(to_embed, embedded, strict=False)
+                    }
+
+            results, _changed_content, updated_content_ids = (
                 doc_repo.upsert_documents_by_external_id(items)
             )
 
@@ -753,10 +827,20 @@ def ingest(
                 assert vec is not None
 
                 rebuilt = False
-                if changed_content:
-                    ids = [doc_id for doc_id, _ in changed_content]
-                    texts = [text for _, text in changed_content]
-                    vectors = embedder.embed(texts)
+                changed_results = [r for r in results if r.content_changed]
+                if changed_results:
+                    missing_vectors = [
+                        r.external_id
+                        for r in changed_results
+                        if r.external_id not in vectors_by_external_id
+                    ]
+                    if missing_vectors:
+                        raise RuntimeError(
+                            "Missing precomputed vectors for changed documents: "
+                            + ", ".join(missing_vectors[:10])
+                        )
+                    ids = [int(r.id) for r in changed_results]
+                    vectors = [vectors_by_external_id[r.external_id] for r in changed_results]
                     try:
                         if updated_content_ids:
                             vec.delete(updated_content_ids)

--- a/src/local_rag_backend/core/services/maintenance.py
+++ b/src/local_rag_backend/core/services/maintenance.py
@@ -72,5 +72,11 @@ def delete_documents_multi_store(
             raise
         if embedder is None:
             raise
-        rebuilt = rebuild_index_from_db(doc_repo=doc_repo, vec_repo=vec_repo, embedder=embedder)
-        return deleted_sql, None, rebuilt >= 0
+        try:
+            rebuilt = rebuild_index_from_db(doc_repo=doc_repo, vec_repo=vec_repo, embedder=embedder)
+            return deleted_sql, None, rebuilt >= 0
+        except Exception as rebuild_err:
+            raise RuntimeError(
+                "Multi-store inconsistency risk: SQL delete succeeded but vector index sync failed. "
+                "Run `rag-rebuild-index` / POST /api/index/rebuild to repair."
+            ) from rebuild_err

--- a/src/local_rag_backend/core/services/write_lock.py
+++ b/src/local_rag_backend/core/services/write_lock.py
@@ -1,0 +1,81 @@
+"""
+Cross-process lock for multi-store write operations.
+
+Why:
+- SQL + vector index updates are not transactional across both stores.
+- Concurrent writers can interleave commits and leave SQL/vector drift.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from contextlib import contextmanager, suppress
+from typing import TYPE_CHECKING, Any
+
+from local_rag_backend.settings import settings
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+_LOCAL_WRITE_LOCK = threading.RLock()
+
+
+@contextmanager
+def _exclusive_file_lock(lock_path: Path) -> Iterator[None]:
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    f = lock_path.open("a+b")
+    locked = False
+    try:
+        try:  # POSIX
+            import fcntl
+
+            fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+            locked = True
+        except Exception:  # pragma: no cover
+            locked = False
+
+        if not locked:  # pragma: no cover
+            try:  # Windows
+                import msvcrt  # pragma: no cover
+
+                msvcrt_any: Any = msvcrt  # pragma: no cover
+                f.seek(0, os.SEEK_END)  # pragma: no cover
+                if f.tell() == 0:  # pragma: no cover
+                    f.write(b"0")  # pragma: no cover
+                    f.flush()  # pragma: no cover
+                f.seek(0)  # pragma: no cover
+                msvcrt_any.locking(  # pragma: no cover
+                    f.fileno(), getattr(msvcrt_any, "LK_LOCK", 1), 1
+                )
+                locked = True  # pragma: no cover
+            except Exception:  # pragma: no cover
+                locked = False  # pragma: no cover
+
+        yield
+    finally:
+        if locked:
+            with suppress(Exception):  # pragma: no cover
+                import fcntl
+
+                fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+            with suppress(Exception):  # pragma: no cover
+                import msvcrt  # pragma: no cover
+
+                msvcrt_mod: Any = msvcrt  # pragma: no cover
+                f.seek(0)  # pragma: no cover
+                msvcrt_mod.locking(  # pragma: no cover
+                    f.fileno(), getattr(msvcrt_mod, "LK_UNLCK", 0), 1
+                )
+        f.close()
+
+
+@contextmanager
+def multi_store_write_lock() -> Iterator[None]:
+    """
+    Serialize mutating multi-store operations (SQL + FAISS) across threads/processes.
+    """
+    lock_path = settings.data_dir / ".rag_multi_store_write.lock"
+    with _LOCAL_WRITE_LOCK, _exclusive_file_lock(lock_path):
+        yield

--- a/src/local_rag_backend/infrastructure/persistence/faiss/faiss_.py
+++ b/src/local_rag_backend/infrastructure/persistence/faiss/faiss_.py
@@ -97,13 +97,15 @@ class FaissVectorStorage(VectorRepoPort):
 
     def upsert(self, ids: Sequence[int], vectors: Sequence[Sequence[float]]) -> None:
         """Add vectors to the FAISS index."""
-        self.faiss_index.add_to_index(list(ids), list(vectors))
+        # Guard first: if manifest drifts from current settings, fail before mutating index files.
         self._ensure_manifest(overwrite=False)
+        self.faiss_index.add_to_index(list(ids), list(vectors))
 
     def delete(self, ids: Sequence[int]) -> None:
         """Delete vectors from the index (may rebuild the underlying index)."""
-        self.faiss_index.delete_ids(list(ids))
+        # Guard first: if manifest drifts from current settings, fail before mutating index files.
         self._ensure_manifest(overwrite=False)
+        self.faiss_index.delete_ids(list(ids))
 
     def rebuild(self, ids: Sequence[int], vectors: Sequence[Sequence[float]]) -> None:
         """Rebuild the full index from scratch (idempotent)."""

--- a/src/local_rag_backend/infrastructure/persistence/sqlalchemy/sql_.py
+++ b/src/local_rag_backend/infrastructure/persistence/sqlalchemy/sql_.py
@@ -18,8 +18,8 @@ from local_rag_backend.infrastructure.persistence.sqlalchemy.crud import (
     add_history,
     delete_documents,
 )
+from local_rag_backend.infrastructure.persistence.sqlalchemy.models import Document as DbDocument
 from local_rag_backend.infrastructure.persistence.sqlalchemy.models import (
-    Document as DbDocument,
     DocumentTombstone as DbDocumentTombstone,
 )
 
@@ -112,6 +112,43 @@ class SqlDocumentStorage(DocumentRepoPort):
         id: int
         action: Literal["inserted", "updated", "unchanged"]
         content_changed: bool
+
+    @dataclass(frozen=True)
+    class ExistingDocState:
+        id: int
+        external_id: str
+        content: str
+        content_sha256: str | None
+
+    def get_existing_doc_states_by_external_id(
+        self, external_ids: Sequence[str]
+    ) -> dict[str, ExistingDocState]:
+        ext_ids = [str(x).strip() for x in external_ids if str(x).strip()]
+        if not ext_ids:
+            return {}
+        with get_session(self._session_factory) as session:
+            rows = (
+                session.query(
+                    DbDocument.id,
+                    DbDocument.external_id,
+                    DbDocument.content,
+                    DbDocument.content_sha256,
+                )
+                .filter(DbDocument.external_id.is_not(None))
+                .filter(DbDocument.external_id.in_(ext_ids))
+                .all()
+            )
+            out: dict[str, SqlDocumentStorage.ExistingDocState] = {}
+            for doc_id, ext_id, content, content_sha in rows:
+                if ext_id is None:
+                    continue
+                out[str(ext_id)] = SqlDocumentStorage.ExistingDocState(
+                    id=int(doc_id),
+                    external_id=str(ext_id),
+                    content=str(content or ""),
+                    content_sha256=(str(content_sha) if content_sha is not None else None),
+                )
+            return out
 
     def upsert_documents_by_external_id(
         self, items: Sequence[UpsertDoc]

--- a/src/local_rag_backend/scripts/bootstrap.py
+++ b/src/local_rag_backend/scripts/bootstrap.py
@@ -25,10 +25,8 @@ from local_rag_backend.infrastructure.embeddings.sentence_transformers import (
 )
 from local_rag_backend.infrastructure.ingestion.loaders.csv_loader import CSVLoader
 from local_rag_backend.infrastructure.persistence.faiss.faiss_ import FaissVectorStorage
-from local_rag_backend.infrastructure.persistence.sqlalchemy import (
-    base as db_base,
-    models,  # noqa: F401
-)
+from local_rag_backend.infrastructure.persistence.sqlalchemy import base as db_base
+from local_rag_backend.infrastructure.persistence.sqlalchemy import models  # noqa: F401
 from local_rag_backend.infrastructure.persistence.sqlalchemy.base import Base
 from local_rag_backend.infrastructure.persistence.sqlalchemy.sql_ import SqlDocumentStorage
 from local_rag_backend.settings import settings as default_settings

--- a/src/local_rag_backend/scripts/build_index.py
+++ b/src/local_rag_backend/scripts/build_index.py
@@ -22,10 +22,8 @@ from local_rag_backend.infrastructure.embeddings.sentence_transformers import (
 
 # Import models to ensure they are registered with Base.metadata
 # To ensure table creation
-from local_rag_backend.infrastructure.persistence.sqlalchemy import (
-    base as db_base,
-    models,  # noqa: F401
-)
+from local_rag_backend.infrastructure.persistence.sqlalchemy import base as db_base
+from local_rag_backend.infrastructure.persistence.sqlalchemy import models  # noqa: F401
 from local_rag_backend.infrastructure.persistence.sqlalchemy.base import Base as AppDeclarativeBase
 from local_rag_backend.settings import settings
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,8 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
 # Import models to ensure they are registered with Base.metadata
-from local_rag_backend.infrastructure.persistence.sqlalchemy import base as db_base, sql_
+from local_rag_backend.infrastructure.persistence.sqlalchemy import base as db_base
+from local_rag_backend.infrastructure.persistence.sqlalchemy import sql_
 
 
 @pytest.fixture()

--- a/tests/unit/app/test_api_router_more.py
+++ b/tests/unit/app/test_api_router_more.py
@@ -2,7 +2,8 @@
 
 import pytest
 
-from local_rag_backend.app import api_router as api, dependencies as deps
+from local_rag_backend.app import api_router as api
+from local_rag_backend.app import dependencies as deps
 from local_rag_backend.settings import settings
 
 

--- a/tests/unit/app/test_api_router_more.py
+++ b/tests/unit/app/test_api_router_more.py
@@ -100,6 +100,8 @@ async def test_ask_eval_invalid_config(asgi_client, monkeypatch):
         ({"retrieval_mode": "hybrid", "k": 3, "hybrid_alpha": 1.1}, 422),  # schema
         ({"retrieval_mode": "sparse", "k": 3, "temperature": -0.5}, 400),  # runtime validation
         ({"retrieval_mode": "sparse", "k": 3, "temperature": 2.5}, 400),  # runtime validation
+        ({"retrieval_mode": "sparse", "k": 3, "top_p": -0.1}, 422),  # schema
+        ({"retrieval_mode": "sparse", "k": 3, "top_p": 1.1}, 422),  # schema
         ({"retrieval_mode": "sparse", "k": 3, "max_tokens": 0}, 400),  # runtime validation
         ({"retrieval_mode": "sparse", "k": 3, "max_tokens": 999999}, 400),  # runtime validation
     ],

--- a/tests/unit/app/test_dependencies.py
+++ b/tests/unit/app/test_dependencies.py
@@ -1,7 +1,8 @@
 # tests/unit/app/test_dependencies.py
 from types import SimpleNamespace
 
-from local_rag_backend.app import dependencies as deps, factory
+from local_rag_backend.app import dependencies as deps
+from local_rag_backend.app import factory
 from local_rag_backend.settings import settings
 
 

--- a/tests/unit/app/test_docs_embedding_atomicity.py
+++ b/tests/unit/app/test_docs_embedding_atomicity.py
@@ -1,0 +1,43 @@
+import pytest
+
+from local_rag_backend.app import api_router as api
+from local_rag_backend.infrastructure.persistence.sqlalchemy.sql_ import SqlDocumentStorage
+from local_rag_backend.settings import settings
+
+
+async def test_docs_dense_embed_failure_does_not_persist_sql(
+    asgi_client, in_memory_sqlite, monkeypatch
+):
+    class BadEmbedder:
+        dim = 4
+
+        def embed(self, texts):
+            raise RuntimeError("embed fail")
+
+    monkeypatch.setattr(settings, "retrieval_mode", "dense", raising=False)
+    monkeypatch.setattr(settings, "openai_api_key", "k", raising=False)
+    monkeypatch.setattr(api, "OpenAIEmbedder", lambda *a, **k: BadEmbedder(), raising=True)
+
+    with pytest.raises(RuntimeError, match="embed fail"):
+        await asgi_client.post("/api/docs", json={"texts": ["hello world"]})
+    assert SqlDocumentStorage().get_all_documents() == []
+
+
+async def test_upsert_dense_embed_failure_does_not_persist_sql(
+    asgi_client, in_memory_sqlite, monkeypatch
+):
+    class BadEmbedder:
+        dim = 4
+
+        def embed(self, texts):
+            raise RuntimeError("embed fail")
+
+    monkeypatch.setattr(settings, "retrieval_mode", "dense", raising=False)
+    monkeypatch.setattr(settings, "openai_api_key", "k", raising=False)
+    monkeypatch.setattr(api, "OpenAIEmbedder", lambda *a, **k: BadEmbedder(), raising=True)
+
+    with pytest.raises(RuntimeError, match="embed fail"):
+        await asgi_client.post(
+            "/api/docs/upsert", json={"docs": [{"external_id": "doc-1", "content": "hello"}]}
+        )
+    assert SqlDocumentStorage().get_all_documents() == []

--- a/tests/unit/app/test_factory_cache_invalidation.py
+++ b/tests/unit/app/test_factory_cache_invalidation.py
@@ -39,3 +39,25 @@ async def test_get_rag_service_cache_is_invalidated_by_reload_token(tmp_path, mo
 
     svc4 = await factory.get_rag_service()
     assert svc4 is svc3
+
+
+def test_write_reload_token_uses_unique_tmp_paths(tmp_path, monkeypatch):
+    monkeypatch.setattr(factory.settings, "data_dir", tmp_path, raising=False)
+    token_path = tmp_path / ".rag_service_reload_token"
+
+    seen_sources: set[str] = set()
+    real_replace = factory.os.replace
+
+    def _replace(src, dst):
+        src_s = str(src)
+        if src_s in seen_sources:
+            raise FileNotFoundError("duplicate temporary path")
+        seen_sources.add(src_s)
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(factory.os, "replace", _replace, raising=True)
+
+    factory._write_reload_token("v1")
+    factory._write_reload_token("v2")
+
+    assert token_path.read_text(encoding="utf-8") == "v2"

--- a/tests/unit/app/test_multistore_write_lock.py
+++ b/tests/unit/app/test_multistore_write_lock.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import threading
+import time
+from dataclasses import dataclass
+
+from local_rag_backend.app import api_router as api
+from local_rag_backend.settings import settings
+
+
+async def test_concurrent_upserts_are_serialized_and_keep_sql_vector_consistent(
+    asgi_client, in_memory_sqlite, monkeypatch
+):
+    @dataclass(frozen=True)
+    class _UpsertDoc:
+        external_id: str
+        content: str
+        source_id: str | None = None
+        metadata: dict[str, object] | None = None
+        chunk_dedup_sha256: str | None = None
+
+    @dataclass(frozen=True)
+    class _UpsertResult:
+        external_id: str
+        id: int
+        action: str
+        content_changed: bool
+
+    @dataclass(frozen=True)
+    class _ExistingDocState:
+        id: int
+        external_id: str
+        content: str
+        content_sha256: str | None
+
+    class FakeRepo:
+        UpsertDoc = _UpsertDoc
+
+        _lock = threading.Lock()
+        _next_id = 1
+        _by_external_id: dict[str, tuple[int, str, str]] = {}
+        _a_sql_done = threading.Event()
+
+        def get_tombstoned_external_ids(self, external_ids):
+            return set()
+
+        def get_existing_doc_states_by_external_id(self, external_ids):
+            with self._lock:
+                out: dict[str, _ExistingDocState] = {}
+                for ext in external_ids:
+                    row = self._by_external_id.get(ext)
+                    if row is None:
+                        continue
+                    doc_id, content, sha = row
+                    out[ext] = _ExistingDocState(
+                        id=doc_id, external_id=ext, content=content, content_sha256=sha
+                    )
+                return out
+
+        def upsert_documents_by_external_id(self, items):
+            results = []
+            changed = []
+            updated_ids = []
+
+            with self._lock:
+                for item in items:
+                    ext = item.external_id
+                    content = item.content.strip()
+                    sha = hashlib.sha256(content.encode("utf-8")).hexdigest()
+                    row = self._by_external_id.get(ext)
+                    if row is None:
+                        doc_id = self._next_id
+                        self._next_id += 1
+                        self._by_external_id[ext] = (doc_id, content, sha)
+                        results.append(_UpsertResult(ext, doc_id, "inserted", True))
+                        changed.append((doc_id, content))
+                        if content == "A":
+                            self._a_sql_done.set()
+                        continue
+
+                    doc_id, old_content, old_sha = row
+                    if content == "B":
+                        # Forces the B request to update SQL while A still sleeps in vector upsert.
+                        self._a_sql_done.wait(timeout=2)
+                    content_changed = old_sha != sha or old_content != content
+                    if content_changed:
+                        self._by_external_id[ext] = (doc_id, content, sha)
+                        results.append(_UpsertResult(ext, doc_id, "updated", True))
+                        changed.append((doc_id, content))
+                        updated_ids.append(doc_id)
+                    else:
+                        results.append(_UpsertResult(ext, doc_id, "unchanged", False))
+
+            return results, changed, updated_ids
+
+    class FakeEmbedder:
+        dim = 1
+
+        def embed(self, texts):
+            return [[1.0 if "A" in text else 2.0] for text in texts]
+
+    class FakeVec:
+        def __init__(self):
+            self.by_id: dict[int, list[float]] = {}
+            self._lock = threading.Lock()
+
+        def delete(self, ids):
+            with self._lock:
+                for i in ids:
+                    self.by_id.pop(int(i), None)
+
+        def upsert(self, ids, vectors):
+            # Force an interleaving window where request A sleeps after SQL commit.
+            if vectors and float(vectors[0][0]) == 1.0:
+                time.sleep(0.2)
+            with self._lock:
+                for i, v in zip(ids, vectors, strict=False):
+                    self.by_id[int(i)] = list(v)
+
+    fake_vec = FakeVec()
+    monkeypatch.setattr(settings, "retrieval_mode", "dense", raising=False)
+    monkeypatch.setattr(settings, "openai_api_key", "k", raising=False)
+    monkeypatch.setattr(api, "SqlDocumentStorage", FakeRepo, raising=True)
+    monkeypatch.setattr(api, "OpenAIEmbedder", lambda *a, **k: FakeEmbedder(), raising=True)
+    monkeypatch.setattr(api, "FaissVectorStorage", lambda *a, **k: fake_vec, raising=True)
+    monkeypatch.setattr(api, "reset_rag_service", lambda: None, raising=True)
+
+    task_a = asyncio.create_task(
+        asgi_client.post(
+            "/api/docs/upsert",
+            json={"docs": [{"external_id": "doc-1", "content": "A"}]},
+        )
+    )
+    await asyncio.sleep(0.02)
+    task_b = asyncio.create_task(
+        asgi_client.post(
+            "/api/docs/upsert",
+            json={"docs": [{"external_id": "doc-1", "content": "B"}]},
+        )
+    )
+    ra, rb = await asyncio.gather(task_a, task_b)
+
+    assert ra.status_code == 200
+    assert rb.status_code == 200
+    # Final SQL state must match final vector state (latest content = B -> vector 2.0).
+    assert FakeRepo._by_external_id["doc-1"][1] == "B"
+    assert fake_vec.by_id[1] == [2.0]

--- a/tests/unit/app/test_request_limits.py
+++ b/tests/unit/app/test_request_limits.py
@@ -35,3 +35,36 @@ async def test_openrouter_generate_rejects_overlong_fields(asgi_client, in_memor
         },
     )
     assert r.status_code == 422
+
+
+@pytest.mark.unit
+async def test_openrouter_generate_rejects_invalid_sampling_params(asgi_client, in_memory_sqlite):
+    r1 = await asgi_client.post(
+        "/api/openrouter/generate",
+        json={
+            "system_instruction": "sys",
+            "user_content": "hi",
+            "top_p": 1.5,
+        },
+    )
+    assert r1.status_code == 422
+
+    r2 = await asgi_client.post(
+        "/api/openrouter/generate",
+        json={
+            "system_instruction": "sys",
+            "user_content": "hi",
+            "temperature": -0.1,
+        },
+    )
+    assert r2.status_code == 422
+
+    r3 = await asgi_client.post(
+        "/api/openrouter/generate",
+        json={
+            "system_instruction": "sys",
+            "user_content": "hi",
+            "max_tokens": 0,
+        },
+    )
+    assert r3.status_code == 422

--- a/tests/unit/core/services/test_maintenance.py
+++ b/tests/unit/core/services/test_maintenance.py
@@ -41,12 +41,15 @@ class DummyEmbedder:
 
 
 class DummyVecRepo:
-    def __init__(self, fail_delete=False) -> None:
+    def __init__(self, fail_delete=False, fail_rebuild=False) -> None:
         self.rebuild_calls = []
         self.delete_calls = []
         self.fail_delete = fail_delete
+        self.fail_rebuild = fail_rebuild
 
     def rebuild(self, ids, vectors):
+        if self.fail_rebuild:
+            raise RuntimeError("fail-rebuild")
         self.rebuild_calls.append((list(ids), list(vectors)))
 
     def delete(self, ids):
@@ -105,4 +108,19 @@ def test_delete_documents_index_failure_no_rebuild_raises():
             embedder=None,
             ids=[1],
             rebuild_on_index_failure=False,
+        )
+
+
+def test_delete_documents_index_and_rebuild_failure_raises_consistency_error():
+    doc_repo = DummyDocRepo([_Doc(1, "a"), _Doc(2, "b")])
+    vec_repo = DummyVecRepo(fail_delete=True, fail_rebuild=True)
+    embedder = DummyEmbedder()
+
+    with pytest.raises(RuntimeError, match="Multi-store inconsistency risk"):
+        delete_documents_multi_store(
+            doc_repo=doc_repo,
+            vec_repo=vec_repo,
+            embedder=embedder,
+            ids=[1],
+            rebuild_on_index_failure=True,
         )

--- a/tests/unit/infrastructure/persistence/faiss/test_vector_storage_manifest_guard.py
+++ b/tests/unit/infrastructure/persistence/faiss/test_vector_storage_manifest_guard.py
@@ -1,0 +1,58 @@
+# tests/unit/infrastructure/persistence/faiss/test_vector_storage_manifest_guard.py
+
+import pytest
+
+from local_rag_backend.infrastructure.persistence.faiss.faiss_ import FaissVectorStorage
+from local_rag_backend.infrastructure.persistence.faiss.index import FaissIndex
+from local_rag_backend.infrastructure.persistence.faiss.manifest import (
+    manifest_path_for,
+    read_manifest,
+    write_manifest,
+)
+from local_rag_backend.settings import settings
+
+
+def test_upsert_does_not_mutate_index_when_manifest_drifts(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "openai_api_key", None, raising=False)
+    monkeypatch.setattr(settings, "st_embedding_model", "all-MiniLM-L6-v2", raising=False)
+
+    index_path = tmp_path / "index.faiss"
+    id_map_path = tmp_path / "id_map.json"
+    vec = FaissVectorStorage(str(index_path), str(id_map_path), dim=4)
+    vec.rebuild([], [])
+
+    mpath = manifest_path_for(index_path)
+    manifest = read_manifest(mpath)
+    assert isinstance(manifest, dict)
+    manifest["embedding_model"] = "different-model"
+    write_manifest(mpath, manifest)
+
+    with pytest.raises(RuntimeError, match="drift"):
+        vec.upsert([1], [[0.0, 0.0, 0.0, 0.0]])
+
+    idx = FaissIndex(index_path, id_map_path, dim=4)
+    assert idx.ntotal == 0
+    assert idx.id_map == []
+
+
+def test_delete_does_not_mutate_index_when_manifest_drifts(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "openai_api_key", None, raising=False)
+    monkeypatch.setattr(settings, "st_embedding_model", "all-MiniLM-L6-v2", raising=False)
+
+    index_path = tmp_path / "index.faiss"
+    id_map_path = tmp_path / "id_map.json"
+    vec = FaissVectorStorage(str(index_path), str(id_map_path), dim=4)
+    vec.rebuild([1], [[0.0, 0.0, 0.0, 0.0]])
+
+    mpath = manifest_path_for(index_path)
+    manifest = read_manifest(mpath)
+    assert isinstance(manifest, dict)
+    manifest["chunker_version"] = "other-version"
+    write_manifest(mpath, manifest)
+
+    with pytest.raises(RuntimeError, match="drift"):
+        vec.delete([1])
+
+    idx = FaissIndex(index_path, id_map_path, dim=4)
+    assert idx.ntotal == 1
+    assert idx.id_map == [1]

--- a/tests/unit/test_cli_ingest.py
+++ b/tests/unit/test_cli_ingest.py
@@ -56,3 +56,48 @@ def test_cli_ingest_dir_mixed_is_idempotent_and_deletes_stale_chunks(
     docs3 = SqlDocumentStorage().get_all_documents()
     assert len(docs3) == 4  # 1 (txt) + 1 (md) + 2 (csv)
     assert sum(1 for d in docs3 if (d.source_id or "").endswith("a.txt")) == 1
+
+
+def test_cli_ingest_dense_embed_failure_does_not_persist_sql(
+    in_memory_sqlite, tmp_path, monkeypatch
+):
+    class BadEmbedder:
+        dim = 4
+
+        def embed(self, texts):
+            raise RuntimeError("embed fail")
+
+    class DummyVec:
+        def __init__(self, *a, **k):
+            return None
+
+        def delete(self, ids):
+            return None
+
+        def upsert(self, ids, vectors):
+            return None
+
+        def rebuild(self, ids, vectors):
+            return None
+
+    monkeypatch.setattr(settings, "retrieval_mode", "dense", raising=False)
+    monkeypatch.setattr(settings, "openai_api_key", "k", raising=False)
+    monkeypatch.setattr(
+        "local_rag_backend.infrastructure.embeddings.openai.OpenAIEmbedder",
+        lambda *a, **k: BadEmbedder(),
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "local_rag_backend.infrastructure.persistence.faiss.faiss_.FaissVectorStorage",
+        lambda *a, **k: DummyVec(),
+        raising=True,
+    )
+
+    root = tmp_path / "in"
+    root.mkdir()
+    (root / "a.txt").write_text("hello", encoding="utf-8")
+
+    r = CliRunner().invoke(cli, ["ingest", str(root), "--no-magic"])
+    assert r.exit_code == 1
+    assert "embed fail" in r.output
+    assert SqlDocumentStorage().get_all_documents() == []

--- a/tests/unit/test_cli_upsert_docs.py
+++ b/tests/unit/test_cli_upsert_docs.py
@@ -26,3 +26,27 @@ def test_cli_upsert_docs_from_json_file(in_memory_sqlite, tmp_path, monkeypatch)
     docs = SqlDocumentStorage().get_all_documents()
     assert len(docs) == 2
     assert {d.external_id for d in docs} == {"doc-1", "doc-2"}
+
+
+def test_cli_upsert_docs_dense_embed_failure_does_not_persist_sql(in_memory_sqlite, monkeypatch):
+    class BadEmbedder:
+        dim = 4
+
+        def embed(self, texts):
+            raise RuntimeError("embed fail")
+
+    monkeypatch.setattr(settings, "retrieval_mode", "dense", raising=False)
+    monkeypatch.setattr(settings, "openai_api_key", "k", raising=False)
+    monkeypatch.setattr(
+        "local_rag_backend.infrastructure.embeddings.openai.OpenAIEmbedder",
+        lambda *a, **k: BadEmbedder(),
+        raising=True,
+    )
+
+    r = CliRunner().invoke(
+        cli,
+        ["upsert-docs", "--external-id", "doc-1", "--content", "hello"],
+    )
+    assert r.exit_code == 1
+    assert "embed fail" in r.output
+    assert SqlDocumentStorage().get_all_documents() == []


### PR DESCRIPTION

Base: `pr/02-2026-10` (stacked PR).

## Contexto
Durante la auditoría técnica se detectaron riesgos críticos de consistencia en operaciones mutantes concurrentes y validación insuficiente de parámetros de generación.

## Cambios principales

### 1) Serialización de escrituras multi-store (SQL + FAISS)
- Nuevo lock cross-process/thread: `src/local_rag_backend/core/services/write_lock.py`.
- Los paths mutantes de API se ejecutan bajo lock compartido:
  - `POST /api/docs`
  - `POST /api/docs/upsert`
  - `POST /api/docs/delete`
  - `POST /api/docs/delete_by_external_id`
  - `POST /api/index/rebuild`
- Objetivo: evitar interleavings que dejen drift entre SQL e índice vectorial.

### 2) Hardening de parámetros de generación
- `OpenRouterGenerateRequest` ahora valida rangos:
  - `temperature` en `[0.0, 2.0]`
  - `top_p` en `[0.0, 1.0]`
  - `max_tokens` en `[1, 4096]`
- `AskEvalConfig.top_p` ahora también se valida en `[0.0, 1.0]`.
- `validate_rag_config()` incluye check explícito de `top_p`.

## Tests añadidos/actualizados
- Nuevo: `tests/unit/app/test_multistore_write_lock.py`
  - Reproduce concurrencia forzada y valida consistencia final SQL/vector.
- Actualizado: `tests/unit/app/test_request_limits.py`
  - Rechazo de sampling params inválidos para OpenRouter.
- Actualizado: `tests/unit/app/test_api_router_more.py`
  - Casos inválidos de `top_p` en `ask_eval`.

## Verificación
- `pytest -q` ✅ (255 passed, cobertura 85.29%)
- `ruff check src tests` ✅
- `black --check src tests` ✅
- `mypy src` ✅
- `isort --check-only src tests` ✅ (luego se arregló y commiteó)

## Commits incluidos
- `5fa6c06` fix: prevent SQL/vector drift when embedding fails
- `fd412d8` fix: harden rag service reload token writes
- `9a33cb7` fix(api): serialize multi-store writes and harden generation params
- `69e715a` chore: fix import ordering and include roadmap updates
