### PR TITLE
breaking: harden bootstrap/eval + health/readiness contract cleanup

### DIFF
--- a/BETA_TEST_PLAN.md
+++ b/BETA_TEST_PLAN.md
@@ -1,0 +1,1010 @@
+# Beta-Test Plan — RAG Prototype v1.3.0
+> Aliado hostil: el objetivo es romper el sistema, no confirmarlo.
+> Ejecutar en orden: cada sección asume el estado del anterior salvo que se indique reset.
+
+---
+
+## Preparación del entorno
+
+```bash
+# Directorio de trabajo temporal con estado limpio
+export TEST_DIR=$(mktemp -d /tmp/rag-beta-XXXXXX)
+export SQLITE_URL="sqlite:///$TEST_DIR/test.db"
+export INDEX_PATH="$TEST_DIR/faiss.index"
+export ID_MAP_PATH="$TEST_DIR/id_map.json"
+export DATA_DIR="$TEST_DIR/data"
+
+mkdir -p "$TEST_DIR"
+
+# Instalar en entorno limpio
+cd /path/to/rag-prototype
+uv sync --extra server
+
+# Alias para no repetir vars
+alias rag-cli="uv run --no-sync"
+```
+
+### Datasets sintéticos
+
+```bash
+# FAQ mínima (3 entradas)
+cat > "$TEST_DIR/faq_small.csv" << 'EOF'
+question,answer
+What is the refund policy?,We offer 30-day full refunds.
+How do I reset my password?,Click "Forgot password" on the login page.
+Where are your servers located?,Our servers are in Frankfurt and Virginia.
+EOF
+
+# CSV sin cabecera (para probar CSV_HAS_HEADER=false)
+cat > "$TEST_DIR/faq_no_header.csv" << 'EOF'
+Shipping times?,Standard shipping takes 5-7 business days.
+Do you ship internationally?,Yes, to 40+ countries.
+EOF
+
+# Texto plano largo (para chunking)
+python3 -c "
+import textwrap, random, string
+paras = ['\\n\\n'.join(' '.join(random.choices(string.ascii_lowercase + ' ', k=200)) for _ in range(5)) for _ in range(10)]
+print('\\n\\n'.join(paras))
+" > "$TEST_DIR/long_doc.txt"
+
+# Markdown con headers
+cat > "$TEST_DIR/sample.md" << 'EOF'
+# Introduction
+
+This is the introduction section with some content.
+
+## Section One
+
+Details about section one including important information.
+
+## Section Two
+
+More details and specifics about section two.
+
+### Subsection
+
+Even more granular information here.
+EOF
+
+# Archivo binario (trampa)
+dd if=/dev/urandom bs=1024 count=4 > "$TEST_DIR/binary_trap.bin" 2>/dev/null
+
+# Archivo vacío (trampa)
+touch "$TEST_DIR/empty_file.txt"
+
+# Archivo con sólo whitespace
+printf "   \n\t\n   " > "$TEST_DIR/whitespace_only.txt"
+
+# CSV con filas corruptas mezcladas
+cat > "$TEST_DIR/mixed_corrupt.csv" << 'EOF'
+question,answer
+Valid question one?,Valid answer one.
+,Missing question field answer.
+Only one column here
+"Unclosed quote,broken csv
+Valid question two?,Valid answer two.
+EOF
+
+# JSON para mutate (válido)
+cat > "$TEST_DIR/mutate_valid.json" << 'EOF'
+{
+  "intents": [
+    {
+      "operation": "upsert",
+      "external_id": "beta-doc-001",
+      "content": "This is test document 001 for beta testing.",
+      "metadata": {"source": "beta-test", "version": "1"}
+    },
+    {
+      "operation": "upsert",
+      "external_id": "beta-doc-002",
+      "content": "This is test document 002 covering different topics.",
+      "metadata": {"source": "beta-test", "version": "1"}
+    },
+    {
+      "operation": "upsert",
+      "external_id": "beta-doc-003",
+      "content": "Third document about system reliability and uptime.",
+      "metadata": {"source": "beta-test", "version": "1"}
+    }
+  ]
+}
+EOF
+
+# JSON mutate — sólo deletions
+cat > "$TEST_DIR/mutate_delete_only.json" << 'EOF'
+{
+  "intents": [
+    {"operation": "delete", "external_id": "beta-doc-001"},
+    {"operation": "delete", "external_id": "nonexistent-999"}
+  ]
+}
+EOF
+
+# JSON mutate — lista vacía (debe rechazarse o ser noop limpio)
+cat > "$TEST_DIR/mutate_empty.json" << 'EOF'
+{"intents": []}
+EOF
+
+# JSON mutate — mismo external_id upsert+delete en la misma request
+cat > "$TEST_DIR/mutate_conflict.json" << 'EOF'
+{
+  "intents": [
+    {"operation": "upsert", "external_id": "conflict-id", "content": "Some content here."},
+    {"operation": "delete", "external_id": "conflict-id"}
+  ]
+}
+EOF
+
+# JSON mutate — contenido vacío en upsert
+cat > "$TEST_DIR/mutate_empty_content.json" << 'EOF'
+{
+  "intents": [
+    {"operation": "upsert", "external_id": "empty-content-001", "content": ""}
+  ]
+}
+EOF
+
+# JSONL de eval con un hit seguro y otro imposible
+cat > "$TEST_DIR/eval_small.jsonl" << 'EOF'
+{"question": "What is the refund policy?", "expected_doc_ids": ["beta-doc-001"], "expected_answer_contains": "refund"}
+{"question": "ajsdflkajsdfkljasdflkj this cannot match anything", "expected_doc_ids": ["nonexistent"], "expected_answer_contains": "xyz"}
+{"question": "Tell me about system reliability", "expected_doc_ids": ["beta-doc-003"], "expected_answer_contains": "reliability"}
+EOF
+```
+
+---
+
+## Bloque 1 — Estado inicial y bootstrap
+
+### B1.1 — Status en DB vacía (estado cero)
+
+```bash
+SQLITE_URL=$SQLITE_URL INDEX_PATH=$INDEX_PATH ID_MAP_PATH=$ID_MAP_PATH \
+  uv run rag-status
+```
+
+**Expectativa:** Debe arrancar sin crash. Debe reportar 0 documentos, sin índice, sin journal entries. No debe hacer ruidos en stderr sobre tablas inexistentes.
+
+**Señal de alerta:** Excepción SQLAlchemy, traceback no capturado, mensaje de error opaco.
+
+---
+
+### B1.2 — Bootstrap con CSV mínimo
+
+```bash
+FAZ_CSV="$TEST_DIR/faq_small.csv" SQLITE_URL=$SQLITE_URL \
+  INDEX_PATH=$INDEX_PATH ID_MAP_PATH=$ID_MAP_PATH \
+  uv run rag-bootstrap
+```
+
+**Expectativa:** 3 documentos ingestados, log estructurado, sin prints, exit 0.
+
+**Inspeccionar:** ¿El external_id generado sigue el esquema esperado (prefijo + contenido)? ¿Hay dedup correcto si se vuelve a ejecutar inmediatamente?
+
+---
+
+### B1.3 — Bootstrap idempotente (segunda ejecución)
+
+```bash
+# Ejecutar dos veces seguidas
+FAZ_CSV="$TEST_DIR/faq_small.csv" SQLITE_URL=$SQLITE_URL \
+  INDEX_PATH=$INDEX_PATH ID_MAP_PATH=$ID_MAP_PATH \
+  uv run rag-bootstrap
+
+FAZ_CSV="$TEST_DIR/faq_small.csv" SQLITE_URL=$SQLITE_URL \
+  INDEX_PATH=$INDEX_PATH ID_MAP_PATH=$ID_MAP_PATH \
+  uv run rag-bootstrap
+```
+
+**Expectativa:** Segunda ejecución = 0 nuevos documentos (dedup por chunk_dedup_sha256). Ningún error de unique constraint de SQLite.
+
+**Señal de alerta:** Duplicados en DB, excepción UNIQUE, crash.
+
+---
+
+### B1.4 — Bootstrap con CSV sin cabecera (CSV_HAS_HEADER=false)
+
+```bash
+FAZ_CSV="$TEST_DIR/faq_no_header.csv" CSV_HAS_HEADER=false \
+  SQLITE_URL=$SQLITE_URL INDEX_PATH=$INDEX_PATH ID_MAP_PATH=$ID_MAP_PATH \
+  uv run rag-bootstrap
+```
+
+**Expectativa:** 2 documentos adicionales ingestados, primera columna como question.
+
+---
+
+### B1.5 — Bootstrap con archivo inexistente
+
+```bash
+FAZ_CSV="/nonexistent/path/file.csv" SQLITE_URL=$SQLITE_URL \
+  INDEX_PATH=$INDEX_PATH ID_MAP_PATH=$ID_MAP_PATH \
+  uv run rag-bootstrap
+```
+
+**Expectativa:** Error claro (FileNotFoundError o mensaje de usuario), exit != 0. Sin traceback crudo al usuario final.
+
+---
+
+## Bloque 2 — Ingest (pipeline completa)
+
+### B2.1 — Ingest de múltiples formatos
+
+```bash
+SQLITE_URL=$SQLITE_URL INDEX_PATH=$INDEX_PATH ID_MAP_PATH=$ID_MAP_PATH \
+  uv run rag-ingest "$TEST_DIR/long_doc.txt" "$TEST_DIR/sample.md"
+```
+
+**Expectativa:** Chunking aplicado al `.txt` largo, log con conteo de chunks por archivo. `.md` ingestado como chunks por sección.
+
+**Verificar:** `rag-status` muestra conteo incrementado.
+
+---
+
+### B2.2 — Ingest de archivo vacío
+
+```bash
+SQLITE_URL=$SQLITE_URL INDEX_PATH=$INDEX_PATH ID_MAP_PATH=$ID_MAP_PATH \
+  uv run rag-ingest "$TEST_DIR/empty_file.txt"
+```
+
+**Expectativa:** Warn/skip del archivo, exit 0 (no debe crashear). 0 documentos nuevos.
+
+---
+
+### B2.3 — Ingest de archivo con sólo whitespace
+
+```bash
+SQLITE_URL=$SQLITE_URL INDEX_PATH=$INDEX_PATH ID_MAP_PATH=$ID_MAP_PATH \
+  uv run rag-ingest "$TEST_DIR/whitespace_only.txt"
+```
+
+**Expectativa:** Igual que B2.2 — skip limpio. El chunk tras limpieza de whitespace debe quedar vacío y descartarse.
+
+---
+
+### B2.4 — Ingest de archivo binario
+
+```bash
+SQLITE_URL=$SQLITE_URL INDEX_PATH=$INDEX_PATH ID_MAP_PATH=$ID_MAP_PATH \
+  uv run rag-ingest "$TEST_DIR/binary_trap.bin"
+```
+
+**Expectativa:** UnicodeDecodeError capturado, log de warning, skip del archivo, exit 0.
+
+**Señal de alerta:** Crash, o peor: contenido binario persistido como "documento".
+
+---
+
+### B2.5 — Ingest de directorio completo (incluyendo trampas)
+
+```bash
+SQLITE_URL=$SQLITE_URL INDEX_PATH=$INDEX_PATH ID_MAP_PATH=$ID_MAP_PATH \
+  uv run rag-ingest "$TEST_DIR"
+```
+
+**Expectativa:** Procesa `.txt`, `.md`, `.csv` del directorio; skip de `.bin`, `.json`, `.jsonl`. Logging por archivo. Exit 0 aunque algunos fallen.
+
+---
+
+### B2.6 — Ingest del mismo archivo dos veces (dedup)
+
+```bash
+SQLITE_URL=$SQLITE_URL INDEX_PATH=$INDEX_PATH ID_MAP_PATH=$ID_MAP_PATH \
+  uv run rag-ingest "$TEST_DIR/sample.md"
+
+SQLITE_URL=$SQLITE_URL INDEX_PATH=$INDEX_PATH ID_MAP_PATH=$ID_MAP_PATH \
+  uv run rag-ingest "$TEST_DIR/sample.md"
+```
+
+**Expectativa:** Segunda ejecución → 0 documentos nuevos (dedup por sha256). No duplicados.
+
+---
+
+### B2.7 — Ingest de ruta inexistente
+
+```bash
+SQLITE_URL=$SQLITE_URL INDEX_PATH=$INDEX_PATH ID_MAP_PATH=$ID_MAP_PATH \
+  uv run rag-ingest "/nonexistent/path/to/file.txt"
+```
+
+**Expectativa:** Error claro, exit != 0.
+
+---
+
+## Bloque 3 — Mutate (mutation saga + journal)
+
+### B3.1 — Mutación válida (upserts)
+
+```bash
+SQLITE_URL=$SQLITE_URL INDEX_PATH=$INDEX_PATH ID_MAP_PATH=$ID_MAP_PATH \
+  uv run rag-mutate-docs "$TEST_DIR/mutate_valid.json"
+```
+
+**Expectativa:** 3 documentos persistidos, journal entries en estado `COMMITTED`, log de cada intent. Exit 0.
+
+**Verificar:** `rag-status` muestra +3 documentos.
+
+---
+
+### B3.2 — Lista de intents vacía
+
+```bash
+SQLITE_URL=$SQLITE_URL INDEX_PATH=$INDEX_PATH ID_MAP_PATH=$ID_MAP_PATH \
+  uv run rag-mutate-docs "$TEST_DIR/mutate_empty.json"
+```
+
+**Expectativa:** Noop limpio (0 documentos modificados) O error de validación. No debe crashear ni dejar journal en estado inconsistente.
+
+---
+
+### B3.3 — Contenido vacío en upsert
+
+```bash
+SQLITE_URL=$SQLITE_URL INDEX_PATH=$INDEX_PATH ID_MAP_PATH=$ID_MAP_PATH \
+  uv run rag-mutate-docs "$TEST_DIR/mutate_empty_content.json"
+```
+
+**Expectativa:** `BadRequestError` o `UnprocessableEntityError` con mensaje claro. No debe persistir un documento con contenido vacío ni generar embeddings para texto vacío.
+
+---
+
+### B3.4 — Upsert y delete del mismo external_id en la misma request
+
+```bash
+SQLITE_URL=$SQLITE_URL INDEX_PATH=$INDEX_PATH ID_MAP_PATH=$ID_MAP_PATH \
+  uv run rag-mutate-docs "$TEST_DIR/mutate_conflict.json"
+```
+
+**Expectativa:** O bien: error de validación pre-ejecución (el contrato rechaza intents conflictivos), o bien: orden determinista (upsert → delete = documento eliminado). Documentar el comportamiento real.
+
+**Señal de alerta:** Documento queda en estado ambiguo (ni vivo ni tombstone), crash, o comportamiento no determinista entre runs.
+
+---
+
+### B3.5 — Delete de external_id inexistente
+
+```bash
+# Crear un JSON con sólo delete de ID no existente
+cat > "$TEST_DIR/mutate_nonexistent_delete.json" << 'EOF'
+{
+  "intents": [
+    {"operation": "delete", "external_id": "id-that-does-not-exist-99999"}
+  ]
+}
+EOF
+
+SQLITE_URL=$SQLITE_URL INDEX_PATH=$INDEX_PATH ID_MAP_PATH=$ID_MAP_PATH \
+  uv run rag-mutate-docs "$TEST_DIR/mutate_nonexistent_delete.json"
+```
+
+**Expectativa:** Respuesta exitosa con `deleted_count: 0` (idempotente), O `NotFoundError` explícito. No debe crashear.
+
+---
+
+### B3.6 — Re-ingest de external_id tombstoneado
+
+```bash
+# Primero eliminar beta-doc-001 (del B3.1)
+SQLITE_URL=$SQLITE_URL INDEX_PATH=$INDEX_PATH ID_MAP_PATH=$ID_MAP_PATH \
+  uv run rag-mutate-docs "$TEST_DIR/mutate_delete_only.json"
+
+# Luego intentar upsert del mismo external_id
+cat > "$TEST_DIR/mutate_tombstone_reingest.json" << 'EOF'
+{
+  "intents": [
+    {
+      "operation": "upsert",
+      "external_id": "beta-doc-001",
+      "content": "Attempting to reingest a tombstoned document.",
+      "metadata": {}
+    }
+  ]
+}
+EOF
+
+SQLITE_URL=$SQLITE_URL INDEX_PATH=$INDEX_PATH ID_MAP_PATH=$ID_MAP_PATH \
+  uv run rag-mutate-docs "$TEST_DIR/mutate_tombstone_reingest.json"
+```
+
+**Expectativa según CHANGELOG:** "deleting by external_id creates tombstones and blocks future re-ingest/upsert". Debe devolver `ConflictError` o similar, no silenciosamente ignorarlo.
+
+**Señal de alerta:** El documento resucita sin advertencia, o peor, el upsert tiene éxito silencioso.
+
+---
+
+### B3.7 — Mutate con JSON malformado
+
+```bash
+echo '{"intents": [{"operation": "upsert"' | \
+  SQLITE_URL=$SQLITE_URL INDEX_PATH=$INDEX_PATH ID_MAP_PATH=$ID_MAP_PATH \
+  uv run rag-mutate-docs /dev/stdin
+```
+
+**Expectativa:** Error de parseo JSON claro, exit != 0.
+
+---
+
+## Bloque 4 — Index (rebuild + status)
+
+### B4.1 — Rebuild en modo sparse (RETRIEVAL_MODE=sparse)
+
+```bash
+RETRIEVAL_MODE=sparse SQLITE_URL=$SQLITE_URL \
+  INDEX_PATH=$INDEX_PATH ID_MAP_PATH=$ID_MAP_PATH \
+  uv run rag-rebuild-index
+```
+
+**Expectativa:** Noop con mensaje informativo ("sparse mode does not require index rebuild"), O error controlado. No debe intentar escribir archivos FAISS en modo sparse.
+
+---
+
+### B4.2 — Rebuild en modo dense (RETRIEVAL_MODE=dense) con documentos existentes
+
+```bash
+RETRIEVAL_MODE=dense SQLITE_URL=$SQLITE_URL \
+  INDEX_PATH=$INDEX_PATH ID_MAP_PATH=$ID_MAP_PATH \
+  uv run rag-rebuild-index
+```
+
+**Expectativa:** FAISS index reconstruido desde SQLite, id_map.json actualizado, log de progreso con batch size, exit 0.
+
+**Verificar:** Los archivos `faiss.index` y `id_map.json` existen y tienen tamaño > 0.
+
+---
+
+### B4.3 — Rebuild en DB vacía (sin documentos)
+
+```bash
+export EMPTY_DIR=$(mktemp -d /tmp/rag-empty-XXXXXX)
+RETRIEVAL_MODE=dense SQLITE_URL="sqlite:///$EMPTY_DIR/empty.db" \
+  INDEX_PATH="$EMPTY_DIR/faiss.index" ID_MAP_PATH="$EMPTY_DIR/id_map.json" \
+  uv run rag-rebuild-index
+```
+
+**Expectativa:** Graceful handling — "0 documents, nothing to index" o similar. No debe crear un FAISS index vacío y luego romperse en queries posteriores.
+
+---
+
+### B4.4 — Status post-rebuild
+
+```bash
+RETRIEVAL_MODE=dense SQLITE_URL=$SQLITE_URL \
+  INDEX_PATH=$INDEX_PATH ID_MAP_PATH=$ID_MAP_PATH \
+  uv run rag-status
+```
+
+**Expectativa:** `ntotal` del índice FAISS coincide con el número de documentos en SQLite (no > no <). Sin drift detectado.
+
+---
+
+### B4.5 — Drift detection: ingest sin rebuild
+
+```bash
+# Ingest nuevo documento sin reconstruir el índice
+cat > "$TEST_DIR/new_doc.txt" << 'EOF'
+This is a brand new document that was ingested after the last index rebuild.
+It should appear as a drift between SQL document count and FAISS index total.
+EOF
+
+SQLITE_URL=$SQLITE_URL INDEX_PATH=$INDEX_PATH ID_MAP_PATH=$ID_MAP_PATH \
+  uv run rag-ingest "$TEST_DIR/new_doc.txt"
+
+RETRIEVAL_MODE=dense SQLITE_URL=$SQLITE_URL \
+  INDEX_PATH=$INDEX_PATH ID_MAP_PATH=$ID_MAP_PATH \
+  uv run rag-status
+```
+
+**Expectativa:** `rag-status` detecta drift (SQL count > FAISS ntotal) y lo reporta como advertencia. No debe crashear ni silenciarlo.
+
+---
+
+## Bloque 5 — Eval pipeline
+
+### B5.1 — Eval con dataset pequeño (sparse mode)
+
+```bash
+# Asegurarse de que los docs del eval estén ingestados
+SQLITE_URL=$SQLITE_URL INDEX_PATH=$INDEX_PATH ID_MAP_PATH=$ID_MAP_PATH \
+  uv run rag-mutate-docs "$TEST_DIR/mutate_valid.json"
+
+RETRIEVAL_MODE=sparse SQLITE_URL=$SQLITE_URL \
+  INDEX_PATH=$INDEX_PATH ID_MAP_PATH=$ID_MAP_PATH \
+  uv run rag-eval --dataset "$TEST_DIR/eval_small.jsonl"
+```
+
+**Expectativa:** Hit rate y MRR reportados. El segundo query (imposible de matchear) debe bajar el hit rate. Exit 0 aunque hit rate sea 0.
+
+---
+
+### B5.2 — Eval con dataset del repo (golden)
+
+```bash
+RETRIEVAL_MODE=sparse SQLITE_URL=$SQLITE_URL \
+  INDEX_PATH=$INDEX_PATH ID_MAP_PATH=$ID_MAP_PATH \
+  uv run rag-eval --dataset datasets/rag_eval_v1.jsonl
+```
+
+**Expectativa:** Resultados coherentes. Comparar vs. baseline documentado (si existe).
+
+---
+
+### B5.3 — Eval con JSONL malformado
+
+```bash
+cat > "$TEST_DIR/eval_corrupt.jsonl" << 'EOF'
+{"question": "Valid question?", "expected_doc_ids": ["doc1"]}
+{invalid json here
+{"question": "Another valid?", "expected_doc_ids": ["doc2"]}
+EOF
+
+RETRIEVAL_MODE=sparse SQLITE_URL=$SQLITE_URL \
+  uv run rag-eval --dataset "$TEST_DIR/eval_corrupt.jsonl"
+```
+
+**Expectativa:** Salta la línea corrupta con warning, procesa las válidas, reporta métricas parciales. No debe crashear.
+
+---
+
+### B5.4 — Eval con dataset vacío
+
+```bash
+touch "$TEST_DIR/eval_empty.jsonl"
+RETRIEVAL_MODE=sparse SQLITE_URL=$SQLITE_URL \
+  uv run rag-eval --dataset "$TEST_DIR/eval_empty.jsonl"
+```
+
+**Expectativa:** "0 records evaluated" con mensaje claro. No división por cero en métricas.
+
+---
+
+## Bloque 6 — HTTP API (servidor levantado)
+
+> Iniciar servidor en terminal separada:
+> ```bash
+> RETRIEVAL_MODE=sparse SQLITE_URL=$SQLITE_URL INDEX_PATH=$INDEX_PATH \
+>   ID_MAP_PATH=$ID_MAP_PATH DEBUG=true \
+>   uv run rag-server --host 127.0.0.1 --port 8765
+> ```
+
+```bash
+export API_BASE="http://127.0.0.1:8765/api"
+```
+
+### B6.1 — Health y readiness básica
+
+```bash
+curl -s "$API_BASE/health" | python3 -m json.tool
+curl -s "$API_BASE/ready" | python3 -m json.tool
+curl -s "$API_BASE/health/ollama" | python3 -m json.tool
+```
+
+**Expectativa:**
+- `/health`: `{"status": "ok"}` siempre que la DB sea accesible.
+- `/ready`: Puede reportar Ollama como no disponible (si no está corriendo), pero el campo debe existir y el estado debe ser legible.
+- `/health/ollama`: `{"available": false}` si Ollama no está corriendo — no debe crashear.
+
+---
+
+### B6.2 — Config y templates
+
+```bash
+curl -s "$API_BASE/config" | python3 -m json.tool
+curl -s "$API_BASE/templates" | python3 -m json.tool
+```
+
+**Expectativa:** JSON válido con los campos esperados. `retrieval_mode: "sparse"` refleja la config del entorno.
+
+---
+
+### B6.3 — Ask con Ollama sin correr
+
+```bash
+curl -s -X POST "$API_BASE/ask" \
+  -H "Content-Type: application/json" \
+  -d '{"question": "What is the refund policy?", "k": 3}' | python3 -m json.tool
+```
+
+**Expectativa:** Si Ollama no está disponible, debe devolver HTTP 503 con mensaje claro. No un 500 con traceback en el body. Los retrieved documents pueden mostrarse aunque la generación falle (si el sistema lo soporta).
+
+---
+
+### B6.4 — Ask con pregunta vacía
+
+```bash
+curl -s -X POST "$API_BASE/ask" \
+  -H "Content-Type: application/json" \
+  -d '{"question": "", "k": 3}' | python3 -m json.tool
+```
+
+**Expectativa:** HTTP 400/422 con mensaje de validación. No 500.
+
+---
+
+### B6.5 — Ask con k=0 y k negativo
+
+```bash
+curl -s -X POST "$API_BASE/ask" \
+  -H "Content-Type: application/json" \
+  -d '{"question": "Test", "k": 0}' | python3 -m json.tool
+
+curl -s -X POST "$API_BASE/ask" \
+  -H "Content-Type: application/json" \
+  -d '{"question": "Test", "k": -1}' | python3 -m json.tool
+```
+
+**Expectativa:** HTTP 422 de Pydantic, no crash.
+
+---
+
+### B6.6 — Ask con k > total de documentos
+
+```bash
+curl -s -X POST "$API_BASE/ask" \
+  -H "Content-Type: application/json" \
+  -d '{"question": "Test reliability", "k": 9999}' | python3 -m json.tool
+```
+
+**Expectativa:** Responde con todos los documentos disponibles (k clipped a ntotal) sin error. O error controlado si FAISS no admite k > ntotal.
+
+---
+
+### B6.7 — List docs y history paginados
+
+```bash
+# Primera página
+curl -s "$API_BASE/docs?limit=2&offset=0" | python3 -m json.tool
+# Segunda página
+curl -s "$API_BASE/docs?limit=2&offset=2" | python3 -m json.tool
+# Límite 0 (borde)
+curl -s "$API_BASE/docs?limit=0" | python3 -m json.tool
+# Límite negativo
+curl -s "$API_BASE/docs?limit=-1" | python3 -m json.tool
+
+curl -s "$API_BASE/history?limit=10&offset=0" | python3 -m json.tool
+```
+
+**Expectativa:** Paginación coherente, `limit=0` y `limit=-1` son 422 o devuelven lista vacía (documentar comportamiento real).
+
+---
+
+### B6.8 — Docs mutate via API
+
+```bash
+# Upsert válido
+curl -s -X POST "$API_BASE/docs/mutate" \
+  -H "Content-Type: application/json" \
+  -d @"$TEST_DIR/mutate_valid.json" | python3 -m json.tool
+
+# Lista vacía
+curl -s -X POST "$API_BASE/docs/mutate" \
+  -H "Content-Type: application/json" \
+  -d '{"intents": []}' | python3 -m json.tool
+
+# Contenido vacío
+curl -s -X POST "$API_BASE/docs/mutate" \
+  -H "Content-Type: application/json" \
+  -d '{"intents": [{"operation": "upsert", "external_id": "x", "content": ""}]}' | python3 -m json.tool
+```
+
+---
+
+### B6.9 — Import de archivo via API (multipart)
+
+```bash
+# TXT válido
+curl -s -X POST "$API_BASE/docs/import" \
+  -F "file=@$TEST_DIR/sample.md;type=text/markdown" | python3 -m json.tool
+
+# Archivo vacío
+curl -s -X POST "$API_BASE/docs/import" \
+  -F "file=@$TEST_DIR/empty_file.txt;type=text/plain" | python3 -m json.tool
+
+# Archivo binario
+curl -s -X POST "$API_BASE/docs/import" \
+  -F "file=@$TEST_DIR/binary_trap.bin;type=application/octet-stream" | python3 -m json.tool
+
+# Archivo demasiado grande (generar 11MB > límite típico de 10MB)
+dd if=/dev/urandom bs=1024 count=11264 2>/dev/null | base64 > "$TEST_DIR/too_large.txt"
+curl -s -X POST "$API_BASE/docs/import" \
+  -F "file=@$TEST_DIR/too_large.txt;type=text/plain" | python3 -m json.tool
+```
+
+**Expectativa:** `too_large.txt` → HTTP 413/422 `PayloadTooLargeError`. Binario → 422 con mensaje de unsupported format o decode error.
+
+---
+
+### B6.10 — Index rebuild via API
+
+```bash
+# En modo sparse (debe ser noop o error controlado)
+curl -s -X POST "$API_BASE/index/rebuild" | python3 -m json.tool
+```
+
+---
+
+### B6.11 — Autenticación (API_KEY enforcement)
+
+```bash
+# Reiniciar servidor con API_KEY configurado
+# CTRL+C el servidor anterior, luego:
+# API_KEY=supersecret RETRIEVAL_MODE=sparse SQLITE_URL=$SQLITE_URL \
+#   INDEX_PATH=$INDEX_PATH ID_MAP_PATH=$ID_MAP_PATH \
+#   uv run rag-server --host 127.0.0.1 --port 8765
+
+# Sin key → 401/403
+curl -s "$API_BASE/health" | python3 -m json.tool
+curl -s "$API_BASE/ask" -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"question": "test", "k": 1}' | python3 -m json.tool
+
+# Con key incorrecta → 401/403
+curl -s "$API_BASE/ask" -X POST \
+  -H "X-API-Key: wrongkey" \
+  -H "Content-Type: application/json" \
+  -d '{"question": "test", "k": 1}' | python3 -m json.tool
+
+# Con key correcta → funciona
+curl -s "$API_BASE/ask" -X POST \
+  -H "X-API-Key: supersecret" \
+  -H "Content-Type: application/json" \
+  -d '{"question": "test", "k": 1}' | python3 -m json.tool
+```
+
+**Expectativa:** Sin key o key incorrecta → HTTP 401 con body JSON, nunca 500. `/health` puede ser pública (verificar).
+
+---
+
+### B6.12 — Concurrent mutations (race condition)
+
+```bash
+# 5 requests de mutate concurrentes con external_ids distintos
+for i in $(seq 1 5); do
+  cat > "$TEST_DIR/concurrent_$i.json" << EOF
+{
+  "intents": [
+    {
+      "operation": "upsert",
+      "external_id": "concurrent-doc-$i",
+      "content": "Concurrent document number $i for race condition testing.",
+      "metadata": {"batch": "$i"}
+    }
+  ]
+}
+EOF
+done
+
+# Lanzar en paralelo
+for i in $(seq 1 5); do
+  curl -s -X POST "$API_BASE/docs/mutate" \
+    -H "Content-Type: application/json" \
+    -d @"$TEST_DIR/concurrent_$i.json" &
+done
+wait
+
+# Verificar que los 5 documentos existen y no hay duplicados
+curl -s "$API_BASE/docs?limit=50" | python3 -m json.tool | grep -c "concurrent-doc"
+```
+
+**Expectativa:** Los 5 documentos existen exactamente 1 vez cada uno. No hay deadlocks ni errores de lock acquisition. Journal en estado COMMITTED para todos.
+
+---
+
+### B6.13 — OpenRouter proxy (sin API key)
+
+```bash
+curl -s -X POST "$API_BASE/openrouter/generate" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "openai/gpt-3.5-turbo",
+    "messages": [{"role": "user", "content": "Hello"}],
+    "max_tokens": 50
+  }' | python3 -m json.tool
+```
+
+**Expectativa:** HTTP 503 o 502 con mensaje claro sobre OPENROUTER_API_KEY no configurado. No un timeout de 30s, no un 500 genérico.
+
+---
+
+## Bloque 7 — Recovery y resiliencia
+
+### B7.1 — Arranque con archivos FAISS corruptos
+
+```bash
+# Corromper el índice FAISS existente
+echo "THIS IS NOT A FAISS INDEX" > $INDEX_PATH
+
+RETRIEVAL_MODE=dense SQLITE_URL=$SQLITE_URL \
+  INDEX_PATH=$INDEX_PATH ID_MAP_PATH=$ID_MAP_PATH \
+  uv run rag-status
+```
+
+**Expectativa:** Error detectado en startup/status, mensaje de "index corrupted or missing, rebuild required". No crash, no silencio.
+
+---
+
+### B7.2 — Arranque con id_map.json malformado
+
+```bash
+echo '{"this_is": "not a valid id map"}' > $ID_MAP_PATH
+
+RETRIEVAL_MODE=dense SQLITE_URL=$SQLITE_URL \
+  INDEX_PATH=$INDEX_PATH ID_MAP_PATH=$ID_MAP_PATH \
+  uv run rag-status
+```
+
+**Expectativa:** Error capturado, solicitud de rebuild o mensaje claro. No IndexError al acceder a campos del id_map.
+
+---
+
+### B7.3 — id_map.json vacío vs. index FAISS válido (mismatch)
+
+```bash
+# Reconstruir index limpio primero
+RETRIEVAL_MODE=dense SQLITE_URL=$SQLITE_URL \
+  INDEX_PATH=$INDEX_PATH ID_MAP_PATH=$ID_MAP_PATH \
+  uv run rag-rebuild-index
+
+# Luego vaciar el id_map
+echo '{}' > $ID_MAP_PATH
+
+# Intentar un ask
+curl -s -X POST "$API_BASE/ask" \
+  -H "Content-Type: application/json" \
+  -d '{"question": "refund policy", "k": 3}' | python3 -m json.tool
+```
+
+**Expectativa:** Error de validación de consistencia (ids/embeddings length mismatch), HTTP 503 o mensaje de "index requires rebuild". No `IndexError: list index out of range`.
+
+---
+
+### B7.4 — Simular crash mid-mutation via journal
+
+```bash
+# Verificar que el journal recovery funciona si hay entradas en PREPARED/IN_PROGRESS
+# (Requiere inspección directa de la DB si el CLI expone esto)
+RETRIEVAL_MODE=sparse SQLITE_URL=$SQLITE_URL \
+  INDEX_PATH=$INDEX_PATH ID_MAP_PATH=$ID_MAP_PATH \
+  uv run rag-status
+```
+
+**Buscar en el log:** Mensajes de `mutation_recovery` al arrancar. Verificar que las entradas en estado `PREPARED` se resetean con warning (no silenciosamente, no crash).
+
+---
+
+## Bloque 8 — Configuración y settings edge cases
+
+### B8.1 — Variables de entorno inválidas
+
+```bash
+# Puerto inválido
+APP_PORT=99999 uv run rag-server 2>&1 | head -5
+
+# Temperatura fuera de rango
+OPENAI_TEMPERATURE=5.0 RETRIEVAL_MODE=sparse SQLITE_URL=$SQLITE_URL \
+  uv run rag-status 2>&1 | head -5
+
+# Modo de retrieval inválido
+RETRIEVAL_MODE=unicorn SQLITE_URL=$SQLITE_URL \
+  uv run rag-status 2>&1 | head -5
+```
+
+**Expectativa:** Validación de Pydantic Settings en startup, mensaje claro de qué campo es inválido, exit != 0.
+
+---
+
+### B8.2 — SQLITE_URL apuntando a directorio sin permisos de escritura
+
+```bash
+SQLITE_URL="sqlite:////root/no_access/test.db" \
+  uv run rag-status 2>&1 | head -10
+```
+
+**Expectativa:** Error de permisos capturado con mensaje claro, no traceback de SQLAlchemy crudo.
+
+---
+
+### B8.3 — INGEST_BATCH_SIZE extremos
+
+```bash
+# Batch size 1 (ingest muy lento pero correcto)
+INGEST_BATCH_SIZE=1 SQLITE_URL=$SQLITE_URL \
+  INDEX_PATH=$INDEX_PATH ID_MAP_PATH=$ID_MAP_PATH \
+  uv run rag-ingest "$TEST_DIR/sample.md"
+
+# Batch size muy grande (mayor que el total de docs)
+INGEST_BATCH_SIZE=10000 SQLITE_URL=$SQLITE_URL \
+  INDEX_PATH=$INDEX_PATH ID_MAP_PATH=$ID_MAP_PATH \
+  uv run rag-ingest "$TEST_DIR/sample.md"
+```
+
+**Expectativa:** Ambos terminan correctamente. El batch size 1 puede ser lento, pero no debe crashear.
+
+---
+
+## Bloque 9 — Frontend / UI (si aplica)
+
+```bash
+# Acceder a la UI embedded en el servidor
+curl -s "http://127.0.0.1:8765/" | head -20
+```
+
+**Verificar:**
+- Responde con HTML (no 404, no 500)
+- La UI carga sin errores de JS en consola del navegador
+- El campo de pregunta envía al endpoint correcto
+- Con Ollama caído: la UI muestra error claro, no spinner infinito
+
+---
+
+## Checklist de señales de alerta críticas
+
+Antes de dar el release por válido, confirmar que **ninguno** de estos patrones aparece:
+
+| # | Señal de alerta | Dónde verificar |
+|---|----------------|-----------------|
+| A1 | Traceback de Python en stdout/stderr para inputs de usuario | Todos los tests de inputs inválidos |
+| A2 | `print()` en producción (en lugar de logger) | Logs de cualquier comando |
+| A3 | `assert` en código de producción (AssertionError en vez de excepción explícita) | Inputs extremos |
+| A4 | HTTP 500 para inputs de usuario inválidos (debe ser 400/422) | B6.4, B6.5, B6.9 |
+| A5 | Duplicados en DB después de doble-ingest | B1.3, B2.6 |
+| A6 | Documento resucitado después de tombstone | B3.6 |
+| A7 | FAISS ntotal != SQL count después de rebuild | B4.4 |
+| A8 | Deadlock o hang en mutations concurrentes | B6.12 |
+| A9 | División por cero en métricas de eval | B5.4 |
+| A10 | Journal en estado PREPARED/IN_PROGRESS tras restart limpio | B7.4 |
+| A11 | Timeout sin mensaje de error para providers caídos | B6.3, B6.13 |
+| A12 | Contenido binario persistido como documento | B2.4 |
+
+---
+
+## Registro de resultados
+
+```markdown
+| Test | Resultado | Comportamiento real | Veredicto |
+|------|-----------|--------------------| --------- |
+| B1.1 |           |                    |           |
+| B1.2 |           |                    |           |
+...
+```
+
+**Veredictos posibles:** `PASS` / `FAIL` / `WARN` (comportamiento incorrecto pero no crítico) / `SKIP` (requires external service)
+
+---
+
+## Escenarios de regresión específicos del CHANGELOG v1.3.0
+
+Basados en los cambios declarados de esta release:
+
+```bash
+# R1: Verificar que alchemy_engine.py NO existe (breaking change)
+ls src/local_rag_backend/infrastructure/persistence/sql/alchemy_engine.py 2>&1
+# Esperado: "No such file or directory"
+
+# R2: Verificar path de composición unificado
+python3 -c "
+from local_rag_backend.composition.container import AppContainer
+from local_rag_backend.settings import Settings
+s = Settings(_env_file=None)
+c = AppContainer.from_settings(s)
+print('OK: from_settings() works')
+"
+
+# R3: Verificar que runtime_wiring_defaults() existe y es callable
+python3 -c "
+from local_rag_backend.composition.container import AppContainer
+from local_rag_backend.settings import Settings
+s = Settings(_env_file=None)
+c = AppContainer.from_settings(s)
+defaults = c.runtime_wiring_defaults()
+print(f'OK: runtime_wiring_defaults() returned {type(defaults)}')
+"
+
+# R4: Verificar que bootstrap va por MutationCoordinator (no legacy ETL)
+# Inspectar el log de rag-bootstrap buscando "mutation" en vez de "etl"
+FAZ_CSV="$TEST_DIR/faq_small.csv" SQLITE_URL=$SQLITE_URL \
+  INDEX_PATH=$INDEX_PATH ID_MAP_PATH=$ID_MAP_PATH \
+  LOG_LEVEL=debug uv run rag-bootstrap 2>&1 | grep -i "mutation\|etl\|coordinator"
+```

--- a/BETA_TEST_RESULTS.md
+++ b/BETA_TEST_RESULTS.md
@@ -1,0 +1,194 @@
+# Beta-Test Results — RAG Prototype v1.3.0
+> Ejecutado: 2026-03-03
+> Entorno: Python 3.12.12, uv 0.9.26, Linux (Fedora 43), sin OPENAI/SentenceTransformers
+> Modo de retrieval bajo test: **sparse** (dense/hybrid requieren embedder externo)
+
+---
+
+## Resumen ejecutivo
+
+| Severidad | Count | Tests afectados |
+|-----------|-------|-----------------|
+| 🔴 FAIL crítico | 5 | B1.5, B5.3, B5.4, B6.3/B6.4/B6.5 (root cause único), B8.x (sistémico) |
+| 🟡 WARN | 5 | B3.3, B3.5, B6.1-/ready, B6.9, B6.11/health |
+| 🟢 PASS | 28 | Ver tabla completa |
+| ⚪ SKIP | 6 | Dense/hybrid (sin embedder en este entorno) |
+
+**El release es estable en modo sparse.** Los FAILs son bugs de UX/DX y un bug de seguridad de baja severidad (comportamiento de bootstrap silencioso), no crashes de producción.
+
+---
+
+## Tabla de resultados completa
+
+| Test | Veredicto | Descripción del comportamiento real |
+|------|-----------|--------------------------------------|
+| **B1.1** Status vacío | 🟢 PASS | 0 docs, sin crash, exit 0 |
+| **B1.2** Bootstrap CSV | 🟢 PASS | 3 docs ingestados, idempotente |
+| **B1.3** Bootstrap idempotente | 🟢 PASS | 0 docs nuevos en segunda ejecución (dedup SHA256 funciona) |
+| **B1.4** CSV sin cabecera | 🟢 PASS | `CSV_HAS_HEADER=false` funciona, 2 docs adicionales |
+| **B1.5** CSV inexistente | 🔴 FAIL | `_resolve_csv_path` hace **fallback silencioso** a `data/faq.csv` del repo cuando `FAQ_CSV` apunta a path inexistente. Exit 0, output "[OK]". El usuario no sabe que sus datos fueron ignorados. |
+| **B2.1** Multi-formato | 🟢 PASS | `.txt` y `.md` ingestados correctamente, chunking aplicado |
+| **B2.2** Archivo vacío | 🟢 PASS | `skipped=1`, exit 0 |
+| **B2.3** Sólo whitespace | 🟢 PASS | `skipped=1`, exit 0 |
+| **B2.4** Binario | 🟢 PASS | `skipped=1`, exit 0 (UnicodeDecodeError capturado) |
+| **B2.5** Directorio completo | 🟢 PASS | Procesa 21 archivos, salta 6 (bin/json/etc.) |
+| **B2.6** Doble-ingest dedup | 🟢 PASS | `unchanged=1, inserted=0` en segunda pasada |
+| **B2.7** Path inexistente | 🟡 WARN | Click valida y da error, pero con traceback crudo (click `BadParameter`) en lugar de `[ERROR]` limpio |
+| **B3.1** Mutación válida | 🟢 PASS | 3 docs ingestados, journal en COMMITTED |
+| **B3.2** Payload vacío `{}` | 🟢 PASS | `[ERROR] Mutation intent must include upserts and/or deletions.`, exit 1 |
+| **B3.3** Content vacío en upsert | 🟡 WARN | El upsert con `content=""` es **filtrado silenciosamente** en `normalize_intent` (línea `if str(it.content).strip()`). El error resultante dice "must include upserts and/or deletions" en lugar de "empty content filtered". Mensaje engañoso. |
+| **B3.4** Upsert+delete mismo ID | 🟢 PASS | `[ERROR] upserts and delete_external_ids cannot target the same external_id values: conflict-id`, exit 1 |
+| **B3.5** Delete ID inexistente | 🟡 WARN | Crea **tombstone preventivo** (`tombstoned=1, deleted_sql=0`). Comportamiento semánticamente discutible: un ID que nunca existió queda tombstoned, bloqueando ingests futuros de ese ID. Documentado pero sorprendente. |
+| **B3.6** Reingest tombstoneado | 🟢 PASS | `[ERROR] Cannot upsert tombstoned external_id values: beta-doc-001`, exit 1. Invariante de tombstone funciona. |
+| **B3.7** JSON malformado | 🟢 PASS | `[ERROR] Expecting ',' delimiter`, exit 1 |
+| **B4.1** Rebuild en sparse | 🟢 PASS | `[ERROR] rebuild-index requires RETRIEVAL_MODE=dense\|hybrid`, exit 1 |
+| **B4.2** Rebuild en dense | ⚪ SKIP | Requiere embedder real (OpenAI key o `dense-st` extra). Error correcto: "Dense/hybrid retrieval requires an embeddings backend." |
+| **B4.3** Rebuild DB vacía | 🟢 PASS | Mismo comportamiento que B4.1 en sparse (correcto) |
+| **B4.4** Status post-rebuild | 🟢 PASS | Reporta ntotal y estado correctamente |
+| **B4.5** Drift detection (sparse) | ⚪ SKIP | En sparse no hay FAISS index; drift sólo aplicable en dense/hybrid |
+| **B5.1** Eval dataset pequeño | 🟢 PASS | `hit_rate=0.667 mrr=0.667`, exit 1 por umbral. Métricas correctas. |
+| **B5.2** Eval dataset golden | 🟢 PASS | `hit_rate=1.000 mrr=1.000`, exit 0. Golden suite: perfecta. |
+| **B5.3** JSONL corrupto | 🔴 FAIL | **Traceback crudo** de `ValueError: Invalid dataset line 1: unknown type=None`. `eval_cmd` no envuelve errores de parseo de dataset (a diferencia de `bootstrap_cmd` que sí tiene try/except → `[ERROR]`). |
+| **B5.4** Dataset vacío | 🔴 FAIL | **Traceback crudo** de `ValueError: Unsupported schema_version=0`. El archivo vacío no tiene línea `meta`, la función asume `schema_version=0` y lanza error sin mensaje limpio. |
+| **B6.1** Health/Ready/Ollama | 🟢 PASS | `/health` → 200, `/ready` → 503 con detalle estructurado, `/health/ollama` → 200 (Ollama está corriendo localmente) |
+| **B6.1** /ready sin LLM | 🟡 WARN | `/ready` devuelve HTTP 503 (correcto), pero el cuerpo está envuelto en `{"detail": {...}}` — formato de error FastAPI, no de payload exitoso. Puede confundir a consumidores del endpoint. |
+| **B6.2** Config/Templates | 🟢 PASS | JSON válido, `retrieval_mode` refleja env var, 4 templates disponibles |
+| **B6.3** Ask sin LLM | 🔴 FAIL | **HTTP 500** en lugar de 503. `get_rag_service()` dependency lanza `RuntimeError` (no `AppError`) antes de que Pydantic valide el body. El error se escapa del exception handler y produce "Internal Server Error" genérico. |
+| **B6.4** Ask pregunta vacía | 🔴 FAIL | **HTTP 500** (mismo root cause que B6.3: la dep crashea antes de la validación Pydantic). Sin la dep crasheada devolvería 422 (Pydantic valida `min_length=1`). |
+| **B6.5** Ask k=0/-1 | 🔴 FAIL | **HTTP 500** (mismo root cause). Sin la dep crasheada devolvería 422 (Pydantic valida `ge=1`). |
+| **B6.6** Ask k > total docs | ⚪ SKIP | Mismo root cause que B6.3, no testeable sin LLM |
+| **B6.7** Paginación docs/history | 🟢 PASS | limit=0 → 422, limit=-1 → 422, paginación correcta |
+| **B6.8** Docs mutate API | 🟢 PASS | Upsert válido → 200, payload vacío → 422 correcto, content vacío → 422 correcto (Pydantic `min_length=1` en content) |
+| **B6.9** Docs import API | 🟡 WARN | `/docs/import` es para exportaciones de conversaciones (ChatGPT/Gemini), **no** para documentos genéricos. El test plan asumía incorrectamente su propósito. Comportamiento correcto: 422 "Could not detect a supported export format". |
+| **B6.10** Index rebuild API sparse | 🟢 PASS | HTTP 400 "Index rebuild requires dense or hybrid mode." |
+| **B6.11** Auth API_KEY | 🟢 PASS | Sin key: 401, key incorrecta: 401, key correcta: 200. Nota: `/health` también requiere key cuando `API_KEY` está configurado (puede ser problema para K8s probes). |
+| **B6.12** Mutations concurrentes | 🟢 PASS | 5 mutations paralelas: cada una inserted=1, 0 duplicados, 0 deadlocks. Mecanismo de write-lock funciona. |
+| **B6.13** OpenRouter sin key | 🟢 PASS | HTTP 400 "OpenRouter is not configured" |
+| **B7.1** FAISS corrupto | 🟢 PASS | `Index: [ERROR] missing (hint: rebuild)` — detectado, no crash |
+| **B7.2** id_map malformado | 🟢 PASS | `Index: [ERROR] corrupt (hint: rebuild)` — detectado, no crash |
+| **B7.3** id_map vacío vs FAISS válido | ⚪ SKIP | Requiere dense mode con embedder real para validar mismatch |
+| **B7.4** Journal recovery | 🟢 PASS | Journal limpio post-operaciones. `mutation_journal: {status: ok, incomplete_records: 0}` en `/ready`. |
+| **B8.1** RETRIEVAL_MODE inválido | 🟡 WARN | Pydantic valida correctamente, pero como `settings = Settings()` está al nivel de módulo, el error produce un **traceback crudo** en import time en lugar de mensaje amigable. Sistémico para todas las settings inválidas. |
+| **B8.2** SQLITE_URL sin permisos | 🟡 WARN | SQLAlchemy traceback crudo en lugar de mensaje amigable. |
+| **B8.3** INGEST_BATCH_SIZE=1 | 🟢 PASS | Lento pero correcto |
+| **B8.3** INGEST_BATCH_SIZE=10000 | 🟡 WARN | Pydantic valida (max 512) pero misma presentación de traceback crudo. |
+| **R1** alchemy_engine.py eliminado | 🟢 PASS | Archivo no existe. Breaking change aplicado correctamente. |
+| **R2** `from_settings()` | 🟢 PASS | Factory funciona, retorna `AppContainer` |
+| **R3** `runtime_wiring_defaults()` | 🟢 PASS | Retorna `dict` |
+| **R4** Bootstrap → MutationCoordinator | 🟢 PASS | `sample_data_ingestion.py` importa y llama `MutationCoordinator`, no legacy ETL |
+| **B9** UI Frontend | 🟢 PASS | HTML válido, carga correctamente. Nota cosmética: ejemplo questions hardcoded con "Legal Engine Search (LES)" irrelevante para KB genérica. |
+
+---
+
+## Hallazgos clasificados por severidad
+
+### 🔴 FAIL — Deben corregirse antes de promover el release
+
+#### F-01: Bootstrap silencia path inválido de FAQ_CSV `[B1.5]`
+- **Ubicación**: [sample_data_ingestion.py:46-52](src/local_rag_backend/scripts/sample_data_ingestion.py#L46-L52) — `_resolve_csv_path`
+- **Comportamiento**: Cuando `FAQ_CSV=/path/que/no/existe`, cae en fallback a `data/faq.csv` del repo **sin ningún warning o error**.
+- **Impacto**: El usuario cree que ingestó sus datos, pero en realidad ingestó la FAQ de demo. Silencio total.
+- **Fix sugerido**: Si `csv_path` fue provisto explícitamente (no es `None`) y no existe, lanzar `FileNotFoundError` inmediatamente. El fallback sólo debe usarse cuando `csv_path is None`.
+
+#### F-02: `eval_cmd` sin manejo de errores de parseo `[B5.3, B5.4]`
+- **Ubicación**: [cli_commands/eval.py:58](src/local_rag_backend/cli_commands/eval.py#L58)
+- **Comportamiento**: JSONL corrupto y dataset vacío producen traceback crudo en lugar de `[ERROR] ...`.
+- **Contraste**: `bootstrap_cmd`, `mutate_docs_cmd` tienen try/except → mensaje limpio. `eval_cmd` no.
+- **Fix sugerido**: Envolver `load_eval_dataset()` y `run_retrieval_eval()` en try/except, salir con `[ERROR]`.
+
+#### F-03: `get_rag_service()` dependency lanza `RuntimeError` no mapeado `[B6.3, B6.4, B6.5]`
+- **Ubicación**: [composition/adapters.py:541](src/local_rag_backend/composition/adapters.py#L541) — `resolve_preferred_llm_provider`
+  [composition/factory.py:129](src/local_rag_backend/composition/factory.py#L129) — `get_rag_service`
+- **Comportamiento**: `RuntimeError: No LLM configured` escapa al handler de FastAPI → HTTP 500 en lugar de 503. Además, la dep se resuelve **antes** que Pydantic valide el body, por lo que B6.4 (pregunta vacía) y B6.5 (k inválido) también devuelven 500 en lugar de 422.
+- **Impacto**: Todos los endpoints que inyectan `get_rag_service` como dep (ask, ask_eval, history) devuelven 500 cuando no hay LLM configurado, ocultando errores de validación Pydantic.
+- **Fix sugerido**:
+  1. En `resolve_preferred_llm_provider`, lanzar `LLMConfigurationError` en lugar de `RuntimeError` (ya está en el exception_handler como `handle_runtime_error`).
+  2. O bien, manejar el `RuntimeError` en la dependencia de FastAPI con una función wrapper.
+
+#### F-04: Presentación de errores de Settings como traceback crudo `[B8.1, B8.2, B8.3]`
+- **Ubicación**: [settings.py:325](src/local_rag_backend/settings.py#L325) — `settings: Settings = Settings()` a nivel de módulo
+- **Comportamiento**: Cualquier variable de entorno con valor inválido produce un `pydantic_core.ValidationError` o `sqlalchemy.exc.OperationalError` con traceback completo en stderr.
+- **Severidad real**: WARN (la información útil está presente, sólo la presentación es fea). Rebajado a WARN por ser comportamiento estándar de Pydantic Settings v2.
+
+---
+
+### 🟡 WARN — Comportamiento subóptimo, no bloqueante
+
+#### W-01: Mensaje de error engañoso para upsert con content vacío `[B3.3]`
+- **Ubicación**: [core/use_cases/docs_mutation_contracts.py:49](src/local_rag_backend/core/use_cases/docs_mutation_contracts.py#L49)
+- El filtro `if str(it.external_id).strip() and str(it.content).strip()` elimina silenciosamente upserts con content vacío, luego lanza "Mutation intent must include upserts and/or deletions" — confuso para quien sí envió un upsert.
+
+#### W-02: Tombstone preventivo en delete de ID inexistente `[B3.5]`
+- Un `delete_external_ids: ["id-inexistente"]` crea un tombstone para un ID que nunca existió. Comportamiento determinista y documentado, pero sorprendente: bloqueará futuros ingests de ese ID.
+
+#### W-03: `/ready` en formato de error (`{"detail": {...}}`) `[B6.1]`
+- La respuesta de `/ready` cuando no está listo usa el formato de error de FastAPI (`HTTPException`), no un payload de readiness estándar. Un consumidor esperaría `{"status": "not_ready", ...}` con HTTP 503, no `{"detail": {...}}`.
+
+#### W-04: `/health` requiere `API_KEY` cuando está configurado `[B6.11]`
+- El router completo (`/api/*`) tiene `Depends(require_api_key)`. Esto incluye `/health`. En deployments con `API_KEY` configurado, los probes de K8s/Docker que consultan `/health` sin key recibirán 401.
+
+#### W-05: Traceback de Click para path inválido en `rag-ingest` `[B2.7]`
+- `rag-ingest /path/inexistente` produce traceback de Click en lugar de `[ERROR]` limpio.
+
+#### W-06: UI con example questions hardcoded irrelevantes `[B9]`
+- La UI tiene `<li>What is Legal Engine Search (LES)?</li>` hardcoded en `index.html`. No son ejemplos genéricos ni se generan dinámicamente desde el KB.
+
+#### W-07: `rag-server` no expone `--host`/`--port` como CLI flags
+- El servidor sólo acepta `APP_HOST`/`APP_PORT` como env vars. No hay flags CLI para cambiar host/puerto sin modificar el entorno. La mayoría de CLIs (uvicorn, gunicorn) exponen estos como flags.
+
+#### W-08: Error de Settings como tracebacks crudos `[B8.1, B8.2, B8.3]`
+- Settings inválidas producen traceback en stderr. Sistémico por `settings = Settings()` a nivel de módulo.
+
+---
+
+### ⚪ SKIP — No testeable en este entorno
+
+- **Dense/hybrid mode completo**: Requiere `OPENAI_API_KEY` real o `uv sync --extra dense-st` (SentenceTransformers + modelo descargado).
+- **Drift detection (B4.5 dense)**: Requiere rebuild exitoso en dense mode.
+- **id_map mismatch (B7.3)**: Requiere dense mode funcional.
+- **Ask con LLM real**: Servidor disponible con Ollama, modelos disponibles (`qwen3.5:2b-q8_0`), pero `OLLAMA_ENABLED` no testeado exhaustivamente dado los otros FAILs.
+- **Archivo oversized import (B6.9)**: El endpoint `/docs/import` es para exportaciones de conversaciones, no documentos genéricos.
+
+---
+
+## Hallazgos adicionales (observaciones de campo)
+
+1. **Esquemas CLI vs API divergentes y no documentados**: El CLI de `rag-mutate-docs` usa `{upserts, delete_ids, delete_external_ids}` y el HTTP API también usa el mismo schema, PERO la documentación del `--help` del CLI y el OpenAPI del servidor no hacen referencia al otro. Un desarrollador usando la API probará con "intents" (lógico por analogía con otros sistemas de mutación) y obtendrá un error confuso de Pydantic.
+
+2. **`data/faq.csv` con delimitador `;` hardcoded en `sample_data_ingestion.py`**: `DELIMITER = ";"` está hardcodeado. Si alguien cambia el `faq.csv` del repo usando `,` como separador, el bootstrap lo procesará incorrectamente sin error.
+
+3. **`/docs/import` propósito no obvio**: El endpoint acepta exportaciones de ChatGPT/Gemini. El nombre `/docs/import` sugiere importación genérica de documentos. Puede generar confusión en nuevos usuarios.
+
+4. **Plan de beta-test tenía 2 errores factuales**: (a) variable de entorno `FAZ_CSV` (typo, debe ser `FAQ_CSV`); (b) formato `intents` para mutate (el correcto es `upserts/delete_external_ids`). Ambos descubiertos durante la ejecución.
+
+---
+
+## Regresiones v1.3.0 — Todas verificadas ✅
+
+| Regresión | Resultado |
+|-----------|-----------|
+| `alchemy_engine.py` eliminado | ✅ Archivo no existe |
+| `AppContainer.from_settings()` funciona | ✅ Retorna `AppContainer` |
+| `runtime_wiring_defaults()` existe | ✅ Retorna `dict` |
+| Bootstrap via `MutationCoordinator` | ✅ No usa ETL legacy |
+
+---
+
+## Priorización de fixes
+
+```
+P0 (antes de release público/producción):
+  F-03: HTTP 500 en ask sin LLM (afecta DX, puede confundir monitoreo)
+  F-01: Bootstrap silencia FAQ_CSV inválido (pérdida silenciosa de datos)
+
+P1 (próximo sprint):
+  F-02: eval_cmd sin manejo de errores → tracebacks crudos
+  W-03: /ready formato de respuesta inconsistente
+  W-04: /health requiere API_KEY → rompe probes K8s
+
+P2 (backlog):
+  W-01: Mensaje de error confuso en upsert con content vacío
+  W-05/W-08: Tracebacks crudos en inputs inválidos (CLI y settings)
+  W-06: Example questions hardcoded en UI
+  W-07: rag-server sin --host/--port flags
+```

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 * **API**
 
   * FastAPI with validation and OpenAPI at `/docs`.
-  * Health: `/api/health`, Readiness: `/api/ready`, Ollama health: `/api/health/ollama`.
+  * Public probes: `/healthz`, `/readyz`, Ollama health: `/healthz/ollama`.
   * Config: `/api/config`, Templates: `/api/templates`.
   * OpenRouter proxy (OpenAI-compatible): `POST /api/openrouter/generate`.
 * **Tests**
@@ -83,8 +83,8 @@ rag-bootstrap
 # FastAPI server
 rag-server
 # UI: http://localhost:8000/
-# Health: http://localhost:8000/api/health
-# Ollama health: http://localhost:8000/api/health/ollama
+# Health: http://localhost:8000/healthz
+# Ollama health: http://localhost:8000/healthz/ollama
 # Docs: http://localhost:8000/docs
 ```
 
@@ -117,7 +117,7 @@ Key variables (non-exhaustive):
 | `RETRIEVAL_MODE`                 | `sparse`                  | retrieval    | `sparse` \| `dense` \| `hybrid`                        |
 | `DATA_DIR`                       | `data`                    | storage      | Base data directory (SQLite parent, vector index paths) |
 | `SQLITE_URL`                     | `sqlite:///./data/app.db` | storage      | SQLite URL                                             |
-| `FAQ_CSV`                        | `data/faq.csv`            | ingestion    | FAQ CSV                                                |
+| `FAQ_CSV`                        | `data/faq.csv`            | ingestion    | Bootstrap CSV path (must exist; no fallback)          |
 | `CSV_HAS_HEADER`                 | `true`                    | ingestion    | CSV has header                                         |
 | `INGEST_CHUNK_STRATEGY`          | `chars_v1`                | ingestion    | Chunking strategy identifier (deterministic)           |
 | `INGEST_CHUNKER_VERSION`         | `chars_v1`                | ingestion    | Version token included in chunk dedup hashes           |
@@ -171,7 +171,7 @@ Key variables (non-exhaustive):
 When `RETRIEVAL_MODE=dense|hybrid`, the system writes an `index_manifest.json` next to `INDEX_PATH`.
 It records stable identifiers for the index build (embedding backend/model, dimension, chunker strategy/version).
 
-If you change any of these settings, `/api/ready` and `rag-status` will report drift and instruct you to rebuild:
+If you change any of these settings, `/readyz` and `rag-status` will report drift and instruct you to rebuild:
 `rag-rebuild-index` (or `POST /api/index/rebuild`).
 
 **Note:**  **fresh-install only** storage contract.
@@ -304,8 +304,8 @@ docker compose up -d --build
 docker exec -it ollama ollama pull lfm2.5-thinking
 
 # Verify services
-curl http://localhost:8000/api/health
-curl http://localhost:8000/api/health/ollama
+curl http://localhost:8000/healthz
+curl http://localhost:8000/healthz/ollama
 ```
 
 Notes:
@@ -360,8 +360,8 @@ docker compose up -d
 ## API
 
 * `GET /` → Serves packaged `index.html` or the source tree `src/local_rag_backend/frontend/index.html`.
-* `GET /api/health` and `GET /api/ready`
-* `GET /api/health/ollama`
+* `GET /healthz` and `GET /readyz`
+* `GET /healthz/ollama`
 * `GET /api/config` and `GET /api/templates`
 * `POST /api/ask`
   * Body: `{ "question": "str", "k": int (1..10, default 3) }`
@@ -386,7 +386,7 @@ Notes:
 * Write-path consistency uses `MutationCoordinator` with `DURABLE_SAGA`: SQL commit + vector delta (`apply_delta_atomic`) + journaled compensation/recovery.
 * Full rebuild is an explicit repair operation only (`/api/index/rebuild` or `rag-rebuild-index`), not a normal write fallback.
 * v1.0 removed legacy write endpoints: `/api/docs/upsert`, `/api/docs/delete`, `/api/docs/delete_by_external_id`.
-* In dense/hybrid mode, `/api/ready` is intentionally strict and returns `503` when it detects missing/corrupt index files or drift between SQLite documents and the vector index (hinting how to rebuild).
+* In dense/hybrid mode, `/readyz` is intentionally strict and returns `503` when it detects missing/corrupt index files or drift between SQLite documents and the vector index (hinting how to rebuild).
 * For public/proxy deployments, use `API_KEY` and sanitize `X-Forwarded-For` / `Forwarded` at the edge proxy.
 
 Example:

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -255,6 +255,13 @@ Levanta el servidor antes de llamar a la API:
 rag-server
 ```
 
+Probes operacionales (públicas):
+
+```bash
+curl -s http://localhost:8000/healthz
+curl -s http://localhost:8000/readyz
+```
+
 ```bash
 curl -X POST "http://localhost:8000/api/docs/mutate" \
   -H "Content-Type: application/json" \

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -54,7 +54,7 @@
 | Attribute    | Target | Measured by |
 | ------------ | -----: | ----------- |
 | Latency p95 (`POST /api/ask`, sparse, local sample dataset) | <= 2000ms | `rag_query_duration_seconds` metric + e2e smoke |
-| Availability (single instance) | >= 99.0% in controlled environment | `/api/health` + `/api/ready` checks |
+| Availability (single instance) | >= 99.0% in controlled environment | `/healthz` + `/readyz` checks |
 | Consistency | `DURABLE_SAGA` (current write model), with capability-driven variants as future work | mutation journal recovery tests + integration tests |
 | Cost | single-node local runtime (no mandatory external SaaS except optional LLM provider) | Docker/local runtime footprint |
 
@@ -93,7 +93,7 @@
 | Retrieval Query | Retrieve docs + generate answer | No | LLM adapters, retrievers | `/api/ask`, `/api/ask_eval`, `RagService.ask` |
 | Document Mutation | Canonical write orchestration SQL + vector | Yes | SQL repo, vector repo, embedder | `/api/docs`, `/api/docs/import`, `/api/docs/mutate`, `rag-mutate-docs`, `rag-ingest` |
 | Index Maintenance | Rebuild/repair vector index | Yes | embedder + vector adapter | `/api/index/rebuild`, `rag-rebuild-index` |
-| Health/Diagnostics | Readiness/consistency diagnostics | No | persistence diagnostics adapters, manifest/index files | `/api/health`, `/api/ready`, `rag-status` |
+| Health/Diagnostics | Readiness/consistency diagnostics | No | persistence diagnostics adapters, manifest/index files | `/healthz`, `/readyz`, `rag-status` |
 | Transport (HTTP/CLI) | Input/output mapping + auth + error translation | No | FastAPI/Click | REST + CLI commands |
 | Composition Runtime | Dependency wiring + runtime cache invalidation | No | settings + adapters | DI factory/container |
 
@@ -356,7 +356,7 @@ Fase B closure (2026-03-01):
   - `/api/docs`, `/api/docs/import`, `/api/docs/mutate`
   - `/api/index/rebuild`
   - `/api/config`, `/api/templates`
-  - `/api/health`, `/api/ready`, `/api/health/ollama`
+  - `/healthz`, `/readyz`, `/healthz/ollama`
   - `/api/openrouter/generate`
   - `/metrics` (when monitoring is enabled)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,6 @@ dependencies = [
   # CLI & Utilities
   "click>=8.0,<9.0",
   "rich>=13.0,<14.0",
-  "pre-commit>=4.5.1",
 ]
 
 [project.optional-dependencies]
@@ -164,7 +163,6 @@ include = ["local_rag_backend*"]
 "*" = ["*.txt","*.md","*.yml","*.yaml","*.json","*.toml"]
 "local_rag_backend" = ["py.typed"]
 "local_rag_backend.frontend" = ["*.html","*.css","*.js","*.ico"]
-"local_rag_backend.config" = ["*.yaml","*.json"]
 
 # === DEVELOPMENT TOOLS ===
 

--- a/src/local_rag_backend/cli_commands/eval.py
+++ b/src/local_rag_backend/cli_commands/eval.py
@@ -46,36 +46,42 @@ def eval_cmd(
     json_out: Path | None,
 ) -> None:
     """Offline retrieval evaluation (reproducible, dependency-free by default)."""
-    from local_rag_backend.core.services.evaluation import (
-        eval_result_to_json,
-        format_eval_result,
-        load_eval_dataset,
-    )
-    from local_rag_backend.core.use_cases.evaluation import run_retrieval_eval
-
-    container = get_cli_container()
-    eval_bundle = container.build_eval_execution_bundle()
-    ds = load_eval_dataset(dataset)
-    res = run_retrieval_eval(
-        dataset=ds,
-        eval_storage_port=eval_bundle.eval_storage_port,
-        eval_retriever_factory_port=eval_bundle.eval_retriever_factory_port,
-        retrieval_mode=retrieval_mode,
-        k=k,
-        reranker_enabled=bool(reranker),
-        reranker_candidate_k=eval_bundle.reranker_candidate_k,
-        reranker_strategy=eval_bundle.reranker_strategy,
-        max_queries=max_queries,
-    )
-    click.echo(format_eval_result(res))
-
-    if json_out is not None:
-        json_out.write_text(json.dumps(eval_result_to_json(res)), encoding="utf-8")
-
-    if res.hit_rate < float(fail_below_hit_rate) or res.mrr < float(fail_below_mrr):
-        click.echo(
-            f"[ERROR] Eval regression: hit_rate={res.hit_rate:.3f} (min {fail_below_hit_rate}), "
-            f"mrr={res.mrr:.3f} (min {fail_below_mrr})",
-            err=True,
+    try:
+        from local_rag_backend.core.services.evaluation import (
+            eval_result_to_json,
+            format_eval_result,
+            load_eval_dataset,
         )
+        from local_rag_backend.core.use_cases.evaluation import run_retrieval_eval
+
+        container = get_cli_container()
+        eval_bundle = container.build_eval_execution_bundle()
+        ds = load_eval_dataset(dataset)
+        res = run_retrieval_eval(
+            dataset=ds,
+            eval_storage_port=eval_bundle.eval_storage_port,
+            eval_retriever_factory_port=eval_bundle.eval_retriever_factory_port,
+            retrieval_mode=retrieval_mode,
+            k=k,
+            reranker_enabled=bool(reranker),
+            reranker_candidate_k=eval_bundle.reranker_candidate_k,
+            reranker_strategy=eval_bundle.reranker_strategy,
+            max_queries=max_queries,
+        )
+        click.echo(format_eval_result(res))
+
+        if json_out is not None:
+            json_out.write_text(json.dumps(eval_result_to_json(res)), encoding="utf-8")
+
+        if res.hit_rate < float(fail_below_hit_rate) or res.mrr < float(fail_below_mrr):
+            click.echo(
+                f"[ERROR] Eval regression: hit_rate={res.hit_rate:.3f} (min {fail_below_hit_rate}), "
+                f"mrr={res.mrr:.3f} (min {fail_below_mrr})",
+                err=True,
+            )
+            raise SystemExit(1)
+    except SystemExit:
+        raise
+    except Exception as e:
+        click.echo(f"[ERROR] Error evaluating dataset: {e}", err=True)
         raise SystemExit(1)

--- a/src/local_rag_backend/composition/adapters.py
+++ b/src/local_rag_backend/composition/adapters.py
@@ -19,7 +19,7 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
-from local_rag_backend.core.errors import EmbeddingsBackendUnavailableError
+from local_rag_backend.core.errors import EmbeddingsBackendUnavailableError, LLMConfigurationError
 from local_rag_backend.core.ports import (
     BlockingExecutorPort,
     BlockingTaskType,
@@ -538,7 +538,7 @@ def resolve_preferred_llm_provider(*, settings_obj: Settings) -> str:
         settings_obj, "openrouter_api_key", None
     ):
         return "openrouter"
-    raise RuntimeError(
+    raise LLMConfigurationError(
         "No LLM configured. Set OPENAI_API_KEY, enable OLLAMA_ENABLED, "
         "or set OPENROUTER_ENABLED=true with OPENROUTER_API_KEY."
     )

--- a/src/local_rag_backend/core/use_cases/errors.py
+++ b/src/local_rag_backend/core/use_cases/errors.py
@@ -89,7 +89,7 @@ def map_runtime_error(exc: Exception) -> AppError | None:
     if isinstance(exc, LLMResponseError):
         return BadGatewayError(str(exc))
     if isinstance(exc, LLMConfigurationError):
-        return InternalServerError(str(exc))
+        return ServiceUnavailableError(str(exc))
     if isinstance(exc, LLMProviderError):
         return BadGatewayError(str(exc))
     return None

--- a/src/local_rag_backend/http/api_router.py
+++ b/src/local_rag_backend/http/api_router.py
@@ -5,14 +5,12 @@ from __future__ import annotations
 from fastapi import APIRouter
 
 from local_rag_backend.http.routers.docs import router as docs_router
-from local_rag_backend.http.routers.health import router as health_router
 from local_rag_backend.http.routers.index import router as index_router
 from local_rag_backend.http.routers.meta import router as meta_router
 from local_rag_backend.http.routers.openrouter import router as openrouter_router
 from local_rag_backend.http.routers.rag_router import router as rag_router
 
 router = APIRouter()
-router.include_router(health_router)
 router.include_router(rag_router)
 router.include_router(docs_router)
 router.include_router(index_router)

--- a/src/local_rag_backend/http/main.py
+++ b/src/local_rag_backend/http/main.py
@@ -24,6 +24,7 @@ from local_rag_backend.http.api_router import router
 from local_rag_backend.http.dependencies import get_rag_service
 from local_rag_backend.http.exception_handlers import register_exception_handlers
 from local_rag_backend.http.middleware import MetricsMiddleware, get_metrics
+from local_rag_backend.http.routers.health import router as health_router
 from local_rag_backend.http.security import enforce_safe_bind_config, require_api_key
 from local_rag_backend.infrastructure.persistence.sql import base as db_base
 from local_rag_backend.settings import settings
@@ -164,6 +165,7 @@ app.add_middleware(
 if settings.enable_monitoring:
     app.add_middleware(MetricsMiddleware)
 
+app.include_router(health_router)
 app.include_router(router, prefix="/api", dependencies=[Depends(require_api_key)])
 
 

--- a/src/local_rag_backend/http/routers/health.py
+++ b/src/local_rag_backend/http/routers/health.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 import httpx
 from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
 
 from local_rag_backend.composition.adapters import (
     get_available_llm_providers as get_available_llm_providers_from_settings,
@@ -53,7 +54,7 @@ def _check_llm_providers(*, checks: dict[str, Any], settings_obj: Settings) -> b
     return True
 
 
-@router.get("/health", tags=["Health"], summary="Health check endpoint")
+@router.get("/healthz", tags=["Health"], summary="Health probe endpoint")
 async def health_check(
     container: AppContainer = Depends(get_app_container_dependency),
 ) -> dict[str, str]:
@@ -66,11 +67,11 @@ async def health_check(
         raise ServiceUnavailableError(f"Database connection failed: {e!s}") from e
 
 
-@router.get("/ready", tags=["Health"], summary="Readiness check endpoint")
+@router.get("/readyz", tags=["Health"], summary="Readiness probe endpoint")
 async def readiness_check(
     settings_obj: Settings = Depends(get_settings_dependency),
     container: AppContainer = Depends(get_app_container_dependency),
-) -> dict[str, Any]:
+) -> Any:
     """Check if all dependencies are ready to handle requests."""
     checks: dict[str, Any] = {}
     is_ready = True
@@ -103,11 +104,11 @@ async def readiness_check(
 
     response_payload = {"status": "ready" if is_ready else "not_ready", "checks": checks}
     if not is_ready:
-        raise ServiceUnavailableError(response_payload)
+        return JSONResponse(status_code=503, content=response_payload)
     return response_payload
 
 
-@router.get("/health/ollama", tags=["Health"], summary="Ollama server health check")
+@router.get("/healthz/ollama", tags=["Health"], summary="Ollama server health check")
 async def ollama_health_check(
     settings_obj: Settings = Depends(get_settings_dependency),
 ) -> dict[str, Any]:

--- a/src/local_rag_backend/http/routers/rag_router.py
+++ b/src/local_rag_backend/http/routers/rag_router.py
@@ -40,7 +40,6 @@ if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
     from local_rag_backend.composition.container import AppContainer
-    from local_rag_backend.core.services.rag_runtime import RagService
     from local_rag_backend.settings import Settings
 
 router = APIRouter()
@@ -49,10 +48,10 @@ router = APIRouter()
 @router.post("/ask", response_model=AskResponse, tags=["RAG"], summary="Ask a question using RAG")
 async def ask(
     request: AskRequest,
-    service: RagService = Depends(get_rag_service),
     settings_obj: Settings = Depends(get_settings_dependency),
 ) -> AskResponse:
     """Ask a question using Retrieval-Augmented Generation."""
+    service = await get_rag_service()
     t = Timer()
     ok = False
     try:

--- a/src/local_rag_backend/scripts/sample_data_ingestion.py
+++ b/src/local_rag_backend/scripts/sample_data_ingestion.py
@@ -45,11 +45,11 @@ def _resolve_csv_path(*, csv_path: str | Path | None, settings_obj: Any) -> Path
     csv_path_obj = Path(settings_obj.faq_csv) if csv_path is None else Path(csv_path)
     if csv_path_obj.is_file():
         return csv_path_obj
-
-    repo_csv = Path(__file__).resolve().parents[3] / "data" / "faq.csv"
-    if repo_csv.is_file():
-        return repo_csv
-    raise FileNotFoundError(f"FAQ CSV not found at {csv_path_obj}. Set FAQ_CSV to a valid path.")
+    source_name = "csv_path" if csv_path is not None else "FAQ_CSV"
+    raise FileNotFoundError(
+        f"{source_name} must point to an existing CSV file: {csv_path_obj}. "
+        "Update FAQ_CSV or pass a valid path explicitly."
+    )
 
 
 def _build_bootstrap_container(

--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -2,8 +2,7 @@
 import tempfile
 from pathlib import Path
 
-from local_rag_backend.http.dependencies import get_rag_service
-from local_rag_backend.http.main import app
+from local_rag_backend.http.routers import rag_router
 
 
 class DummyRagSvc:
@@ -27,17 +26,16 @@ class DummyRagSvcWithDocs:
 
 
 # ---------- tests -----------------------------------------------------------
-async def test_post_ask_endpoint(asgi_client):
+async def test_post_ask_endpoint(asgi_client, monkeypatch):
     async def _override():
         return DummyRagSvc()
 
-    app.dependency_overrides[get_rag_service] = _override
+    monkeypatch.setattr(rag_router, "get_rag_service", _override, raising=True)
     resp = await asgi_client.post("/api/ask", json={"question": "hola", "k": 2})
     assert resp.status_code == 200
     data = resp.json()
     assert data["answer"] == "eco:hola"
     assert data["sources"] == []
-    app.dependency_overrides.clear()
 
 
 async def test_get_root_frontend_not_found(asgi_client, tmp_path, monkeypatch):
@@ -102,12 +100,12 @@ async def test_get_frontend_assets_path_traversal_404(asgi_client):
     assert r.status_code == 404
 
 
-async def test_api_ask_schema_with_sources(asgi_client):
+async def test_api_ask_schema_with_sources(asgi_client, monkeypatch):
     # Test API schema validation for /api/ask endpoint with documents
     async def _override():
         return DummyRagSvcWithDocs()
 
-    app.dependency_overrides[get_rag_service] = _override
+    monkeypatch.setattr(rag_router, "get_rag_service", _override, raising=True)
     resp = await asgi_client.post("/api/ask", json={"question": "test", "k": 1})
     assert resp.status_code == 200
     data = resp.json()
@@ -128,4 +126,3 @@ async def test_api_ask_schema_with_sources(asgi_client):
     assert source["document"]["content"] == "Test document"
     assert isinstance(source["score"], int | float)
     assert 0.0 <= source["score"] <= 1.0
-    app.dependency_overrides.clear()

--- a/tests/integration/test_bootstrap_ingestion_pipeline.py
+++ b/tests/integration/test_bootstrap_ingestion_pipeline.py
@@ -1,8 +1,7 @@
 import csv
-from unittest.mock import patch
 
-from local_rag_backend.core.domain.entities import LoadedItem
-from local_rag_backend.core.domain.types import ItemLineage
+import pytest
+
 from local_rag_backend.scripts.sample_data_ingestion import run_sample_data_ingestion
 from local_rag_backend.settings import settings
 
@@ -159,57 +158,12 @@ def test_bootstrap_with_custom_chunking_settings(tmp_path, monkeypatch, capsys):
     assert all("Long Question" in doc.content for doc in docs)
 
 
-def test_bootstrap_with_repo_csv_fallback(tmp_path, monkeypatch, caplog):
-    """Test bootstrap falls back to the repo CSV when the configured file doesn't exist."""
-
-    # Mock CSV loader to return test data (regardless of which fallback path is used)
-    def mock_csv_loader_load(self):
-        return iter(
-            [
-                LoadedItem(
-                    text="Packaged Question\n\nPackaged Answer",
-                    lineage=ItemLineage(
-                        source_uri="test://bootstrap",
-                        loader_name="mock",
-                    ),
-                    metadata={"title": "Packaged Question"},
-                )
-            ]
-        )
-
-    # Configure non-existent local CSV
+def test_bootstrap_fails_when_configured_csv_is_missing(tmp_path, monkeypatch):
+    """Bootstrap must fail fast when FAQ_CSV points to a missing file."""
     monkeypatch.setattr(settings, "faq_csv", "nonexistent.csv", raising=False)
     monkeypatch.setattr(settings, "csv_has_header", True, raising=False)
     monkeypatch.setattr(settings, "retrieval_mode", "sparse", raising=False)
     monkeypatch.setattr(settings, "sqlite_url", f"sqlite:///{tmp_path}/app.db", raising=False)
 
-    # Mock CSVLoader to simulate fallback data
-    import logging
-
-    with patch(
-        "local_rag_backend.infrastructure.ingestion.loaders.csv_loader.CSVLoader.load",
-        mock_csv_loader_load,
-    ):
-        with caplog.at_level(logging.INFO):
-            run_sample_data_ingestion()
-
-        assert any("Ingested" in m for m in caplog.messages)
-
-        # Verify fallback data was loaded
-        from sqlalchemy import create_engine
-        from sqlalchemy.orm import sessionmaker
-
-        from local_rag_backend.infrastructure.persistence.sql import (
-            SqlDocumentStorage,
-        )
-        from local_rag_backend.infrastructure.persistence.sql.base import Base
-
-        engine = create_engine(settings.sqlite_url, connect_args={"check_same_thread": False})
-        SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
-        Base.metadata.create_all(bind=engine)
-
-        doc_repo = SqlDocumentStorage(session_factory=SessionLocal)
-        docs = doc_repo.get_all_documents()
-
-        assert len(docs) == 1
-        assert "Packaged Question" in docs[0].content
+    with pytest.raises(FileNotFoundError, match="FAQ_CSV must point to an existing CSV file"):
+        run_sample_data_ingestion()

--- a/tests/integration/test_invariants_f1_f5_golden.py
+++ b/tests/integration/test_invariants_f1_f5_golden.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 from local_rag_backend.composition import factory
 from local_rag_backend.core.domain.entities import Document
-from local_rag_backend.http.dependencies import get_rag_service
-from local_rag_backend.http.main import app
-from local_rag_backend.http.routers import health as health_router
+from local_rag_backend.http.routers import health as health_router, rag_router
 from local_rag_backend.infrastructure.persistence.sql import HistorySqlStorage
 from local_rag_backend.settings import settings
 
@@ -100,7 +98,7 @@ async def test_golden_f3_query_eval_and_history_contract(
                 "scores": [0.8],
             }
 
-    app.dependency_overrides[get_rag_service] = _override_rag_service
+    monkeypatch.setattr(rag_router, "get_rag_service", _override_rag_service, raising=True)
     container = factory.get_app_context().container
     monkeypatch.setattr(
         container,
@@ -108,38 +106,35 @@ async def test_golden_f3_query_eval_and_history_contract(
         lambda: _DummyRagRuntimeFactory(),
         raising=True,
     )
-    try:
-        r1 = await asgi_client.post("/api/ask", json={"question": "hello", "k": 1})
-        assert r1.status_code == 200
-        p1 = r1.json()
-        assert p1["answer"] == "echo:hello"
-        assert isinstance(p1["sources"], list) and len(p1["sources"]) == 1
-        assert set(p1["sources"][0].keys()) >= {"document", "score"}
+    r1 = await asgi_client.post("/api/ask", json={"question": "hello", "k": 1})
+    assert r1.status_code == 200
+    p1 = r1.json()
+    assert p1["answer"] == "echo:hello"
+    assert isinstance(p1["sources"], list) and len(p1["sources"]) == 1
+    assert set(p1["sources"][0].keys()) >= {"document", "score"}
 
-        r2 = await asgi_client.post(
-            "/api/ask_eval",
-            json={
-                "question": "hello",
-                "config": {
-                    "retrieval_mode": "sparse",
-                    "k": 1,
-                },
+    r2 = await asgi_client.post(
+        "/api/ask_eval",
+        json={
+            "question": "hello",
+            "config": {
+                "retrieval_mode": "sparse",
+                "k": 1,
             },
-        )
-        assert r2.status_code == 200
-        p2 = r2.json()
-        assert p2["answer"] == "eval:hello"
-        assert isinstance(p2.get("latency_ms"), int)
-        assert isinstance(p2["sources"], list) and len(p2["sources"]) == 1
+        },
+    )
+    assert r2.status_code == 200
+    p2 = r2.json()
+    assert p2["answer"] == "eval:hello"
+    assert isinstance(p2.get("latency_ms"), int)
+    assert isinstance(p2["sources"], list) and len(p2["sources"]) == 1
 
-        HistorySqlStorage().save("q-golden", "a-golden", ["doc:1"])
-        r3 = await asgi_client.get("/api/history?limit=1")
-        assert r3.status_code == 200
-        rows = r3.json()
-        assert isinstance(rows, list) and rows
-        assert set(rows[0].keys()) >= {"id", "question", "answer", "created_at", "source_ids"}
-    finally:
-        app.dependency_overrides.pop(get_rag_service, None)
+    HistorySqlStorage().save("q-golden", "a-golden", ["doc:1"])
+    r3 = await asgi_client.get("/api/history?limit=1")
+    assert r3.status_code == 200
+    rows = r3.json()
+    assert isinstance(rows, list) and rows
+    assert set(rows[0].keys()) >= {"id", "question", "answer", "created_at", "source_ids"}
 
 
 async def test_golden_f4_f5_rebuild_and_readiness(
@@ -179,10 +174,10 @@ async def test_golden_f4_f5_rebuild_and_readiness(
     assert r1.status_code == 200
     assert int(r1.json()["indexed"]) >= 1
 
-    r2 = await asgi_client.get("/api/health")
+    r2 = await asgi_client.get("/healthz")
     assert r2.status_code == 200
     assert r2.json().get("status") == "healthy"
 
-    r3 = await asgi_client.get("/api/ready")
+    r3 = await asgi_client.get("/readyz")
     assert r3.status_code == 200
     assert r3.json().get("status") == "ready"

--- a/tests/unit/http/test_api_contracts.py
+++ b/tests/unit/http/test_api_contracts.py
@@ -4,8 +4,7 @@ API contract validation tests for parameter bounds and validation.
 
 import pytest
 
-from local_rag_backend.http import dependencies as deps
-from local_rag_backend.http.main import app
+from local_rag_backend.http.routers import rag_router
 
 
 class _MockRagService:
@@ -25,15 +24,13 @@ class _MockRagService:
 
 
 @pytest.fixture(autouse=True)
-def _mock_rag_service():
-    """Override RAG service dependency for all tests in this module."""
+def _mock_rag_service(monkeypatch):
+    """Override RAG service resolver for all tests in this module."""
 
     async def _override():
         return _MockRagService()
 
-    app.dependency_overrides[deps.get_rag_service] = _override
-    yield
-    app.dependency_overrides.pop(deps.get_rag_service, None)
+    monkeypatch.setattr(rag_router, "get_rag_service", _override, raising=True)
 
 
 async def test_ask_rejects_k_out_of_range(asgi_client, in_memory_sqlite) -> None:

--- a/tests/unit/http/test_api_key_auth.py
+++ b/tests/unit/http/test_api_key_auth.py
@@ -12,12 +12,12 @@ from local_rag_backend.settings import settings
 async def test_api_key_required_when_configured(asgi_client, in_memory_sqlite, monkeypatch):
     monkeypatch.setattr(settings, "api_key", "secret", raising=False)
 
-    r1 = await asgi_client.get("/api/health")
+    r1 = await asgi_client.get("/api/config")
     assert r1.status_code == 401
 
-    r2 = await asgi_client.get("/api/health", headers={"X-API-Key": "secret"})
+    r2 = await asgi_client.get("/api/config", headers={"X-API-Key": "secret"})
     assert r2.status_code == 200
-    assert r2.json().get("status") == "healthy"
+    assert "retrieval_mode" in r2.json()
 
     r3 = await asgi_client.get("/metrics")
     assert r3.status_code == 401
@@ -38,7 +38,7 @@ async def test_non_local_requests_require_api_key_when_public_bind_guard_enabled
             app=app, raise_app_exceptions=True, client=("203.0.113.7", 4242)
         )
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
-            r = await client.get("/api/health")
+            r = await client.get("/api/config")
 
     assert r.status_code == 401
     assert "non-local requests" in r.json()["detail"]
@@ -54,7 +54,7 @@ async def test_non_local_requests_can_be_allowed_explicitly(in_memory_sqlite, mo
             app=app, raise_app_exceptions=True, client=("203.0.113.9", 9000)
         )
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
-            r = await client.get("/api/health")
+            r = await client.get("/api/config")
 
     assert r.status_code == 200
 
@@ -65,7 +65,7 @@ async def test_unknown_client_host_requires_api_key_when_public_bind_guard_enabl
     monkeypatch.setattr(settings, "public_bind_requires_api_key", True, raising=False)
 
     # Some ASGI deployments/tests may provide no `client` tuple in scope.
-    request = Request({"type": "http", "method": "GET", "path": "/api/health", "headers": []})
+    request = Request({"type": "http", "method": "GET", "path": "/api/config", "headers": []})
     with pytest.raises(UnauthorizedError) as excinfo:
         await require_api_key(request)
 
@@ -86,7 +86,7 @@ async def test_forwarded_non_local_host_requires_api_key_even_when_client_is_loc
         )
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
             r = await client.get(
-                "/api/health",
+                "/api/config",
                 headers={"X-Forwarded-For": "203.0.113.7"},
             )
 
@@ -107,7 +107,7 @@ async def test_rfc7239_forwarded_non_local_host_requires_api_key_when_client_is_
         )
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
             r = await client.get(
-                "/api/health",
+                "/api/config",
                 headers={"Forwarded": "for=203.0.113.60;proto=https;by=203.0.113.43"},
             )
 
@@ -128,7 +128,7 @@ async def test_rfc7239_forwarded_unknown_requires_api_key_when_client_is_local(
         )
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
             r = await client.get(
-                "/api/health",
+                "/api/config",
                 headers={"Forwarded": "for=unknown;proto=https"},
             )
 
@@ -149,9 +149,20 @@ async def test_x_forwarded_for_blank_chain_requires_api_key_when_client_is_local
         )
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
             r = await client.get(
-                "/api/health",
+                "/api/config",
                 headers={"X-Forwarded-For": " ,   "},
             )
 
     assert r.status_code == 401
     assert "non-local requests" in r.json()["detail"]
+
+
+@pytest.mark.unit
+async def test_public_probe_endpoints_do_not_require_api_key(
+    asgi_client, in_memory_sqlite, monkeypatch
+):
+    monkeypatch.setattr(settings, "api_key", "secret", raising=False)
+    r1 = await asgi_client.get("/healthz")
+    assert r1.status_code == 200
+    r2 = await asgi_client.get("/readyz")
+    assert r2.status_code in (200, 503)

--- a/tests/unit/http/test_api_misc.py
+++ b/tests/unit/http/test_api_misc.py
@@ -36,3 +36,16 @@ async def test_get_templates(asgi_client):
     arr = r.json()
     names = {t["name"] for t in arr}
     assert {"default", "ollama", "concise", "detailed"}.issubset(names)
+
+
+async def test_public_healthz_endpoint(asgi_client):
+    r = await asgi_client.get("/healthz")
+    assert r.status_code == 200
+    assert r.json().get("status") == "healthy"
+
+
+async def test_legacy_api_health_and_ready_endpoints_are_removed(asgi_client):
+    r1 = await asgi_client.get("/api/health")
+    r2 = await asgi_client.get("/api/ready")
+    assert r1.status_code == 404
+    assert r2.status_code == 404

--- a/tests/unit/http/test_api_router_docs_and_eval.py
+++ b/tests/unit/http/test_api_router_docs_and_eval.py
@@ -187,7 +187,7 @@ async def test_ready_retrieval_index_present(asgi_client, in_memory_sqlite, tmp_
 
     monkeypatch.setattr(health_router, "get_rag_service", _override, raising=True)
 
-    r = await asgi_client.get("/api/ready")
+    r = await asgi_client.get("/readyz")
     assert r.status_code == 200
     checks = r.json()["checks"]
     assert checks.get("retrieval_index") == "ok"

--- a/tests/unit/http/test_api_router_endpoints_extra.py
+++ b/tests/unit/http/test_api_router_endpoints_extra.py
@@ -10,7 +10,7 @@ async def test_health_db_failure(asgi_client, monkeypatch):
         raise Boom("db down")
 
     monkeypatch.setattr(health_router, "ping_database", _boom)
-    r = await asgi_client.get("/api/health")
+    r = await asgi_client.get("/healthz")
     assert r.status_code == 503
     assert "Database connection failed" in r.json()["detail"]
 
@@ -29,9 +29,9 @@ async def test_ready_not_ready_db_and_no_llm(asgi_client, monkeypatch):
         return None
 
     monkeypatch.setattr(health_router, "get_rag_service", _override, raising=True)
-    r = await asgi_client.get("/api/ready")
+    r = await asgi_client.get("/readyz")
     assert r.status_code == 503
-    detail = r.json()["detail"]
+    detail = r.json()
     assert detail["status"] == "not_ready"
     checks = detail["checks"]
     assert checks.get("database", "").startswith("failed")
@@ -48,7 +48,7 @@ async def test_ollama_health_ok(asgi_client, monkeypatch):
             return None
 
     monkeypatch.setattr(health_router.httpx, "get", lambda *a, **k: Resp())
-    r = await asgi_client.get("/api/health/ollama")
+    r = await asgi_client.get("/healthz/ollama")
     assert r.status_code == 200
     assert r.json()["status"] == "ok"
 
@@ -58,5 +58,5 @@ async def test_ollama_health_fail(asgi_client, monkeypatch):
         raise health_router.httpx.HTTPError("oops")
 
     monkeypatch.setattr(health_router.httpx, "get", boom)
-    r = await asgi_client.get("/api/health/ollama")
+    r = await asgi_client.get("/healthz/ollama")
     assert r.status_code == 503

--- a/tests/unit/http/test_api_router_more.py
+++ b/tests/unit/http/test_api_router_more.py
@@ -142,7 +142,9 @@ async def test_dependencies_no_llm(monkeypatch, in_memory_sqlite):
         await deps.get_rag_service()
 
 
-async def test_ask_returns_503_without_llm_for_valid_payload(asgi_client, in_memory_sqlite, monkeypatch):
+async def test_ask_returns_503_without_llm_for_valid_payload(
+    asgi_client, in_memory_sqlite, monkeypatch
+):
     monkeypatch.setattr(settings, "openai_api_key", None, raising=False)
     monkeypatch.setattr(settings, "ollama_enabled", False, raising=False)
     monkeypatch.setattr(settings, "openrouter_enabled", False, raising=False)

--- a/tests/unit/http/test_api_router_more.py
+++ b/tests/unit/http/test_api_router_more.py
@@ -3,16 +3,15 @@
 import pytest
 
 from local_rag_backend.composition import factory
-from local_rag_backend.core.errors import LLMConnectionError, LLMTimeoutError
+from local_rag_backend.core.errors import LLMConfigurationError, LLMConnectionError, LLMTimeoutError
 from local_rag_backend.http import dependencies as deps
-from local_rag_backend.http.main import app
-from local_rag_backend.http.routers import health as health_router
+from local_rag_backend.http.routers import health as health_router, rag_router
 from local_rag_backend.infrastructure.persistence.sql import SqlDocumentStorage
 from local_rag_backend.settings import settings
 
 
 async def test_health_endpoint_ok(asgi_client):
-    r = await asgi_client.get("/api/health")
+    r = await asgi_client.get("/healthz")
     assert r.status_code == 200
     assert r.json()["status"] == "healthy"
 
@@ -30,7 +29,7 @@ async def test_ready_endpoint_ok(asgi_client, monkeypatch):
         return _Dummy()
 
     monkeypatch.setattr(health_router, "get_rag_service", _override, raising=True)
-    r = await asgi_client.get("/api/ready")
+    r = await asgi_client.get("/readyz")
     assert r.status_code == 200
     data = r.json()
     assert data["status"] == "ready"
@@ -52,11 +51,11 @@ async def test_ready_endpoint_not_ready_no_llm(asgi_client, monkeypatch):
         return _Dummy()
 
     monkeypatch.setattr(health_router, "get_rag_service", _override, raising=True)
-    r = await asgi_client.get("/api/ready")
+    r = await asgi_client.get("/readyz")
     assert r.status_code == 503
     payload = r.json()
-    assert payload["detail"]["status"] == "not_ready"
-    assert "llm_providers" in payload["detail"]["checks"]
+    assert payload["status"] == "not_ready"
+    assert "llm_providers" in payload["checks"]
 
 
 async def test_templates_endpoint(asgi_client):
@@ -139,8 +138,32 @@ async def test_dependencies_no_llm(monkeypatch, in_memory_sqlite):
     monkeypatch.setattr(settings, "ollama_enabled", False, raising=False)
     monkeypatch.setattr(settings, "retrieval_mode", "sparse", raising=False)
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(LLMConfigurationError):
         await deps.get_rag_service()
+
+
+async def test_ask_returns_503_without_llm_for_valid_payload(asgi_client, in_memory_sqlite, monkeypatch):
+    monkeypatch.setattr(settings, "openai_api_key", None, raising=False)
+    monkeypatch.setattr(settings, "ollama_enabled", False, raising=False)
+    monkeypatch.setattr(settings, "openrouter_enabled", False, raising=False)
+    monkeypatch.setattr(settings, "openrouter_api_key", None, raising=False)
+    monkeypatch.setattr(settings, "retrieval_mode", "sparse", raising=False)
+    r = await asgi_client.post("/api/ask", json={"question": "hi", "k": 1})
+    assert r.status_code == 503
+    assert "No LLM configured" in r.json().get("detail", "")
+
+
+@pytest.mark.parametrize("payload", [{"question": "", "k": 1}, {"question": "hi", "k": 0}])
+async def test_ask_validation_errors_take_precedence_without_llm(
+    asgi_client, in_memory_sqlite, monkeypatch, payload
+):
+    monkeypatch.setattr(settings, "openai_api_key", None, raising=False)
+    monkeypatch.setattr(settings, "ollama_enabled", False, raising=False)
+    monkeypatch.setattr(settings, "openrouter_enabled", False, raising=False)
+    monkeypatch.setattr(settings, "openrouter_api_key", None, raising=False)
+    monkeypatch.setattr(settings, "retrieval_mode", "sparse", raising=False)
+    r = await asgi_client.post("/api/ask", json=payload)
+    assert r.status_code == 422
 
 
 async def test_metrics_endpoint_disabled(asgi_client, monkeypatch):
@@ -151,7 +174,7 @@ async def test_metrics_endpoint_disabled(asgi_client, monkeypatch):
     assert r.text.startswith("# Monitoring disabled")
 
 
-async def test_ask_maps_typed_llm_timeout_to_504(asgi_client, in_memory_sqlite):
+async def test_ask_maps_typed_llm_timeout_to_504(asgi_client, in_memory_sqlite, monkeypatch):
     class _FailingService:
         def ask(self, question, top_k=3):
             raise LLMTimeoutError("provider timeout")
@@ -159,11 +182,8 @@ async def test_ask_maps_typed_llm_timeout_to_504(asgi_client, in_memory_sqlite):
     async def _override():
         return _FailingService()
 
-    app.dependency_overrides[deps.get_rag_service] = _override
-    try:
-        r = await asgi_client.post("/api/ask", json={"question": "hi", "k": 1})
-    finally:
-        app.dependency_overrides.pop(deps.get_rag_service, None)
+    monkeypatch.setattr(rag_router, "get_rag_service", _override, raising=True)
+    r = await asgi_client.post("/api/ask", json={"question": "hi", "k": 1})
 
     assert r.status_code == 504
     assert "provider timeout" in r.json()["detail"]

--- a/tests/unit/http/test_async_offload.py
+++ b/tests/unit/http/test_async_offload.py
@@ -3,13 +3,12 @@ import threading
 import pytest
 
 from local_rag_backend.composition import adapters as composition_adapters
-from local_rag_backend.http.dependencies import get_rag_service
-from local_rag_backend.http.main import app
+from local_rag_backend.http.routers import rag_router
 from local_rag_backend.settings import settings
 
 
 @pytest.mark.unit
-async def test_ask_runs_in_worker_thread(asgi_client, in_memory_sqlite):
+async def test_ask_runs_in_worker_thread(asgi_client, in_memory_sqlite, monkeypatch):
     main_tid = threading.get_ident()
     seen: dict[str, int] = {}
 
@@ -21,13 +20,10 @@ async def test_ask_runs_in_worker_thread(asgi_client, in_memory_sqlite):
     async def _override():
         return DummyService()
 
-    app.dependency_overrides[get_rag_service] = _override
-    try:
-        r = await asgi_client.post("/api/ask", json={"question": "hi", "k": 1})
-        assert r.status_code == 200
-        assert seen["tid"] != main_tid
-    finally:
-        app.dependency_overrides.pop(get_rag_service, None)
+    monkeypatch.setattr(rag_router, "get_rag_service", _override, raising=True)
+    r = await asgi_client.post("/api/ask", json={"question": "hi", "k": 1})
+    assert r.status_code == 200
+    assert seen["tid"] != main_tid
 
 
 @pytest.mark.unit
@@ -95,7 +91,7 @@ async def test_ollama_health_check_runs_in_worker_thread(asgi_client, monkeypatc
         return DummyResp()
 
     monkeypatch.setattr(health_router.httpx, "get", _fake_get)
-    r = await asgi_client.get("/api/health/ollama")
+    r = await asgi_client.get("/healthz/ollama")
     assert r.status_code == 200
     assert seen["tid"] != main_tid
 

--- a/tests/unit/http/test_composition.py
+++ b/tests/unit/http/test_composition.py
@@ -11,7 +11,7 @@ from local_rag_backend.composition.adapters import (
     build_retriever_with_default_embedder_from_settings,
     resolve_preferred_llm_provider,
 )
-from local_rag_backend.core.errors import EmbeddingsBackendUnavailableError
+from local_rag_backend.core.errors import EmbeddingsBackendUnavailableError, LLMConfigurationError
 
 
 def test_build_dense_embedder_uses_default_missing_backend_message():
@@ -144,5 +144,5 @@ def test_resolve_preferred_llm_provider(openai_api_key, ollama_enabled, expected
 
 def test_resolve_preferred_llm_provider_raises_when_none_available():
     cfg = SimpleNamespace(openai_api_key=None, ollama_enabled=False)
-    with pytest.raises(RuntimeError, match="No LLM configured"):
+    with pytest.raises(LLMConfigurationError, match="No LLM configured"):
         resolve_preferred_llm_provider(settings_obj=cfg)

--- a/tests/unit/http/test_cors.py
+++ b/tests/unit/http/test_cors.py
@@ -5,7 +5,7 @@ import pytest
 async def test_cors_preflight_does_not_enable_credentials(asgi_client, in_memory_sqlite):
     # Preflight request
     r = await asgi_client.options(
-        "/api/health",
+        "/api/config",
         headers={
             "Origin": "http://example.com",
             "Access-Control-Request-Method": "GET",

--- a/tests/unit/http/test_error_mapping.py
+++ b/tests/unit/http/test_error_mapping.py
@@ -20,7 +20,7 @@ from local_rag_backend.core.use_cases.errors import AppError, map_runtime_error
         (LLMTimeoutError("timeout"), 504),
         (LLMConnectionError("connection"), 503),
         (LLMResponseError("response"), 502),
-        (LLMConfigurationError("config"), 500),
+        (LLMConfigurationError("config"), 503),
         (LLMProviderError("provider"), 502),
     ],
 )

--- a/tests/unit/http/test_health_endpoints.py
+++ b/tests/unit/http/test_health_endpoints.py
@@ -9,7 +9,7 @@ class _DummyRag:
 
 
 async def test_health_endpoint_ok(asgi_client):
-    r = await asgi_client.get("/api/health")
+    r = await asgi_client.get("/healthz")
     assert r.status_code == 200
     assert r.json().get("status") == "healthy"
 
@@ -24,9 +24,9 @@ async def test_ready_endpoint_503_without_llm(asgi_client, monkeypatch):
 
     monkeypatch.setattr(health_router, "get_rag_service", _override, raising=True)
 
-    r = await asgi_client.get("/api/ready")
+    r = await asgi_client.get("/readyz")
     assert r.status_code == 503
-    assert r.json()["detail"]["status"] == "not_ready"
+    assert r.json()["status"] == "not_ready"
 
 
 async def test_ready_endpoint_200_with_openai(asgi_client, monkeypatch):
@@ -38,7 +38,7 @@ async def test_ready_endpoint_200_with_openai(asgi_client, monkeypatch):
 
     monkeypatch.setattr(health_router, "get_rag_service", _override, raising=True)
 
-    r = await asgi_client.get("/api/ready")
+    r = await asgi_client.get("/readyz")
     assert r.status_code == 200
     assert r.json()["status"] == "ready"
 
@@ -53,9 +53,9 @@ async def test_ready_endpoint_503_when_dense_index_missing(asgi_client, tmp_path
         return _DummyRag()
 
     monkeypatch.setattr(health_router, "get_rag_service", _override, raising=True)
-    r = await asgi_client.get("/api/ready")
+    r = await asgi_client.get("/readyz")
     assert r.status_code == 503
-    detail = r.json()["detail"]
+    detail = r.json()
     assert detail["status"] == "not_ready"
     assert detail["checks"]["retrieval_index"].startswith("failed")
 
@@ -82,9 +82,9 @@ async def test_ready_endpoint_503_when_dense_index_drifts_from_sql(
         return _DummyRag()
 
     monkeypatch.setattr(health_router, "get_rag_service", _override, raising=True)
-    r = await asgi_client.get("/api/ready")
+    r = await asgi_client.get("/readyz")
     assert r.status_code == 503
-    detail = r.json()["detail"]
+    detail = r.json()
     assert detail["status"] == "not_ready"
     assert detail["checks"]["retrieval_index"].startswith("failed: drift")
 
@@ -94,7 +94,7 @@ async def test_ready_endpoint_503_when_dense_index_id_set_mismatch(
 ):
     """
     Counts can match while the actual ID set differs (stale vectors + missing docs).
-    /api/ready should catch this for small corpora and return actionable drift details.
+    /readyz should catch this for small corpora and return actionable drift details.
     """
     from local_rag_backend.infrastructure.persistence.sql import SqlDocumentStorage
     from local_rag_backend.infrastructure.persistence.vector.storage import VectorStorage
@@ -118,9 +118,9 @@ async def test_ready_endpoint_503_when_dense_index_id_set_mismatch(
         return _DummyRag()
 
     monkeypatch.setattr(health_router, "get_rag_service", _override, raising=True)
-    r = await asgi_client.get("/api/ready")
+    r = await asgi_client.get("/readyz")
     assert r.status_code == 503
-    detail = r.json()["detail"]
+    detail = r.json()
     assert detail["status"] == "not_ready"
     assert detail["checks"]["retrieval_index"].startswith(
         "failed: drift detected (ID set mismatch)"
@@ -149,9 +149,9 @@ async def test_ready_endpoint_503_when_dense_id_map_is_corrupt(
         return _DummyRag()
 
     monkeypatch.setattr(health_router, "get_rag_service", _override, raising=True)
-    r = await asgi_client.get("/api/ready")
+    r = await asgi_client.get("/readyz")
     assert r.status_code == 503
-    detail = r.json()["detail"]
+    detail = r.json()
     assert detail["status"] == "not_ready"
     assert detail["checks"]["retrieval_index"].startswith("failed: corrupt")
 
@@ -176,9 +176,9 @@ async def test_ready_endpoint_503_when_dense_manifest_missing(
 
     monkeypatch.setattr(health_router, "get_rag_service", _override, raising=True)
 
-    r = await asgi_client.get("/api/ready")
+    r = await asgi_client.get("/readyz")
     assert r.status_code == 503
-    detail = r.json()["detail"]
+    detail = r.json()
     assert detail["status"] == "not_ready"
     assert "manifest" in detail["checks"]["retrieval_index_stats"].get("error", "")
 
@@ -225,9 +225,9 @@ async def test_ready_endpoint_503_when_dense_manifest_mismatch_embedding_model(
 
     monkeypatch.setattr(health_router, "get_rag_service", _override, raising=True)
 
-    r = await asgi_client.get("/api/ready")
+    r = await asgi_client.get("/readyz")
     assert r.status_code == 503
-    detail = r.json()["detail"]
+    detail = r.json()
     assert detail["status"] == "not_ready"
     stats = detail["checks"]["retrieval_index_stats"]
     assert stats["status"] == "drift"
@@ -273,12 +273,12 @@ async def test_rebuild_index_rewrites_manifest_and_ready_becomes_ok(
     monkeypatch.setattr(health_router, "get_rag_service", _override, raising=True)
 
     # Not ready due to manifest drift.
-    r1 = await asgi_client.get("/api/ready")
+    r1 = await asgi_client.get("/readyz")
     assert r1.status_code == 503
 
     # Rebuild should rewrite manifest to match current settings.
     rr = await asgi_client.post("/api/index/rebuild")
     assert rr.status_code == 200
 
-    r2 = await asgi_client.get("/api/ready")
+    r2 = await asgi_client.get("/readyz")
     assert r2.status_code == 200

--- a/tests/unit/test_cli_eval.py
+++ b/tests/unit/test_cli_eval.py
@@ -38,3 +38,21 @@ def test_rag_eval_fails_below_threshold(tmp_path: Path) -> None:
     )
     assert r.exit_code == 1, r.output
     assert "Eval regression" in r.output
+
+
+def test_rag_eval_reports_invalid_jsonl_cleanly(tmp_path: Path) -> None:
+    ds = tmp_path / "bad.jsonl"
+    ds.write_text('{"not":"valid"\n', encoding="utf-8")
+
+    r = CliRunner().invoke(cli, ["eval", "--dataset", str(ds)])
+    assert r.exit_code == 1
+    assert "[ERROR] Error evaluating dataset:" in r.output
+
+
+def test_rag_eval_reports_empty_dataset_cleanly(tmp_path: Path) -> None:
+    ds = tmp_path / "empty.jsonl"
+    ds.write_text("", encoding="utf-8")
+
+    r = CliRunner().invoke(cli, ["eval", "--dataset", str(ds)])
+    assert r.exit_code == 1
+    assert "[ERROR] Error evaluating dataset:" in r.output

--- a/uv.lock
+++ b/uv.lock
@@ -3698,14 +3698,13 @@ wheels = [
 
 [[package]]
 name = "rag-prototype"
-version = "1.0.0"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "click", marker = "python_full_version < '3.13'" },
     { name = "httpx", marker = "python_full_version < '3.13'" },
     { name = "numpy", marker = "python_full_version < '3.13'" },
     { name = "openai", marker = "python_full_version < '3.13'" },
-    { name = "pre-commit", marker = "python_full_version < '3.13'" },
     { name = "pydantic", marker = "python_full_version < '3.13'" },
     { name = "pydantic-settings", marker = "python_full_version < '3.13'" },
     { name = "python-dotenv", marker = "python_full_version < '3.13'" },
@@ -3808,7 +3807,6 @@ requires-dist = [
     { name = "openai", specifier = ">=1.24,<2.0" },
     { name = "orjson", marker = "extra == 'performance'", specifier = ">=3.10,<4.0" },
     { name = "orjson", marker = "extra == 'performance-cpu'", specifier = ">=3.10,<4.0" },
-    { name = "pre-commit", specifier = ">=4.5.1" },
     { name = "prometheus-client", marker = "extra == 'monitoring'", specifier = ">=0.19,<1.0" },
     { name = "pydantic", specifier = ">=2.0,<3.0" },
     { name = "pydantic-settings", specifier = ">=2.2,<3.0" },


### PR DESCRIPTION
## Summary

This PR implements the last-mille breaking cleanup requested from beta feedback:
- Strict bootstrap CSV resolution (no silent fallback)
- Robust  error handling for invalid/empty datasets
-   now returns 503 for missing LLM config and preserves 422 request validation
- Health/readiness contract moved to public probes: , , 
- Removed  and  (breaking)\n- Updated docs and tests to match the new contract

## Breaking Changes
1. Removed endpoints: , 
3. New probe endpoints: must point to an existing file; bootstrap no longer falls back silently
5. Readiness 503 payload is now top-level  (no  wrapper

## Validation
- All checks passed!