### PR TITLE
feat(search-engine): add Elasticsearch backend and canonical import/sync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,8 +16,10 @@ CORS_ALLOW_ORIGINS=
 
 # --- Retrieval ---
 # sparse | dense | hybrid (default is sparse for a lightweight base install)
-# Note: dense/hybrid require the optional 'dense' extra (FAISS + SentenceTransformers).
+# local_split: sparse|dense|hybrid
+# elasticsearch: dense|hybrid
 RETRIEVAL_MODE=sparse
+PERSISTENCE_BACKEND=local_split
 HYBRID_RETRIEVAL_ALPHA=0.5
 
 # --- SQLite / datos ---
@@ -40,8 +42,26 @@ INGEST_CLEAN_STRIP=true
 
 # --- Embeddings (SentenceTransformers por defecto) ---
 ST_EMBEDDING_MODEL=all-MiniLM-L6-v2
+# local_split only
+VECTOR_BACKEND=auto
 INDEX_PATH=data/index.faiss
 ID_MAP_PATH=data/id_map.json
+
+# --- Elasticsearch (backend unificado; dense/hybrid only) ---
+ES_BASE_URL=
+ES_API_KEY=
+ES_USERNAME=
+ES_PASSWORD=
+ES_VERIFY_TLS=true
+ES_REQUEST_TIMEOUT_S=30.0
+ES_DOCS_INDEX=rag-docs
+ES_HISTORY_INDEX=rag-history
+ES_SYSTEM_INDEX=rag-system
+ES_TOMBSTONES_INDEX=rag-tombstones
+ES_CONTENT_FIELD=content
+ES_EMBEDDING_FIELD=embedding
+ES_HYBRID_LEXICAL_K=50
+ES_HYBRID_VECTOR_K=50
 
 # --- OpenAI (opcional) ---
 OPENAI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -275,6 +275,12 @@ cat > /tmp/mutate_upsert.json <<'JSON'
 JSON
 rag-mutate-docs --json /tmp/mutate_upsert.json
 
+# Canonical external import/sync (e.g. RepoGPT code-units)
+cat > /tmp/canonical_import.json <<'JSON'
+{"scope":"repogpt:demo","snapshot_id":"snap-1","documents":[{"external_id":"repogpt:demo:1","source_id":"repogpt:demo:file:src/app.py","content":"def hello():\n    return 1\n","metadata":{"path":"src/app.py","unit_type":"function"}}]}
+JSON
+rag-import-canonical --json /tmp/canonical_import.json
+
 # Delete by SQL doc IDs
 cat > /tmp/mutate_delete_ids.json <<'JSON'
 {"op_id":"op-del-ids-1","delete_ids":["doc:...","doc:..."]}
@@ -406,6 +412,7 @@ docker compose up -d
 * `POST /api/docs` (ingest texts) and `GET /api/docs` (list docs)
 * `POST /api/docs/import` (ingest conversations from ChatGPT/Gemini export JSON)
 * `POST /api/docs/mutate` (canonical unified docs mutation: upserts, delete_ids, delete_external_ids)
+* `POST /api/docs/import-canonical` (scope/snapshot import for external producers such as RepoGPT)
 * `POST /api/index/rebuild` (idempotent rebuild of retrieval state from the canonical document store; dense/hybrid only)
 * `POST /api/openrouter/generate` (enabled if OpenRouter configured)
 
@@ -414,7 +421,7 @@ Notes:
 * Retrieval “scores” are normalized to [0,1] in the adapters.
 * The service persists each Q/A with the IDs of the retrieved sources (best-effort; retrieval/answer response is not blocked if history persistence fails).
 * For `/api/ask`, default provider selection is `ollama` -> `openai` -> `openrouter` depending on active configuration.
-* In dense/hybrid mode, write via `/api/docs/mutate` (or `rag-mutate-docs`) rather than mutating stores independently.
+* In dense/hybrid mode, write via `/api/docs/mutate`, `/api/docs/import-canonical`, `rag-mutate-docs`, or `rag-import-canonical` rather than mutating stores independently.
 * `local_split` uses `MutationCoordinator` with `DURABLE_SAGA`: SQL commit + vector delta (`apply_delta_atomic`) + journaled compensation/recovery.
 * `elasticsearch` uses `MutationCoordinator` with an atomic backend path: document, vector, history, system-state, and tombstone semantics are unified in Elasticsearch.
 * Full rebuild is an explicit repair operation only (`/api/index/rebuild` or `rag-rebuild-index`), not a normal write fallback.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Downloads](https://img.shields.io/pypi/dm/rag-prototype.svg)](https://pypi.org/project/rag-prototype/) -->
 
 > General-purpose RAG system with a hexagonal architecture (Ports & Adapters), FastAPI, three retrieval modes (BM25, dense vector, hybrid), and swappable LLM connectors (OpenAI, OpenRouter, Ollama). Designed as a solid base to iterate in experimental environments.
-> Default runtime mode is `sparse` (SQLite-only). In dense/hybrid modes, vector state is persisted to disk (`faiss` or `numpy` backend).
+> Default runtime mode is `sparse` on `local_split` persistence (`SQLite` only). Dense/hybrid can run either on `local_split` (`SQLite + faiss/numpy`) or on a unified Elasticsearch backend.
 
 ---
 
@@ -24,8 +24,8 @@
 * **Retrieval**
 
   * Sparse: BM25 (offline).
-  * Dense: vector index (`faiss`/`numpy`) + embeddings backend (OpenAI or SentenceTransformers).
-  * Hybrid: dense + BM25 combination with configurable weight.
+  * Dense: local vector index (`faiss`/`numpy`) or unified Elasticsearch vector search.
+  * Hybrid: local dense+BM25 combination or Elasticsearch lexical+vector fusion.
 * **LLMs**
 
   * OpenAI Chat (via API key).
@@ -33,8 +33,8 @@
   * Local Ollama (over HTTP). Current clients are synchronous.
 * **Persistence**
 
-  * SQLite via SQLAlchemy: documents and Q\&A history.
-  * Vector index on disk for dense/hybrid mode (`faiss` or `numpy` backend).
+  * `local_split`: SQLite via SQLAlchemy for documents/history + on-disk vector index for dense/hybrid.
+  * `elasticsearch`: unified documents, vectors, history, system state, and tombstones in Elasticsearch.
 * **API**
 
   * FastAPI with validation and OpenAPI at `/docs`.
@@ -63,7 +63,7 @@ source .venv/bin/activate
 # Install runtime deps (uses uv.lock); --extra server adds FastAPI/uvicorn
 uv sync --frozen --extra server
 
-# (Optional) Dense/Hybrid deps (FAISS)
+# (Optional) Dense/Hybrid deps for local split backend (FAISS)
 # uv sync --frozen --extra server --extra dense
 #
 # (Optional) SentenceTransformers embeddings (heavy: torch/transformers)
@@ -76,7 +76,7 @@ uv sync --frozen --extra server
 Initialize sample data and start:
 
 ```bash
-# Load sample CSV into SQLite and, if applicable, build vector index
+# Load sample CSV into the configured backend and, if applicable, build/rebuild retrieval state
 rag-bootstrap
 
 
@@ -115,6 +115,7 @@ Key variables (non-exhaustive):
 | `PUBLIC_BIND_REQUIRES_API_KEY`   | `true`                    | security     | Refuse unsafe public startup and reject non-local `/api/*` + `/metrics` requests when `API_KEY` is unset |
 | `CORS_ALLOW_ORIGINS`             | `[]`                      | security     | Allowed CORS origins when `DEBUG=false` (JSON list or comma-separated) |
 | `RETRIEVAL_MODE`                 | `sparse`                  | retrieval    | `sparse` \| `dense` \| `hybrid`                        |
+| `PERSISTENCE_BACKEND`            | `local_split`             | storage      | `local_split` \| `elasticsearch`                       |
 | `DATA_DIR`                       | `data`                    | storage      | Base data directory (SQLite parent, vector index paths) |
 | `SQLITE_URL`                     | `sqlite:///./data/app.db` | storage      | SQLite URL                                             |
 | `FAQ_CSV`                        | `data/faq.csv`            | ingestion    | FAQ CSV                                                |
@@ -130,8 +131,8 @@ Key variables (non-exhaustive):
 | `INGEST_CLEAN_STRIP`             | `true`                    | ingestion    | Strip leading/trailing whitespace                       |
 | `ST_EMBEDDING_MODEL`             | `all-MiniLM-L6-v2`        | dense/hybrid | SentenceTransformers model                             |
 | `OPENAI_EMBEDDING_MODEL`         | `text-embedding-3-small`  | OpenAI       | Embeddings model                                       |
-| `VECTOR_BACKEND`                 | `auto`                    | dense/hybrid | Vector backend selector: `auto` \| `faiss` \| `numpy` |
-| `STORAGE_PROFILE`                | _(auto)_                  | consistency  | Optional explicit storage profile (`sql_only_local`, `sql_faiss_local`, `sql_numpy_local`) |
+| `VECTOR_BACKEND`                 | `auto`                    | local_split  | Vector backend selector: `auto` \| `faiss` \| `numpy` |
+| `STORAGE_PROFILE`                | _(auto)_                  | consistency  | Optional explicit storage profile (`sql_only_local`, `sql_faiss_local`, `sql_numpy_local`, `es_unified_dense`, `es_unified_hybrid`) |
 | `WRITE_LOCK_TIMEOUT_S`           | `30.0`                    | consistency  | Timeout (seconds) for multi-store write lock           |
 | `WRITE_LOCK_POLL_S`              | `0.05`                    | consistency  | Poll interval (seconds) while waiting for lock         |
 | `MUTATION_BATCH_MAX_SIZE`        | `32`                      | consistency  | Max queued mutation requests coalesced per batch cycle (`1..512`) |
@@ -141,6 +142,20 @@ Key variables (non-exhaustive):
 | `INDEX_PATH`                     | `data/index.faiss`        | dense/hybrid | FAISS file                                             |
 | `ID_MAP_PATH`                    | `data/id_map.json`        | dense/hybrid | FAISS ID map (JSON)                                    |
 | (derived) `index_manifest.json`  | `data/index_manifest.json`| dense/hybrid | Index manifest (model/dim/chunker) for drift detection |
+| `ES_BASE_URL`                    | —                         | elasticsearch| Elasticsearch base URL                                 |
+| `ES_API_KEY`                     | —                         | elasticsearch| Elasticsearch API key                                  |
+| `ES_USERNAME`                    | —                         | elasticsearch| Elasticsearch username                                 |
+| `ES_PASSWORD`                    | —                         | elasticsearch| Elasticsearch password                                 |
+| `ES_VERIFY_TLS`                  | `true`                    | elasticsearch| Verify TLS certificates                                |
+| `ES_REQUEST_TIMEOUT_S`           | `30.0`                    | elasticsearch| HTTP timeout for Elasticsearch                          |
+| `ES_DOCS_INDEX`                  | `rag-docs`                | elasticsearch| Documents index                                         |
+| `ES_HISTORY_INDEX`               | `rag-history`             | elasticsearch| History index                                           |
+| `ES_SYSTEM_INDEX`                | `rag-system`              | elasticsearch| System state / cache invalidation index                |
+| `ES_TOMBSTONES_INDEX`            | `rag-tombstones`          | elasticsearch| Tombstones index                                        |
+| `ES_CONTENT_FIELD`               | `content`                 | elasticsearch| Text field used for lexical retrieval                   |
+| `ES_EMBEDDING_FIELD`             | `embedding`               | elasticsearch| Dense vector field                                      |
+| `ES_HYBRID_LEXICAL_K`            | `50`                      | elasticsearch| Lexical candidate pool for hybrid                       |
+| `ES_HYBRID_VECTOR_K`             | `50`                      | elasticsearch| Vector candidate pool for hybrid                        |
 | `ENABLE_RERANKER`                | `false`                   | retrieval    | Wrap selected retriever with reranking layer           |
 | `RERANKER_CANDIDATE_K`           | `20`                      | retrieval    | Candidate set size fetched before reranking (`3..200`) |
 | `RERANKER_STRATEGY`              | `overlap_v1`              | retrieval    | Reranker strategy identifier                            |
@@ -166,9 +181,18 @@ Key variables (non-exhaustive):
 | `OLLAMA_PROMPT_TEMPLATE`         | _(builtin template)_      | prompting    | Prompt template for Ollama generator                   |
 
 
-### Index manifest (dense/hybrid)
+### Backend matrix
 
-When `RETRIEVAL_MODE=dense|hybrid`, the system writes an `index_manifest.json` next to `INDEX_PATH`.
+| Persistence backend | Retrieval modes | Canonical write model | Notes |
+| --- | --- | --- | --- |
+| `local_split` | `sparse`, `dense`, `hybrid` | `DURABLE_SAGA` | `sparse` is SQLite-only; dense/hybrid use SQLite + local vector state |
+| `elasticsearch` | `dense`, `hybrid` | `ATOMIC` | Unified docs/history/vectors/system-state/tombstones in Elasticsearch |
+
+`PERSISTENCE_BACKEND=elasticsearch` rejects `RETRIEVAL_MODE=sparse` at startup.
+
+### Index manifest (`local_split` dense/hybrid only)
+
+When `PERSISTENCE_BACKEND=local_split` and `RETRIEVAL_MODE=dense|hybrid`, the system writes an `index_manifest.json` next to `INDEX_PATH`.
 It records stable identifiers for the index build (embedding backend/model, dimension, chunker strategy/version).
 
 If you change any of these settings, `/api/ready` and `rag-status` will report drift and instruct you to rebuild:
@@ -184,10 +208,14 @@ If you change any of these settings, `/api/ready` and `rag-status` will report d
 
 * `RETRIEVAL_MODE=sparse`:
   `RetrieverPort := SparseBM25Retriever` (BM25 corpus + SQL doc repo)
-* `RETRIEVAL_MODE=dense`:
-  `RetrieverPort := DenseVectorRetriever` (embedder + vector index + SQL doc repo)
-* `RETRIEVAL_MODE=hybrid`:
+* `PERSISTENCE_BACKEND=local_split` and `RETRIEVAL_MODE=dense`:
+  `RetrieverPort := DenseVectorRetriever` (embedder + local vector index + SQL doc repo)
+* `PERSISTENCE_BACKEND=local_split` and `RETRIEVAL_MODE=hybrid`:
   `RetrieverPort := HybridRetriever(DenseVectorRetriever, SparseBM25Retriever, alpha)`
+* `PERSISTENCE_BACKEND=elasticsearch` and `RETRIEVAL_MODE=dense`:
+  `RetrieverPort := DenseVectorRetriever` (embedder + Elasticsearch vector repo + ES doc repo)
+* `PERSISTENCE_BACKEND=elasticsearch` and `RETRIEVAL_MODE=hybrid`:
+  `RetrieverPort := HybridRetriever(DenseVectorRetriever, Elastic lexical retriever, alpha)`
 * If `ENABLE_RERANKER=true`, the selected retriever is wrapped as:
   `RetrieverPort := RerankingRetriever(base=<selected>)`
 
@@ -207,10 +235,14 @@ The ingestion process is orchestrated by `IngestionPipeline`:
 ### CLI support
 
 * **Sparse**: stores directly in SQLite (no embeddings required).
-* **Dense / Hybrid**:
+* **Dense / Hybrid on `local_split`**:
   1. Save chunks in SQLite
   2. Generate embeddings with OpenAI (if `OPENAI_API_KEY`) or SentenceTransformers (`ST_EMBEDDING_MODEL`)
   3. Upsert into the vector index (`INDEX_PATH`, `ID_MAP_PATH`)
+* **Dense / Hybrid on `elasticsearch`**:
+  1. Generate embeddings for changed chunks
+  2. Upsert documents and embeddings atomically by `external_id`
+  3. Use native Elasticsearch lexical/vector retrieval for runtime queries
 
 Chunking parameters (in settings):
 
@@ -233,7 +265,7 @@ rag-ingest ./my_notes ./docs/handbook.md ./data/faq.csv
 rag-ingest --no-follow-symlinks ./docs
 
 
-# Rebuild vector index from current SQLite documents (idempotent; dense/hybrid only)
+# Rebuild retrieval state from the current document store (idempotent; dense/hybrid only)
 rag-rebuild-index
 
 
@@ -312,8 +344,8 @@ Notes:
 - Backend listens on `8000`, Ollama on `11434`.
 - Configure providers via `.env` or environment variables (see `.env.example`).
 - In `docker-compose.yml`, `OLLAMA_ENABLED=true` and `OLLAMA_BASE_URL=http://ollama:11434` are set.
-- `docker-compose.yml` defaults to `RETRIEVAL_MODE=sparse` for a lightweight image.
-- For dense/hybrid in compose, build backend with extras, for example:
+- `docker-compose.yml` defaults to `PERSISTENCE_BACKEND=local_split` and `RETRIEVAL_MODE=sparse` for a lightweight image.
+- For `local_split` dense/hybrid in compose, build backend with extras, for example:
 
 ```bash
 docker compose build --build-arg RAG_EXTRAS=dense rag-backend
@@ -374,7 +406,7 @@ docker compose up -d
 * `POST /api/docs` (ingest texts) and `GET /api/docs` (list docs)
 * `POST /api/docs/import` (ingest conversations from ChatGPT/Gemini export JSON)
 * `POST /api/docs/mutate` (canonical unified docs mutation: upserts, delete_ids, delete_external_ids)
-* `POST /api/index/rebuild` (idempotent rebuild of vector index from SQLite; dense/hybrid only)
+* `POST /api/index/rebuild` (idempotent rebuild of retrieval state from the canonical document store; dense/hybrid only)
 * `POST /api/openrouter/generate` (enabled if OpenRouter configured)
 
 Notes:
@@ -382,11 +414,13 @@ Notes:
 * Retrieval “scores” are normalized to [0,1] in the adapters.
 * The service persists each Q/A with the IDs of the retrieved sources (best-effort; retrieval/answer response is not blocked if history persistence fails).
 * For `/api/ask`, default provider selection is `ollama` -> `openai` -> `openrouter` depending on active configuration.
-* In dense/hybrid mode, the vector index is **derived operational state**; write via `/api/docs/mutate` (or `rag-mutate-docs`) rather than mutating stores independently.
-* Write-path consistency uses `MutationCoordinator` with `DURABLE_SAGA`: SQL commit + vector delta (`apply_delta_atomic`) + journaled compensation/recovery.
+* In dense/hybrid mode, write via `/api/docs/mutate` (or `rag-mutate-docs`) rather than mutating stores independently.
+* `local_split` uses `MutationCoordinator` with `DURABLE_SAGA`: SQL commit + vector delta (`apply_delta_atomic`) + journaled compensation/recovery.
+* `elasticsearch` uses `MutationCoordinator` with an atomic backend path: document, vector, history, system-state, and tombstone semantics are unified in Elasticsearch.
 * Full rebuild is an explicit repair operation only (`/api/index/rebuild` or `rag-rebuild-index`), not a normal write fallback.
 * v1.0 removed legacy write endpoints: `/api/docs/upsert`, `/api/docs/delete`, `/api/docs/delete_by_external_id`.
-* In dense/hybrid mode, `/api/ready` is intentionally strict and returns `503` when it detects missing/corrupt index files or drift between SQLite documents and the vector index (hinting how to rebuild).
+* In `local_split` dense/hybrid mode, `/api/ready` is intentionally strict and returns `503` when it detects missing/corrupt index files or drift between SQLite documents and the vector index.
+* In `elasticsearch` mode, `/api/ready` validates backend connectivity, index existence, mapping dimensions, and embedded-document counts.
 * For public/proxy deployments, use `API_KEY` and sanitize `X-Forwarded-For` / `Forwarded` at the edge proxy.
 
 Example:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,11 @@ services:
       # Security (recommended when exposing beyond localhost)
       # - API_KEY=${API_KEY}
       # - CORS_ALLOW_ORIGINS=["http://localhost:5173"]
-      # Default sparse lightweight image. For dense/hybrid, install `dense` extra
+      # Default lightweight image.
+      # local_split => sparse|dense|hybrid
+      # elasticsearch => dense|hybrid (requires external ES service/env)
+      - PERSISTENCE_BACKEND=local_split
+      # For local_split dense/hybrid, install the `dense` extra
       - RETRIEVAL_MODE=sparse # if dense set accordingly.
       # OpenAI (optional)
       # - OPENAI_API_KEY=${OPENAI_API_KEY}

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -41,8 +41,20 @@ OLLAMA_MODEL="lfm2.5-thinking" # O el modelo que prefieras
 # Para empezar, 'sparse' es el más sencillo ya que no requiere embeddings.
 RETRIEVAL_MODE="sparse"
 
+# Topología de persistencia:
+# - local_split: SQLite (+ índice vectorial local en dense/hybrid)
+# - elasticsearch: backend unificado; solo soporta dense/hybrid
+PERSISTENCE_BACKEND="local_split"
+
 # Ruta de la base de datos para almacenar los documentos
 SQLITE_URL="sqlite:///./data/custom_app.db"
+
+# Si usas PERSISTENCE_BACKEND=elasticsearch:
+# ES_BASE_URL="http://localhost:9200"
+# ES_DOCS_INDEX="rag-docs"
+# ES_HISTORY_INDEX="rag-history"
+# ES_SYSTEM_INDEX="rag-system"
+# ES_TOMBSTONES_INDEX="rag-tombstones"
 
 # Opcional: ajusta los parámetros de logging
 LOG_LEVEL="INFO"
@@ -113,6 +125,7 @@ def main():
     print("--- Iniciando script de ingesta ---")
 
     # 4. Configurar la base de datos
+    # Este ejemplo es para local_split/sparse. En elasticsearch no necesitas abrir SQLite.
     # Asegurarse de que el directorio de datos exista
     settings.data_dir.mkdir(parents=True, exist_ok=True)
     engine = create_engine(settings.sqlite_url)
@@ -211,7 +224,8 @@ rag-ingest --dry-run ./docs
 
 Notas:
 
-* En `dense`/`hybrid`, la CLI actualiza SQLite y el índice vectorial de forma consistente (FAISS o NumPy, según `VECTOR_BACKEND`) y borra chunks obsoletos si un fichero se acorta.
+* En `local_split` + `dense`/`hybrid`, la CLI actualiza SQLite y el índice vectorial local de forma consistente (FAISS o NumPy, según `VECTOR_BACKEND`) y borra chunks obsoletos si un fichero se acorta.
+* En `elasticsearch` + `dense`/`hybrid`, la CLI usa el backend unificado: documentos, embeddings, history, system state y tombstones viven en Elasticsearch.
 * La detección de formato es best-effort (no solo extensión). Opcionalmente puedes instalar `python-magic` con el extra `magic`.
 * Si no quieres seguir enlaces simbólicos (incluyendo rutas raíz que sean symlink), usa `--no-follow-symlinks`.
 
@@ -219,8 +233,10 @@ Notas:
 
 ## Mantenimiento (dense/hybrid): mutación canónica + repair explícito
 
-En `dense`/`hybrid`, SQLite es el store de entidad y el índice vectorial es estado operacional incremental.
-El write-path canónico usa `MutationCoordinator` (`DURABLE_SAGA`) con journal duradero.
+`MutationCoordinator` es el write-path canónico en ambos backends:
+
+* `local_split`: `DURABLE_SAGA` con journal duradero, SQLite como store canónico y vector index local como estado derivado.
+* `elasticsearch`: path atómico sobre backend unificado; no hay journal de mutación local ni lock SQL.
 
 ### 1) CLI (canónico)
 
@@ -243,7 +259,7 @@ cat > /tmp/mutate_delete_ext.json <<'JSON'
 JSON
 rag-mutate-docs --json /tmp/mutate_delete_ext.json
 
-# Repair explícito del índice
+# Repair explícito del estado de retrieval
 rag-rebuild-index
 ```
 
@@ -298,7 +314,11 @@ summary = coordinator.execute(
 print(summary)
 ```
 
-Nota: el rebuild completo queda para reparación explícita (`rag-rebuild-index` / `POST /api/index/rebuild`), no como fallback normal de mutación.
+Notas:
+
+* En `local_split`, el rebuild recompone el índice vectorial local desde el store canónico.
+* En `elasticsearch`, el rebuild re-embebe los documentos del índice de documentos y actualiza los vectores in-place.
+* El rebuild completo queda para reparación explícita (`rag-rebuild-index` / `POST /api/index/rebuild`), no como fallback normal de mutación.
 
 ---
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -259,6 +259,23 @@ cat > /tmp/mutate_delete_ext.json <<'JSON'
 JSON
 rag-mutate-docs --json /tmp/mutate_delete_ext.json
 
+# Import/sync canónico para productores externos (p.ej. RepoGPT)
+cat > /tmp/canonical_import.json <<'JSON'
+{
+  "scope":"repogpt:demo",
+  "snapshot_id":"snap-1",
+  "documents":[
+    {
+      "external_id":"repogpt:demo:1",
+      "source_id":"repogpt:demo:file:src/app.py",
+      "content":"def hello():\n    return 1\n",
+      "metadata":{"path":"src/app.py","unit_type":"function"}
+    }
+  ]
+}
+JSON
+rag-import-canonical --json /tmp/canonical_import.json
+
 # Repair explícito del estado de retrieval
 rag-rebuild-index
 ```
@@ -279,6 +296,10 @@ curl -X POST "http://localhost:8000/api/docs/mutate" \
 curl -X POST "http://localhost:8000/api/docs/mutate" \
   -H "Content-Type: application/json" \
   -d '{"op_id":"op-2","delete_external_ids":["chunk:<sha256>"]}'
+
+curl -X POST "http://localhost:8000/api/docs/import-canonical" \
+  -H "Content-Type: application/json" \
+  -d '{"scope":"repogpt:demo","snapshot_id":"snap-1","replace_scope":true,"documents":[{"external_id":"repogpt:demo:1","source_id":"repogpt:demo:file:src/app.py","content":"def hello():\n    return 1\n","metadata":{"path":"src/app.py","unit_type":"function"}}]}'
 
 curl -X POST "http://localhost:8000/api/index/rebuild"
 ```
@@ -319,6 +340,7 @@ Notas:
 * En `local_split`, el rebuild recompone el índice vectorial local desde el store canónico.
 * En `elasticsearch`, el rebuild re-embebe los documentos del índice de documentos y actualiza los vectores in-place.
 * El rebuild completo queda para reparación explícita (`rag-rebuild-index` / `POST /api/index/rebuild`), no como fallback normal de mutación.
+* `rag-import-canonical` / `POST /api/docs/import-canonical` hacen sync por `scope + snapshot_id`; con `replace_scope=true` eliminan documentos obsoletos sin crear tombstones.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,11 +7,14 @@
 
 ## 0) TL;DR (90 seconds)
 
-- **What:** `rag-prototype` is a local-first RAG system (library + CLI + optional FastAPI transport) built as a modular monolith with hexagonal boundaries. Today it runs with SQL + local vector index adapters, and target architecture evolves to backend-agnostic persistence adapters (split-store or unified-store engines).
+- **What:** `rag-prototype` is a local-first RAG system (library + CLI + optional FastAPI transport) built as a modular monolith with hexagonal boundaries. Today it supports both split-store persistence (`local_split`: SQLite + local vector index) and unified persistence (`elasticsearch`), while keeping application contracts backend-agnostic.
 - **Why:** The immediate priority is architectural stabilization and decoupling (not feature expansion). We will accept breaking changes to eliminate structural debt now and freeze a clean first deliverable.
 - **How:**
   - Domain + ports in `core/`, adapters in `infrastructure/`, composition in `composition/`, transports in `http/` and `cli_commands/`.
-  - Canonical write path via `MutationCoordinator` (thin orchestrator), with batch and saga execution delegated to dedicated modules. Current write consistency model is `DURABLE_SAGA`; capability-driven alternatives are future work.
+  - Canonical write path via `MutationCoordinator` (thin orchestrator), with batch and execution strategy delegated to dedicated modules.
+  - Current write consistency model is capability-driven:
+    - `local_split` => `DURABLE_SAGA`
+    - `elasticsearch` => `ATOMIC`
   - SQL writes inside canonical mutation run under explicit `mutation_uow_factory` and shared SQL session context (`session_uow`).
   - App/runtime wiring centralized in `AppContainer` + `composition/*`.
   - Architecture guard tests enforce import boundaries in CI.
@@ -46,7 +49,7 @@
 - Legal / regulatory: no special regulated-domain requirement declared for D1.
 - Budget / latency / throughput: local-first single-node operation, optional Docker; avoid infra-heavy dependencies by default.
 - Team: small maintainer set; changes must be reviewable in small increments.
-- Tech (languages, runtime, hosting): Python 3.11/3.12, `uv`, FastAPI optional extra (`server`). Current baseline uses SQLite + local vector index, but architecture must support unified engines (ElasticSearch, pgvector, Qdrant) through ports.
+- Tech (languages, runtime, hosting): Python 3.11/3.12, `uv`, FastAPI optional extra (`server`). Current supported backends are `local_split` (SQLite + local vector index) and `elasticsearch`, and architecture must keep room for future unified engines (OpenSearch, pgvector, Qdrant) through ports.
 - Product constraint: breaking changes explicitly allowed for this deliverable.
 
 ### 1.4 Quality attributes
@@ -55,7 +58,7 @@
 | ------------ | -----: | ----------- |
 | Latency p95 (`POST /api/ask`, sparse, local sample dataset) | <= 2000ms | `rag_query_duration_seconds` metric + e2e smoke |
 | Availability (single instance) | >= 99.0% in controlled environment | `/api/health` + `/api/ready` checks |
-| Consistency | `DURABLE_SAGA` (current write model), with capability-driven variants as future work | mutation journal recovery tests + integration tests |
+| Consistency | capability-driven (`DURABLE_SAGA` or `ATOMIC`) | mutation/recovery tests + integration tests |
 | Cost | single-node local runtime (no mandatory external SaaS except optional LLM provider) | Docker/local runtime footprint |
 
 ### 1.5 Definition of Done (Deliverable D1)
@@ -92,8 +95,8 @@
 | ------- | -------------- | ---------: | ------------- | ----------- |
 | Retrieval Query | Retrieve docs + generate answer | No | LLM adapters, retrievers | `/api/ask`, `/api/ask_eval`, `RagService.ask` |
 | Document Mutation | Canonical write orchestration SQL + vector | Yes | SQL repo, vector repo, embedder | `/api/docs`, `/api/docs/import`, `/api/docs/mutate`, `rag-mutate-docs`, `rag-ingest` |
-| Index Maintenance | Rebuild/repair vector index | Yes | embedder + vector adapter | `/api/index/rebuild`, `rag-rebuild-index` |
-| Health/Diagnostics | Readiness/consistency diagnostics | No | persistence diagnostics adapters, manifest/index files | `/api/health`, `/api/ready`, `rag-status` |
+| Index Maintenance | Rebuild/repair retrieval state | Yes | embedder + persistence/vector adapters | `/api/index/rebuild`, `rag-rebuild-index` |
+| Health/Diagnostics | Readiness/consistency diagnostics | No | persistence diagnostics adapters, manifest/index files, ES mappings | `/api/health`, `/api/ready`, `rag-status` |
 | Transport (HTTP/CLI) | Input/output mapping + auth + error translation | No | FastAPI/Click | REST + CLI commands |
 | Composition Runtime | Dependency wiring + runtime cache invalidation | No | settings + adapters | DI factory/container |
 
@@ -137,15 +140,15 @@
 ## 3) Data model
 
 ### 3.1 Storage overview
-- Current baseline:
-  - relational persistence via SQLite + SQLAlchemy;
-  - vector index via FAISS/numpy adapters on local disk.
+- Current supported backends:
+  - `local_split`: relational persistence via SQLite + SQLAlchemy plus vector index via FAISS/numpy adapters on local disk.
+  - `elasticsearch`: unified document/vector/history/system-state/tombstone persistence via HTTP adapter.
 - Target abstraction:
   - application uses persistence ports and capability profile, not concrete store topology;
   - supported topologies:
     - split-store (`DocumentRepoPort` + `VectorRepoPort`);
     - unified-store (single adapter handles document + vector + metadata operations).
-- Cache: in-process runtime cache (`RagService` cache versioned via `system_state`).
+- Cache: in-process runtime cache (`RagService` cache versioned via `system_state`, stored in SQLite or Elasticsearch depending on backend).
 - Files / blobs: local filesystem (`data/`, index artifacts, mutation journal).
 - Concurrency locks: OS-level file/write lock adapters in `infrastructure/concurrency/locks/{file_lock.py,write_lock.py}`.
 - Evaluation fixtures: repository-level datasets under `datasets/` (for example `datasets/rag_eval_v1.jsonl`), optionally overridden by `RAG_EVAL_DATASET_PATH`.
@@ -195,11 +198,11 @@
 ## 4) Invariants & validation
 
 ### 4.1 Global invariants
-- Multi-store write operations are serialized under shared write lock.
-- Canonical write flow is journaled and recoverable (`DURABLE_SAGA`).
+- Multi-store write operations are serialized under shared write lock when the active storage profile requires `DURABLE_SAGA`.
+- Canonical write flow is strategy-driven by `StorageProfile` capability (`DURABLE_SAGA` or `ATOMIC`).
 - Canonical SQL mutation and SQL compensation run inside explicit unit-of-work boundaries.
 - When UoW is active, SQL repositories must reuse the bound session and must not force early commit.
-- Lock scope is bounded to local commit work only (journal transition + SQL + vector/index commit).
+- Lock scope is bounded to local commit work only when the active backend requires split-store coordination.
 - Network I/O (`embeddings`/provider calls) must never execute while holding `multiprocess_write_lock`.
 - Mutation requests may be coalesced before lock acquisition and drained as bounded micro-batches (`max_batch_size`, `max_wait_ms`).
 - Dense/hybrid mutation cannot silently proceed when embeddings backend is unavailable.
@@ -220,10 +223,11 @@
 - Idempotency: `op_id` in mutation intent guarantees replay-safe behavior.
 - Retry safety: incomplete mutation records are recoverable at startup/background intervals.
 - Embedding failures are pre-lock failures: they must not leave partial SQL/vector state.
-- Batch mutation failures preserve per-item safety: item-level replay remains safe through idempotent `op_id` and journal state transitions.
+- Batch mutation failures preserve per-item safety: item-level replay remains safe through idempotent `op_id`; journal state transitions apply only to `DURABLE_SAGA` backends.
 - Consistency model per operation:
   - SQL-only operations: atomic per DB transaction (owned session) or per explicit unit-of-work (shared session).
-  - SQL + vector mutations: `DURABLE_SAGA` with compensation/recovery.
+  - `local_split` SQL + vector mutations: `DURABLE_SAGA` with compensation/recovery.
+  - `elasticsearch` unified mutations: `ATOMIC` backend path with no local journal recovery loop.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,7 @@ Changelog = "https://github.com/Intrinsical-AI/rag-prototype/releases"
 [project.scripts]
 rag-bootstrap   = "local_rag_backend.cli:rag_bootstrap"
 rag-ingest      = "local_rag_backend.cli:rag_ingest"
+rag-import-canonical = "local_rag_backend.cli:rag_import_canonical"
 rag-rebuild-index = "local_rag_backend.cli:rag_rebuild_index"
 rag-mutate-docs = "local_rag_backend.cli:rag_mutate_docs"
 rag-server      = "local_rag_backend.cli:rag_server"

--- a/src/local_rag_backend/cli.py
+++ b/src/local_rag_backend/cli.py
@@ -10,6 +10,7 @@ from local_rag_backend import __version__
 from local_rag_backend.cli_commands import (
     bootstrap_cmd,
     eval_cmd,
+    import_canonical_cmd,
     ingest_cmd,
     mutate_docs_cmd,
     rebuild_index_cmd,
@@ -28,6 +29,7 @@ def cli() -> None:
 cli.add_command(server_cmd)
 cli.add_command(rebuild_index_cmd)
 cli.add_command(mutate_docs_cmd)
+cli.add_command(import_canonical_cmd)
 cli.add_command(bootstrap_cmd)
 cli.add_command(status_cmd)
 cli.add_command(eval_cmd)
@@ -74,6 +76,11 @@ def rag_ingest() -> None:
 def rag_mutate_docs() -> None:
     """Entry point for rag-mutate-docs command."""
     _dispatch_entrypoint(command="mutate-docs", include_argv=True)
+
+
+def rag_import_canonical() -> None:
+    """Entry point for rag-import-canonical command."""
+    _dispatch_entrypoint(command="import-canonical", include_argv=True)
 
 
 if __name__ == "__main__":

--- a/src/local_rag_backend/cli_commands/__init__.py
+++ b/src/local_rag_backend/cli_commands/__init__.py
@@ -2,6 +2,7 @@
 
 from local_rag_backend.cli_commands.docs import (
     bootstrap_cmd,
+    import_canonical_cmd,
     ingest_cmd,
     mutate_docs_cmd,
 )
@@ -12,6 +13,7 @@ from local_rag_backend.cli_commands.server import server_cmd
 __all__ = [
     "bootstrap_cmd",
     "eval_cmd",
+    "import_canonical_cmd",
     "ingest_cmd",
     "mutate_docs_cmd",
     "rebuild_index_cmd",

--- a/src/local_rag_backend/cli_commands/docs/__init__.py
+++ b/src/local_rag_backend/cli_commands/docs/__init__.py
@@ -1,11 +1,13 @@
 """Document-related CLI commands."""
 
 from local_rag_backend.cli_commands.docs.docs_bootstrap import bootstrap_cmd
+from local_rag_backend.cli_commands.docs.docs_import_canonical import import_canonical_cmd
 from local_rag_backend.cli_commands.docs.docs_ingest import ingest_cmd
 from local_rag_backend.cli_commands.docs.docs_mutate import mutate_docs_cmd
 
 __all__ = [
     "bootstrap_cmd",
+    "import_canonical_cmd",
     "ingest_cmd",
     "mutate_docs_cmd",
 ]

--- a/src/local_rag_backend/cli_commands/docs/docs_import_canonical.py
+++ b/src/local_rag_backend/cli_commands/docs/docs_import_canonical.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import click
+
+from local_rag_backend.cli_commands.runtime import get_cli_container, run_cli_mutation
+from local_rag_backend.core.use_cases.docs_import_canonical import (
+    CanonicalImportDocumentInput,
+    CanonicalImportRequestInput,
+    execute_import_canonical_sync,
+)
+from local_rag_backend.core.use_cases.results import CanonicalImportSummary
+from local_rag_backend.settings import settings
+
+
+def _read_payload(payload_json: Path) -> dict[str, Any]:
+    payload = json.loads(payload_json.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("--json must contain a JSON object payload")
+    return cast("dict[str, Any]", payload)
+
+
+def _build_request(
+    payload: dict[str, Any],
+    *,
+    replace_scope: bool,
+) -> CanonicalImportRequestInput:
+    documents_raw = payload.get("documents") or []
+    if not isinstance(documents_raw, list):
+        raise ValueError("payload.documents must be a list")
+
+    documents: list[CanonicalImportDocumentInput] = []
+    for item in documents_raw:
+        if not isinstance(item, dict):
+            raise ValueError("each payload.documents item must be an object")
+        metadata = item.get("metadata")
+        documents.append(
+            CanonicalImportDocumentInput(
+                external_id=str(item.get("external_id") or "").strip(),
+                content=str(item.get("content") or "").strip(),
+                source_id=(
+                    str(item.get("source_id")) if item.get("source_id") is not None else None
+                ),
+                metadata=(cast("dict[str, Any]", metadata) if isinstance(metadata, dict) else None),
+            )
+        )
+
+    return CanonicalImportRequestInput(
+        scope=str(payload.get("scope") or "").strip(),
+        snapshot_id=str(payload.get("snapshot_id") or "").strip(),
+        replace_scope=replace_scope,
+        documents=tuple(documents),
+        source="cli:docs:import-canonical",
+    )
+
+
+@click.command("import-canonical")
+@click.option(
+    "--json",
+    "payload_json",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    required=True,
+    help="Path to canonical import JSON ({scope, snapshot_id, documents[]}).",
+)
+@click.option(
+    "--replace-scope/--upsert-only",
+    default=True,
+    show_default=True,
+    help="Delete stale docs in the same scope after importing the snapshot.",
+)
+def import_canonical_cmd(payload_json: Path, replace_scope: bool) -> None:
+    """Import/sync external canonical documents through the native mutation stack."""
+    try:
+        payload = _read_payload(payload_json)
+        request = _build_request(payload, replace_scope=replace_scope)
+        container = get_cli_container()
+        mutation_bundle = container.build_docs_mutation_bundle()
+
+        def _run_sync() -> CanonicalImportSummary:
+            return execute_import_canonical_sync(
+                request=request,
+                settings_obj=settings,
+                ports=mutation_bundle.ports,
+            )
+
+        summary = run_cli_mutation(_run_sync, use_lock=True)
+        click.echo(
+            "[OK] Canonical import committed. "
+            f"scope={summary.scope} snapshot_id={summary.snapshot_id} "
+            f"inserted={summary.inserted} updated={summary.updated} "
+            f"unchanged={summary.unchanged} deleted_sql={summary.deleted_sql} "
+            f"deleted_index={summary.deleted_index}"
+        )
+    except Exception as e:
+        click.echo(f"[ERROR] Error importing canonical documents: {e}", err=True)
+        raise SystemExit(1)

--- a/src/local_rag_backend/cli_commands/docs/docs_mutate.py
+++ b/src/local_rag_backend/cli_commands/docs/docs_mutate.py
@@ -51,6 +51,10 @@ def _build_intent(payload: dict[str, Any]) -> MutationIntent:
                 source_id=(
                     str(item.get("source_id")) if item.get("source_id") is not None else None
                 ),
+                scope=(str(item.get("scope")) if item.get("scope") is not None else None),
+                snapshot_id=(
+                    str(item.get("snapshot_id")) if item.get("snapshot_id") is not None else None
+                ),
                 metadata=(cast("dict[str, Any]", md) if isinstance(md, dict) else None),
             )
         )

--- a/src/local_rag_backend/cli_commands/index.py
+++ b/src/local_rag_backend/cli_commands/index.py
@@ -15,7 +15,7 @@ from local_rag_backend.settings import settings
 
 @click.command("rebuild-index")
 def rebuild_index_cmd() -> None:
-    """Rebuild FAISS index from the current SQLite documents (idempotent)."""
+    """Rebuild retrieval index from the current document store (idempotent)."""
     try:
         from local_rag_backend.core.use_cases import index as index_service
 
@@ -42,11 +42,9 @@ def rebuild_index_cmd() -> None:
 @click.command("status")
 def status_cmd() -> None:
     """Display system status and configuration."""
-    from local_rag_backend.infrastructure.persistence.sql import base as db_base
-
-    ensure_sqlite_schema_for_cli()
     container = get_cli_container()
-    readiness_bundle = container.build_health_readiness_bundle(engine=db_base.engine)
+    ensure_sqlite_schema_for_cli()
+    readiness_bundle = container.build_health_readiness_bundle()
     diagnostics = readiness_bundle.diagnostics
 
     title_fg = "cyan"
@@ -61,6 +59,9 @@ def status_cmd() -> None:
     )
     click.echo(
         f"  {click.style('Retrieval Mode:', fg=key_fg, bold=True)} {settings.retrieval_mode}"
+    )
+    click.echo(
+        f"  {click.style('Persistence Backend:', fg=key_fg, bold=True)} {settings.persistence_backend}"
     )
     click.echo(
         f"  {click.style('Debug Mode:', fg=key_fg, bold=True)} {'✅' if settings.debug else '❌'}"
@@ -81,16 +82,28 @@ def status_cmd() -> None:
         click.echo(f"    {click.style('Model:', fg=key_fg, bold=True)} {settings.openai_model}")
     click.echo()
 
-    click.secho("📁 File Status", fg=title_fg, bold=True)
-    for name, path_str in [
-        ("Database", settings.sqlite_url.replace("sqlite:///", "")),
-        ("FAISS index", settings.index_path),
-        ("Sample data", settings.faq_csv),
-    ]:
-        path = Path(path_str)
-        status_icon = "✅ YES" if path.exists() else "❌ NO"
-        click.echo(f"  {click.style(name + ':', fg=key_fg, bold=True)} {status_icon}")
-        click.echo(f"    Path: {path}")
+    click.secho("📁 Storage Status", fg=title_fg, bold=True)
+    if settings.persistence_backend == "elasticsearch":
+        click.echo(
+            f"  {click.style('Elasticsearch:', fg=key_fg, bold=True)} {settings.es_base_url or '[MISSING]'}"
+        )
+        for name, value in [
+            ("Docs index", settings.es_docs_index),
+            ("History index", settings.es_history_index),
+            ("System index", settings.es_system_index),
+            ("Tombstones index", settings.es_tombstones_index),
+        ]:
+            click.echo(f"  {click.style(name + ':', fg=key_fg, bold=True)} {value}")
+    else:
+        for name, path_str in [
+            ("Database", settings.sqlite_url.replace("sqlite:///", "")),
+            ("FAISS index", settings.index_path),
+            ("Sample data", settings.faq_csv),
+        ]:
+            path = Path(path_str)
+            status_icon = "✅ YES" if path.exists() else "❌ NO"
+            click.echo(f"  {click.style(name + ':', fg=key_fg, bold=True)} {status_icon}")
+            click.echo(f"    Path: {path}")
 
     click.echo()
     click.secho("📊 Data & Index Diagnostics", fg=title_fg, bold=True)
@@ -123,10 +136,11 @@ def status_cmd() -> None:
                 f"{stats.get('vectors')} vectors "
                 f"(dim={stats.get('dim')}, backend={stats.get('backend')})"
             )
-            click.echo(
-                f"  {click.style('Manifest:', fg=key_fg, bold=True)} OK "
-                f"(path={stats.get('manifest_path')})"
-            )
+            if settings.persistence_backend != "elasticsearch":
+                click.echo(
+                    f"  {click.style('Manifest:', fg=key_fg, bold=True)} OK "
+                    f"(path={stats.get('manifest_path')})"
+                )
             if int(stats.get("duplicates") or 0):
                 click.echo(
                     f"  {click.style('Index drift:', fg=key_fg, bold=True)} "
@@ -147,7 +161,7 @@ def status_cmd() -> None:
                 f"[ERROR] {status_txt} "
                 f"(hint: {stats.get('hint')})"
             )
-            if status_txt == "drift":
+            if status_txt == "drift" and settings.persistence_backend != "elasticsearch":
                 mm = stats.get("manifest_mismatches") or []
                 if isinstance(mm, list) and mm:
                     sample = ", ".join(

--- a/src/local_rag_backend/cli_commands/runtime.py
+++ b/src/local_rag_backend/cli_commands/runtime.py
@@ -31,6 +31,9 @@ def ensure_sqlite_schema_for_cli() -> None:
     CLI commands can be run without starting the FastAPI server, so they must
     apply the same best-effort SQLite migrations that the app does at startup.
     """
+    if settings.persistence_backend == "elasticsearch":
+        return
+
     from local_rag_backend.infrastructure.persistence.sql import base as db_base
 
     settings.data_dir.mkdir(parents=True, exist_ok=True)

--- a/src/local_rag_backend/composition/adapters.py
+++ b/src/local_rag_backend/composition/adapters.py
@@ -39,6 +39,7 @@ from local_rag_backend.core.ports import (
     OpenRouterGenerateResult,
     OpenRouterUsage,
     RagRuntimeFactoryPort,
+    RetrieverPort,
 )
 from local_rag_backend.core.services.rag_runtime import RagService
 from local_rag_backend.core.services.reranking import RerankingRetriever
@@ -57,13 +58,15 @@ from local_rag_backend.infrastructure.observability.diagnostics import (
     get_incomplete_mutation_records_count,
     get_retrieval_index_stats,
 )
+from local_rag_backend.infrastructure.persistence.elasticsearch import (
+    ElasticHealthDiagnostics,
+)
 from local_rag_backend.infrastructure.persistence.sql import (
     HistorySqlStorage,
     SqlDocumentStorage,
     base as db_base,
 )
 from local_rag_backend.infrastructure.persistence.sql.crud import get_history
-from local_rag_backend.infrastructure.persistence.sql.models import Document as DbDocument
 from local_rag_backend.infrastructure.persistence.vector.manifest import (
     expected_manifest_config_from_settings,
 )
@@ -74,8 +77,6 @@ from local_rag_backend.infrastructure.retrieval.sparse_bm25 import SparseBM25Ret
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Mapping, Sequence
-
-    from sqlalchemy.orm import Session
 
     from local_rag_backend.core.domain.entities import Document as DomainDocument
     from local_rag_backend.core.domain.types import DocId
@@ -100,26 +101,21 @@ DEFAULT_DENSE_BACKEND_MESSAGE = (
 
 
 @dataclass(frozen=True)
-class _SqlDocsReadPort(DocsReadPort):
-    db: Session
+class _RepoDocsReadPort(DocsReadPort):
+    doc_repo_factory: Callable[[], DocumentRepoPort]
 
     def list_docs_page(self, *, limit: int, offset: int) -> tuple[ListedDocument, ...]:
-        rows = (
-            self.db.query(DbDocument)
-            .order_by(DbDocument.doc_id.asc())
-            .offset(offset)
-            .limit(limit)
-            .all()
-        )
+        rows = list(self.doc_repo_factory().get_all_documents())
+        page = rows[offset : offset + limit]
         return tuple(
             ListedDocument(
-                id=str(row.doc_id),
+                id=str(row.id),
                 content=str(row.content),
                 external_id=row.external_id,
                 source_id=row.source_id,
-                metadata=row.metadata_,
+                metadata=dict(row.metadata or {}) if row.metadata is not None else None,
             )
-            for row in rows
+            for row in page
         )
 
 
@@ -143,10 +139,11 @@ class _DefaultBlockingExecutor(BlockingExecutorPort):
 
 @dataclass(frozen=True)
 class _SqlHistoryReadPort(HistoryReadPort):
-    db: Session
+    session_factory: Any
 
     def list_history_entries(self, *, limit: int, offset: int) -> tuple[HistoryEntry, ...]:
-        rows = get_history(db=self.db, limit=limit, offset=offset)
+        with self.session_factory() as db:
+            rows = get_history(db=db, limit=limit, offset=offset)
         entries: list[HistoryEntry] = []
         for row in rows:
             created_at = getattr(row, "created_at", None)
@@ -166,6 +163,28 @@ class _SqlHistoryReadPort(HistoryReadPort):
                 )
             )
         return tuple(entries)
+
+
+@dataclass(frozen=True)
+class _StorageHistoryReadPort(HistoryReadPort):
+    history_repo_factory: Callable[[], QAHistoryPort]
+
+    def list_history_entries(self, *, limit: int, offset: int) -> tuple[HistoryEntry, ...]:
+        repo = self.history_repo_factory()
+        list_entries = getattr(repo, "list_entries", None)
+        if not callable(list_entries):
+            raise RuntimeError("Configured history backend does not support list_entries.")
+        rows = list_entries(limit=limit, offset=offset)
+        return tuple(
+            HistoryEntry(
+                id=int(getattr(row, "id", 0) or 0),
+                question=str(getattr(row, "question", "") or ""),
+                answer=str(getattr(row, "answer", "") or ""),
+                created_at=str(getattr(row, "created_at", "") or ""),
+                source_ids=tuple(str(x) for x in (getattr(row, "source_ids", ()) or ())),
+            )
+            for row in rows
+        )
 
 
 @dataclass(frozen=True)
@@ -355,15 +374,54 @@ class _OpenAICompatibleOpenRouterClient(OpenRouterClientPort):
         return OpenRouterGenerateResult(text=text, usage=usage)
 
 
-def build_docs_read_port(*, db: Session) -> DocsReadPort:
-    return _SqlDocsReadPort(db=db)
+class _ElasticLexicalRetriever(RetrieverPort):
+    def __init__(self, *, vector_repo: Any, doc_repo: DocumentRepoPort) -> None:
+        self._vector_repo = vector_repo
+        self._doc_repo = doc_repo
+
+    def retrieve(self, query: str, k: int = 5) -> tuple[Sequence[DomainDocument], Sequence[float]]:
+        if k <= 0:
+            return [], []
+        lexical_search = getattr(self._vector_repo, "lexical_search", None)
+        if not callable(lexical_search):
+            raise RuntimeError("Configured vector backend does not support lexical_search.")
+        id_score_pairs = lexical_search(query, k=k)
+        if not id_score_pairs:
+            return [], []
+        doc_ids, _scores = zip(*id_score_pairs, strict=False)
+        docs = self._doc_repo.get(list(doc_ids))
+        docs_by_id = {doc.id: doc for doc in docs}
+        ordered_docs = [docs_by_id[doc_id] for doc_id in doc_ids if doc_id in docs_by_id]
+        ordered_scores = [score for doc_id, score in id_score_pairs if doc_id in docs_by_id]
+        return ordered_docs, ordered_scores
 
 
-def build_history_read_port(*, db: Session) -> HistoryReadPort:
-    return _SqlHistoryReadPort(db=db)
+def build_docs_read_port(
+    *,
+    settings_obj: Settings,
+    doc_repo_factory: Callable[[], DocumentRepoPort],
+) -> DocsReadPort:
+    _ = settings_obj
+    return _RepoDocsReadPort(doc_repo_factory=doc_repo_factory)
 
 
-def build_health_diagnostics_port(*, engine: Any) -> HealthDiagnosticsPort:
+def build_history_read_port(
+    *,
+    settings_obj: Settings,
+    history_repo_factory: Callable[[], QAHistoryPort],
+) -> HistoryReadPort:
+    if settings_obj.persistence_backend == "elasticsearch":
+        return _StorageHistoryReadPort(history_repo_factory=history_repo_factory)
+    return _SqlHistoryReadPort(session_factory=db_base.SessionLocal)
+
+
+def build_health_diagnostics_port(
+    *,
+    settings_obj: Settings,
+    engine: Any,
+) -> HealthDiagnosticsPort:
+    if settings_obj.persistence_backend == "elasticsearch":
+        return ElasticHealthDiagnostics(settings_obj=settings_obj)
     return _DefaultHealthDiagnosticsPort(engine=engine)
 
 
@@ -564,13 +622,19 @@ def build_retriever_from_settings(
     mode = str(retrieval_mode)
     if mode not in {"sparse", "dense", "hybrid"}:
         raise ValueError(f"Unsupported retrieval_mode: {mode}")
+    persistence_backend = str(getattr(settings_obj, "persistence_backend", "local_split"))
+
+    if persistence_backend == "elasticsearch" and mode == "sparse":
+        raise ValueError(
+            "PERSISTENCE_BACKEND=elasticsearch supports only retrieval_mode=dense|hybrid"
+        )
 
     retriever: RetrieverPort
     docs_for_sparse: Sequence[DomainDocument] | None = None
     corpus: list[str] | None = None
     doc_ids: list[DocId] | None = None
 
-    if mode in {"sparse", "hybrid"}:
+    if mode in {"sparse", "hybrid"} and persistence_backend != "elasticsearch":
         docs_for_sparse = (
             list(preloaded_docs) if preloaded_docs is not None else doc_repo.get_all_documents()
         )
@@ -605,16 +669,23 @@ def build_retriever_from_settings(
         if mode == "dense":
             retriever = dense_retriever
         else:
-            if corpus is None or doc_ids is None or docs_for_sparse is None:
-                raise RuntimeError(
-                    f"Internal error: hybrid retrieval vars uninitialized for mode '{mode}'"
+            sparse_retriever: RetrieverPort
+            if persistence_backend == "elasticsearch":
+                sparse_retriever = _ElasticLexicalRetriever(
+                    vector_repo=vector_repo,
+                    doc_repo=doc_repo,
                 )
-            sparse_retriever = sparse_retriever_factory(
-                documents=corpus,
-                doc_ids=doc_ids,
-                doc_repo=doc_repo,
-                preloaded_docs=docs_for_sparse,
-            )
+            else:
+                if corpus is None or doc_ids is None or docs_for_sparse is None:
+                    raise RuntimeError(
+                        f"Internal error: hybrid retrieval vars uninitialized for mode '{mode}'"
+                    )
+                sparse_retriever = sparse_retriever_factory(
+                    documents=corpus,
+                    doc_ids=doc_ids,
+                    doc_repo=doc_repo,
+                    preloaded_docs=docs_for_sparse,
+                )
             alpha = (
                 hybrid_alpha if hybrid_alpha is not None else settings_obj.hybrid_retrieval_alpha
             )

--- a/src/local_rag_backend/composition/container.py
+++ b/src/local_rag_backend/composition/container.py
@@ -41,6 +41,13 @@ from local_rag_backend.infrastructure.embeddings.sentence_transformers import (
 )
 from local_rag_backend.infrastructure.llms.ollama_chat import OllamaGenerator
 from local_rag_backend.infrastructure.llms.openai_chat import OpenAIGenerator
+from local_rag_backend.infrastructure.persistence.elasticsearch import (
+    ElasticDocsRepository,
+    ElasticHistoryStorage,
+    ElasticSystemStateStorage,
+    ElasticVectorRepo,
+    purge_index_artifacts_noop,
+)
 from local_rag_backend.infrastructure.persistence.shared.mutation_journal import FileMutationJournal
 from local_rag_backend.infrastructure.persistence.sql import (
     HistorySqlStorage,
@@ -157,6 +164,7 @@ class AppContainer:
         system_state_factory: Callable[[], SystemStateStorage] | None = None,
     ) -> None:
         defaults = self.runtime_wiring_defaults()
+        use_elasticsearch = settings_obj.persistence_backend == "elasticsearch"
         self.settings_obj = settings_obj
         self.openai_embedder_factory = openai_embedder_factory or cast(
             "Callable[[], EmbedderPort]", defaults["openai_embedder_factory"]
@@ -170,13 +178,22 @@ class AppContainer:
         self.ollama_generator_factory = ollama_generator_factory or cast(
             "Callable[..., GeneratorPort]", defaults["ollama_generator_factory"]
         )
-        self.doc_repo_factory = doc_repo_factory or cast(
-            "Callable[[], DocumentRepoPort]", defaults["doc_repo_factory"]
-        )
-        self.build_upsert_doc = build_upsert_doc or defaults["build_upsert_doc"]
-        self.history_repo_factory = history_repo_factory or cast(
+        default_doc_repo_factory = cast("Callable[[], DocumentRepoPort]", defaults["doc_repo_factory"])
+        self.doc_repo_factory = doc_repo_factory or default_doc_repo_factory
+        if use_elasticsearch and self.doc_repo_factory == default_doc_repo_factory:
+            self.doc_repo_factory = lambda: ElasticDocsRepository(settings_obj=self.settings_obj)
+
+        default_build_upsert_doc = defaults["build_upsert_doc"]
+        self.build_upsert_doc = build_upsert_doc or default_build_upsert_doc
+        if use_elasticsearch and self.build_upsert_doc == default_build_upsert_doc:
+            self.build_upsert_doc = ElasticDocsRepository.UpsertDoc
+
+        default_history_repo_factory = cast(
             "Callable[[], QAHistoryPort]", defaults["history_repo_factory"]
         )
+        self.history_repo_factory = history_repo_factory or default_history_repo_factory
+        if use_elasticsearch and self.history_repo_factory == default_history_repo_factory:
+            self.history_repo_factory = lambda: ElasticHistoryStorage(settings_obj=self.settings_obj)
         self.sparse_retriever_factory = sparse_retriever_factory or cast(
             "Callable[..., RetrieverPort]", defaults["sparse_retriever_factory"]
         )
@@ -186,16 +203,25 @@ class AppContainer:
         self.hybrid_retriever_factory = hybrid_retriever_factory or cast(
             "Callable[..., RetrieverPort]", defaults["hybrid_retriever_factory"]
         )
-        self.vector_repo_factory = vector_repo_factory or cast(
+        default_vector_repo_factory = cast(
             "Callable[..., VectorRepoPort]", defaults["vector_repo_factory"]
         )
+        self.vector_repo_factory = vector_repo_factory or default_vector_repo_factory
+        if use_elasticsearch and self.vector_repo_factory == default_vector_repo_factory:
+            self.vector_repo_factory = lambda **kwargs: ElasticVectorRepo(
+                settings_obj=self.settings_obj,
+                **kwargs,
+            )
         self.reranker_factory = reranker_factory or cast(
             "Callable[..., RetrieverPort]", defaults["reranker_factory"]
         )
         self.rebuild_fn = rebuild_fn or cast("Callable[..., int]", defaults["rebuild_fn"])
-        self.purge_index_artifacts_fn = purge_index_artifacts_fn or cast(
+        default_purge_index_artifacts_fn = cast(
             "Callable[..., None]", defaults["purge_index_artifacts_fn"]
         )
+        self.purge_index_artifacts_fn = purge_index_artifacts_fn or default_purge_index_artifacts_fn
+        if use_elasticsearch and self.purge_index_artifacts_fn == default_purge_index_artifacts_fn:
+            self.purge_index_artifacts_fn = purge_index_artifacts_noop
         self.write_lock = write_lock or cast("Callable[..., Any]", defaults["write_lock"])
         self.mutation_journal_factory = mutation_journal_factory or (
             lambda: FileMutationJournal(
@@ -207,10 +233,16 @@ class AppContainer:
         self.rag_service_factory = rag_service_factory or cast(
             "Callable[..., RagService]", defaults["rag_service_factory"]
         )
-        self._system_state = (
-            system_state_factory
-            or cast("Callable[[], SystemStateStorage]", defaults["system_state_factory"])
-        )()
+        default_system_state_factory = cast(
+            "Callable[[], SystemStateStorage]", defaults["system_state_factory"]
+        )
+        resolved_system_state_factory = system_state_factory or default_system_state_factory
+        if use_elasticsearch and resolved_system_state_factory == default_system_state_factory:
+            resolved_system_state_factory = cast(
+                "Callable[[], SystemStateStorage]",
+                lambda: ElasticSystemStateStorage(settings_obj=self.settings_obj),
+            )
+        self._system_state = resolved_system_state_factory()
         self._rag_service_cache_lock = Lock()
         self._rag_service_cache: RagService | None = None
         self._rag_service_cache_version: int | None = None
@@ -256,14 +288,21 @@ class AppContainer:
         with self.write_lock():
             return fn()
 
-    def build_docs_read_port(self, *, db: Any) -> DocsReadPort:
-        return build_docs_read_port(db=db)
+    def build_docs_read_port(self) -> DocsReadPort:
+        return build_docs_read_port(
+            settings_obj=self.settings_obj,
+            doc_repo_factory=self.doc_repo_factory,
+        )
 
-    def build_history_read_port(self, *, db: Any) -> HistoryReadPort:
-        return build_history_read_port(db=db)
+    def build_history_read_port(self) -> HistoryReadPort:
+        return build_history_read_port(
+            settings_obj=self.settings_obj,
+            history_repo_factory=self.history_repo_factory,
+        )
 
     def build_health_diagnostics_port(self, *, engine: Any | None = None) -> HealthDiagnosticsPort:
         return build_health_diagnostics_port(
+            settings_obj=self.settings_obj,
             engine=(engine if engine is not None else db_base.engine)
         )
 
@@ -346,7 +385,11 @@ class AppContainer:
             write_lock=self.write_lock,
             mutation_journal_factory=self.mutation_journal_factory,
             storage_profile_registry=self.storage_profile_registry,
-            mutation_uow_factory=self.mutation_uow_factory or db_base.session_uow,
+            mutation_uow_factory=(
+                None
+                if self.settings_obj.persistence_backend == "elasticsearch"
+                else (self.mutation_uow_factory or db_base.session_uow)
+            ),
         )
 
     def index_mutation_ports(

--- a/src/local_rag_backend/composition/container.py
+++ b/src/local_rag_backend/composition/container.py
@@ -178,7 +178,9 @@ class AppContainer:
         self.ollama_generator_factory = ollama_generator_factory or cast(
             "Callable[..., GeneratorPort]", defaults["ollama_generator_factory"]
         )
-        default_doc_repo_factory = cast("Callable[[], DocumentRepoPort]", defaults["doc_repo_factory"])
+        default_doc_repo_factory = cast(
+            "Callable[[], DocumentRepoPort]", defaults["doc_repo_factory"]
+        )
         self.doc_repo_factory = doc_repo_factory or default_doc_repo_factory
         if use_elasticsearch and self.doc_repo_factory == default_doc_repo_factory:
             self.doc_repo_factory = lambda: ElasticDocsRepository(settings_obj=self.settings_obj)
@@ -193,7 +195,9 @@ class AppContainer:
         )
         self.history_repo_factory = history_repo_factory or default_history_repo_factory
         if use_elasticsearch and self.history_repo_factory == default_history_repo_factory:
-            self.history_repo_factory = lambda: ElasticHistoryStorage(settings_obj=self.settings_obj)
+            self.history_repo_factory = lambda: ElasticHistoryStorage(
+                settings_obj=self.settings_obj
+            )
         self.sparse_retriever_factory = sparse_retriever_factory or cast(
             "Callable[..., RetrieverPort]", defaults["sparse_retriever_factory"]
         )
@@ -303,7 +307,7 @@ class AppContainer:
     def build_health_diagnostics_port(self, *, engine: Any | None = None) -> HealthDiagnosticsPort:
         return build_health_diagnostics_port(
             settings_obj=self.settings_obj,
-            engine=(engine if engine is not None else db_base.engine)
+            engine=(engine if engine is not None else db_base.engine),
         )
 
     def build_health_readiness_bundle(self, *, engine: Any | None = None) -> HealthReadinessBundle:

--- a/src/local_rag_backend/core/domain/profiles.py
+++ b/src/local_rag_backend/core/domain/profiles.py
@@ -47,6 +47,18 @@ def default_storage_profiles() -> dict[str, StorageProfile]:
             supports_vectors=True,
             description="SQL + numpy vector store with durable saga semantics.",
         ),
+        "es_unified_dense": StorageProfile(
+            profile_id="es_unified_dense",
+            capabilities=frozenset({StorageCapability.ATOMIC}),
+            supports_vectors=True,
+            description="Elasticsearch unified storage profile for dense retrieval.",
+        ),
+        "es_unified_hybrid": StorageProfile(
+            profile_id="es_unified_hybrid",
+            capabilities=frozenset({StorageCapability.ATOMIC}),
+            supports_vectors=True,
+            description="Elasticsearch unified storage profile for hybrid retrieval.",
+        ),
     }
 
 
@@ -68,6 +80,7 @@ class StorageProfileRegistry:
         self,
         *,
         profile_id: str | None,
+        persistence_backend: str,
         retrieval_mode: str,
         vector_backend: str,
     ) -> StorageProfile:
@@ -75,7 +88,12 @@ class StorageProfileRegistry:
         if explicit:
             return self.get(explicit)
 
+        backend = str(persistence_backend).strip().lower()
         mode = str(retrieval_mode).strip().lower()
+        if backend == "elasticsearch":
+            if mode == "hybrid":
+                return self.get("es_unified_hybrid")
+            return self.get("es_unified_dense")
         if mode == "sparse":
             return self.get("sql_only_local")
         if str(vector_backend).strip().lower() == "numpy":

--- a/src/local_rag_backend/core/domain/retrieval.py
+++ b/src/local_rag_backend/core/domain/retrieval.py
@@ -1,0 +1,108 @@
+"""Retrieval request/result contracts."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from local_rag_backend.core.domain.entities import Document
+
+RetrievalMode = Literal["sparse", "dense", "dual", "hybrid"]
+FilterField = Literal["scope", "source_id", "path", "language", "unit_type"]
+
+
+@dataclass(frozen=True)
+class RetrievalFilter:
+    """Structured filter applied during retrieval."""
+
+    field: FilterField
+    values: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        normalized = tuple(str(value).strip() for value in self.values if str(value).strip())
+        if not str(self.field).strip():
+            raise ValueError("RetrievalFilter.field must not be blank")
+        if not normalized:
+            raise ValueError("RetrievalFilter.values must not be empty")
+        object.__setattr__(self, "values", normalized)
+
+
+@dataclass(frozen=True)
+class RetrievalRequest:
+    """Single retrieval plan for one question."""
+
+    query: str
+    top_k: int = 5
+    mode: RetrievalMode = "sparse"
+    filters: tuple[RetrievalFilter, ...] = ()
+    candidate_k: int | None = None
+    dual_candidate_k: int | None = None
+    min_score: float | None = None
+
+    def __post_init__(self) -> None:
+        query = str(self.query).strip()
+        if not query:
+            raise ValueError("RetrievalRequest.query must not be blank")
+        if int(self.top_k) <= 0:
+            raise ValueError("RetrievalRequest.top_k must be positive")
+        if self.candidate_k is not None and int(self.candidate_k) <= 0:
+            raise ValueError("RetrievalRequest.candidate_k must be positive when set")
+        if self.dual_candidate_k is not None and int(self.dual_candidate_k) <= 0:
+            raise ValueError("RetrievalRequest.dual_candidate_k must be positive when set")
+        object.__setattr__(self, "query", query)
+        object.__setattr__(self, "top_k", int(self.top_k))
+        if self.candidate_k is not None:
+            object.__setattr__(self, "candidate_k", int(self.candidate_k))
+        if self.dual_candidate_k is not None:
+            object.__setattr__(self, "dual_candidate_k", int(self.dual_candidate_k))
+
+
+@dataclass(frozen=True)
+class RetrievedDoc:
+    """Document plus retrieval metadata."""
+
+    document: Document
+    score: float
+    stage: str | None = None
+    score_breakdown: Mapping[str, float] | None = None
+
+
+@dataclass(frozen=True)
+class RetrievalResult:
+    """Structured retrieval output."""
+
+    items: tuple[RetrievedDoc, ...]
+    mode_used: RetrievalMode
+    backend_used: str
+    candidate_count: int = 0
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    @property
+    def documents(self) -> tuple[Document, ...]:
+        return tuple(item.document for item in self.items)
+
+    @property
+    def scores(self) -> tuple[float, ...]:
+        return tuple(float(item.score) for item in self.items)
+
+
+def retrieval_result_from_pairs(
+    *,
+    docs: Sequence[Document],
+    scores: Sequence[float],
+    mode_used: RetrievalMode,
+    backend_used: str,
+    stage: str | None = None,
+    candidate_count: int | None = None,
+) -> RetrievalResult:
+    items = tuple(
+        RetrievedDoc(document=doc, score=float(score), stage=stage)
+        for doc, score in zip(docs, scores, strict=False)
+    )
+    return RetrievalResult(
+        items=items,
+        mode_used=mode_used,
+        backend_used=backend_used,
+        candidate_count=len(items) if candidate_count is None else int(candidate_count),
+    )

--- a/src/local_rag_backend/core/ports/__init__.py
+++ b/src/local_rag_backend/core/ports/__init__.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
 
     from local_rag_backend.core.domain.entities import Document, Embedding, LoadedItem
+    from local_rag_backend.core.domain.retrieval import RetrievalRequest, RetrievalResult
     from local_rag_backend.core.domain.types import DocId
 
 
@@ -35,7 +36,7 @@ class GeneratorPort(Protocol):
 class RetrieverPort(Protocol):
     """Interface for retrieving relevant documents for a given query."""
 
-    def retrieve(self, query: str, k: int = 5) -> tuple[Sequence[Document], Sequence[float]]: ...
+    def retrieve(self, request: RetrievalRequest) -> RetrievalResult: ...
 
 
 @runtime_checkable

--- a/src/local_rag_backend/core/ports/contracts.py
+++ b/src/local_rag_backend/core/ports/contracts.py
@@ -46,6 +46,8 @@ class UpsertDocBuilderPort(Protocol):
         external_id: str,
         content: str,
         source_id: str | None = None,
+        scope: str | None = None,
+        snapshot_id: str | None = None,
         metadata: Mapping[str, Any] | None = None,
         chunk_dedup_sha256: str | None = None,
         embedding: Sequence[float] | None = None,

--- a/src/local_rag_backend/core/ports/contracts.py
+++ b/src/local_rag_backend/core/ports/contracts.py
@@ -48,6 +48,7 @@ class UpsertDocBuilderPort(Protocol):
         source_id: str | None = None,
         metadata: Mapping[str, Any] | None = None,
         chunk_dedup_sha256: str | None = None,
+        embedding: Sequence[float] | None = None,
     ) -> object: ...
 
 

--- a/src/local_rag_backend/core/services/rag_runtime.py
+++ b/src/local_rag_backend/core/services/rag_runtime.py
@@ -8,6 +8,13 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+from local_rag_backend.core.domain.retrieval import (
+    RetrievalFilter,
+    RetrievalRequest,
+    RetrievalResult,
+    retrieval_result_from_pairs,
+)
+
 if TYPE_CHECKING:
     from local_rag_backend.core.ports import GeneratorPort, QAHistoryPort, RetrieverPort
 
@@ -31,7 +38,39 @@ class RagService:
         self.history_storage = history_storage
         self.no_docs_answer = no_docs_answer
 
-    def ask(self, question: str, top_k: int = 3) -> dict[str, Any]:
+    def _coerce_retrieval_result(
+        self,
+        raw_result: Any,
+        *,
+        request: RetrievalRequest,
+    ) -> RetrievalResult:
+        if isinstance(raw_result, RetrievalResult):
+            return raw_result
+        if (
+            isinstance(raw_result, tuple)
+            and len(raw_result) == 2
+            and isinstance(raw_result[0], (list, tuple))
+            and isinstance(raw_result[1], (list, tuple))
+        ):
+            docs, scores = raw_result
+            return retrieval_result_from_pairs(
+                docs=docs,
+                scores=scores,
+                mode_used=request.mode,
+                backend_used="legacy",
+            )
+        raise RuntimeError(f"Unsupported retriever response type: {type(raw_result)!r}")
+
+    def ask(
+        self,
+        question: str,
+        top_k: int = 3,
+        *,
+        filters: tuple[RetrievalFilter, ...] = (),
+        candidate_k: int | None = None,
+        dual_candidate_k: int | None = None,
+        retrieval_mode: str = "sparse",
+    ) -> dict[str, Any]:
         """Processes a question through the RAG pipeline.
 
         1. Retrieves relevant documents.
@@ -41,8 +80,18 @@ class RagService:
         Returns:
             A dictionary containing the answer, source documents, and scores.
         """
-        # 1. Retrieve relevant documents
-        docs, scores = self.retriever.retrieve(question, top_k)
+        request = RetrievalRequest(
+            query=question,
+            top_k=top_k,
+            mode=str(retrieval_mode),  # type: ignore[arg-type]
+            filters=filters,
+            candidate_k=candidate_k,
+            dual_candidate_k=dual_candidate_k,
+        )
+        raw_result = self.retriever.retrieve(request)
+        retrieval = self._coerce_retrieval_result(raw_result, request=request)
+        docs = list(retrieval.documents)
+        scores = list(retrieval.scores)
         if len(docs) != len(scores):
             raise RuntimeError(
                 f"Retriever contract violated: {len(docs)} docs != {len(scores)} scores."
@@ -68,4 +117,9 @@ class RagService:
         except Exception as e:  # pragma: no cover
             logger.warning("History persistence failed (ignored): %s", e)
 
-        return {"answer": answer, "docs": docs, "scores": scores}
+        return {
+            "answer": answer,
+            "docs": docs,
+            "scores": scores,
+            "retrieval": retrieval,
+        }

--- a/src/local_rag_backend/core/use_cases/_atomic_mutation_executor.py
+++ b/src/local_rag_backend/core/use_cases/_atomic_mutation_executor.py
@@ -40,6 +40,8 @@ class AtomicMutationExecutor:
                     external_id=u.external_id,
                     content=u.content,
                     source_id=u.source_id,
+                    scope=u.scope,
+                    snapshot_id=u.snapshot_id,
                     metadata=u.metadata,
                     embedding=prepared.precomputed_vectors_by_external_id.get(u.external_id),
                 )

--- a/src/local_rag_backend/core/use_cases/_atomic_mutation_executor.py
+++ b/src/local_rag_backend/core/use_cases/_atomic_mutation_executor.py
@@ -1,0 +1,110 @@
+"""Atomic mutation executor for unified backends such as Elasticsearch."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from local_rag_backend.core.domain.types import DocId
+from local_rag_backend.core.use_cases.results import MutationSummary, UpsertDocResult
+
+if TYPE_CHECKING:
+    from local_rag_backend.core.ports.contracts import DocsMutationPorts
+    from local_rag_backend.core.use_cases._mutation_saga_executor import PreparedMutation
+    from local_rag_backend.settings import Settings
+
+
+class AtomicMutationExecutor:
+    def __init__(self, *, settings_obj: Settings, ports: DocsMutationPorts) -> None:
+        self.settings_obj = settings_obj
+        self.ports = ports
+
+    def execute_locked(self, *, prepared: PreparedMutation) -> MutationSummary:
+        intent = prepared.intent
+        doc_repo = self.ports.doc_repo_factory()
+        inserted = 0
+        updated = 0
+        unchanged = 0
+        deleted_sql = 0
+        deleted_index = 0 if prepared.vector_mode_enabled else None
+        tombstoned = 0
+        missing_external_ids: list[str] = []
+        results: list[UpsertDocResult] = []
+
+        if intent.upserts:
+            delete_tombstones = getattr(doc_repo, "delete_tombstones", None)
+            if callable(delete_tombstones):
+                delete_tombstones([u.external_id for u in intent.upserts])
+
+            items = [
+                self.ports.build_upsert_doc(
+                    external_id=u.external_id,
+                    content=u.content,
+                    source_id=u.source_id,
+                    metadata=u.metadata,
+                    embedding=prepared.precomputed_vectors_by_external_id.get(u.external_id),
+                )
+                for u in intent.upserts
+            ]
+            upsert_results, _changed, _updated_ids = doc_repo.upsert_documents_by_external_id(items)
+            for row in upsert_results:
+                action = str(row.action)
+                if action == "inserted":
+                    inserted += 1
+                elif action == "updated":
+                    updated += 1
+                else:
+                    unchanged += 1
+                results.append(
+                    UpsertDocResult(
+                        external_id=str(row.external_id),
+                        id=str(row.id),
+                        action=action,
+                        content_changed=bool(row.content_changed),
+                    )
+                )
+
+        deleted_doc_ids: list[DocId] = []
+        if intent.delete_ids:
+            ids_doc = [DocId(str(x)) for x in intent.delete_ids]
+            existing_docs = list(doc_repo.get(ids_doc))
+            deleted_sql += len(existing_docs)
+            deleted_doc_ids.extend([DocId(str(d.id)) for d in existing_docs])
+            if existing_docs:
+                doc_repo.delete_documents(ids_doc)
+
+        if intent.delete_external_ids:
+            deleted_count, deleted_ids, missing, tombstoned_count = doc_repo.delete_by_external_ids(
+                list(intent.delete_external_ids)
+            )
+            deleted_sql += int(deleted_count)
+            deleted_doc_ids.extend([DocId(str(x)) for x in deleted_ids])
+            missing_external_ids.extend([str(x) for x in missing])
+            tombstoned += int(tombstoned_count)
+
+        if prepared.vector_mode_enabled and deleted_index is not None:
+            deleted_index = len({str(doc_id) for doc_id in deleted_doc_ids})
+
+        index_doc_count = None
+        if prepared.vector_mode_enabled and hasattr(doc_repo, "get_all_documents"):
+            index_doc_count = len(list(doc_repo.get_all_documents()))
+
+        return MutationSummary(
+            op_id=intent.op_id,
+            inserted=inserted,
+            updated=updated,
+            unchanged=unchanged,
+            deleted_sql=deleted_sql,
+            deleted_index=deleted_index,
+            tombstoned=tombstoned,
+            missing_external_ids=missing_external_ids,
+            index_rebuilt=False,
+            index_doc_count=index_doc_count,
+            results=results,
+        )
+
+    def recover_incomplete(self, *, limit: int = 100) -> int:
+        _ = limit
+        return 0
+
+
+__all__ = ["AtomicMutationExecutor"]

--- a/src/local_rag_backend/core/use_cases/_mutation_saga_executor.py
+++ b/src/local_rag_backend/core/use_cases/_mutation_saga_executor.py
@@ -51,7 +51,9 @@ def validate_storage_profile(
         raise RuntimeError(
             f"Storage profile {profile.profile_id!r} is read-only and cannot serve mutations."
         )
-    if not profile.has(StorageCapability.DURABLE_SAGA) and not profile.has(StorageCapability.ATOMIC):
+    if not profile.has(StorageCapability.DURABLE_SAGA) and not profile.has(
+        StorageCapability.ATOMIC
+    ):
         raise RuntimeError(
             f"Storage profile {profile.profile_id!r} does not satisfy writable storage capabilities."
         )

--- a/src/local_rag_backend/core/use_cases/_mutation_saga_executor.py
+++ b/src/local_rag_backend/core/use_cases/_mutation_saga_executor.py
@@ -43,6 +43,7 @@ def validate_storage_profile(
 ) -> None:
     profile = ports.storage_profile_registry.resolve(
         profile_id=getattr(settings_obj, "storage_profile", ""),
+        persistence_backend=getattr(settings_obj, "persistence_backend", "local_split"),
         retrieval_mode=settings_obj.retrieval_mode,
         vector_backend=getattr(settings_obj, "vector_backend", "auto"),
     )
@@ -50,9 +51,9 @@ def validate_storage_profile(
         raise RuntimeError(
             f"Storage profile {profile.profile_id!r} is read-only and cannot serve mutations."
         )
-    if not profile.has(StorageCapability.DURABLE_SAGA):
+    if not profile.has(StorageCapability.DURABLE_SAGA) and not profile.has(StorageCapability.ATOMIC):
         raise RuntimeError(
-            f"Storage profile {profile.profile_id!r} does not satisfy DURABLE_SAGA writes."
+            f"Storage profile {profile.profile_id!r} does not satisfy writable storage capabilities."
         )
     if vector_mode_enabled and not profile.supports_vectors:
         raise RuntimeError(

--- a/src/local_rag_backend/core/use_cases/_mutation_saga_executor.py
+++ b/src/local_rag_backend/core/use_cases/_mutation_saga_executor.py
@@ -436,6 +436,8 @@ def _apply_sql_mutation(
                 external_id=u.external_id,
                 content=u.content,
                 source_id=u.source_id,
+                scope=u.scope,
+                snapshot_id=u.snapshot_id,
                 metadata=u.metadata,
             )
             for u in intent.upserts

--- a/src/local_rag_backend/core/use_cases/docs_import_canonical.py
+++ b/src/local_rag_backend/core/use_cases/docs_import_canonical.py
@@ -1,0 +1,232 @@
+"""Canonical import/sync use case for external document producers."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, cast
+
+from local_rag_backend.core.domain.types import DocId
+from local_rag_backend.core.use_cases.docs_mutation import (
+    MutationCoordinator,
+    MutationIntent,
+    MutationUpsertInput,
+    uses_vector_index,
+)
+from local_rag_backend.core.use_cases.results import CanonicalImportSummary, UpsertDocResult
+
+if TYPE_CHECKING:
+    from local_rag_backend.core.ports.contracts import DocsMutationPorts
+    from local_rag_backend.settings import Settings
+
+
+CANONICAL_BATCH_SIZE = 256
+
+
+@dataclass(frozen=True)
+class CanonicalImportDocumentInput:
+    external_id: str
+    content: str
+    source_id: str | None = None
+    metadata: Mapping[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class CanonicalImportRequestInput:
+    scope: str
+    snapshot_id: str
+    replace_scope: bool
+    documents: tuple[CanonicalImportDocumentInput, ...]
+    source: str = "unknown"
+
+
+def execute_import_canonical_sync(
+    *,
+    request: CanonicalImportRequestInput,
+    settings_obj: Settings,
+    ports: DocsMutationPorts,
+) -> CanonicalImportSummary:
+    scope = str(request.scope).strip()
+    snapshot_id = str(request.snapshot_id).strip()
+    if not scope:
+        raise ValueError("scope must not be blank")
+    if not snapshot_id:
+        raise ValueError("snapshot_id must not be blank")
+
+    documents = _normalize_documents(
+        documents=request.documents,
+        scope=scope,
+        snapshot_id=snapshot_id,
+    )
+    if not documents:
+        raise ValueError("documents must not be empty")
+
+    coordinator = MutationCoordinator(settings_obj=settings_obj, ports=ports)
+    inserted = 0
+    updated = 0
+    unchanged = 0
+    results: list[UpsertDocResult] = []
+
+    for batch_idx, batch in enumerate(_batched(documents, size=CANONICAL_BATCH_SIZE), start=1):
+        summary = coordinator.execute(
+            MutationIntent(
+                op_id=f"canon:{uuid.uuid4().hex}:batch:{batch_idx}",
+                upserts=tuple(batch),
+                source=request.source,
+            )
+        )
+        inserted += int(summary.inserted)
+        updated += int(summary.updated)
+        unchanged += int(summary.unchanged)
+        results.extend(list(summary.results or []))
+
+    deleted_sql = 0
+    deleted_index: int | None = 0 if uses_vector_index(settings_obj=settings_obj) else None
+    stale_external_ids: list[str] = []
+    if request.replace_scope:
+        stale_external_ids, deleted_sql, deleted_index = _delete_stale_scope_documents(
+            scope=scope,
+            keep_external_ids={doc.external_id for doc in documents},
+            settings_obj=settings_obj,
+            ports=ports,
+        )
+
+    return CanonicalImportSummary(
+        scope=scope,
+        snapshot_id=snapshot_id,
+        replace_scope=bool(request.replace_scope),
+        inserted=inserted,
+        updated=updated,
+        unchanged=unchanged,
+        deleted_sql=deleted_sql,
+        deleted_index=deleted_index,
+        deleted_external_ids=stale_external_ids,
+        results=results,
+    )
+
+
+def _normalize_documents(
+    *,
+    documents: Sequence[CanonicalImportDocumentInput],
+    scope: str,
+    snapshot_id: str,
+) -> tuple[MutationUpsertInput, ...]:
+    upserts: list[MutationUpsertInput] = []
+    seen_external_ids: set[str] = set()
+    for document in documents:
+        external_id = str(document.external_id).strip()
+        content = str(document.content).strip()
+        if not external_id or not content:
+            continue
+        if external_id in seen_external_ids:
+            raise ValueError(
+                "documents.external_id values must be unique per canonical import: " + external_id
+            )
+        seen_external_ids.add(external_id)
+        metadata = dict(document.metadata) if document.metadata is not None else {}
+        metadata["scope"] = scope
+        metadata["snapshot_id"] = snapshot_id
+        upserts.append(
+            MutationUpsertInput(
+                external_id=external_id,
+                content=content,
+                source_id=(
+                    str(document.source_id).strip()
+                    if document.source_id is not None and str(document.source_id).strip()
+                    else None
+                ),
+                scope=scope,
+                snapshot_id=snapshot_id,
+                metadata=metadata,
+            )
+        )
+    return tuple(upserts)
+
+
+def _batched(
+    documents: Sequence[MutationUpsertInput],
+    *,
+    size: int,
+) -> Sequence[tuple[MutationUpsertInput, ...]]:
+    return tuple(
+        tuple(documents[idx : idx + size]) for idx in range(0, len(documents), max(1, int(size)))
+    )
+
+
+def _delete_stale_scope_documents(
+    *,
+    scope: str,
+    keep_external_ids: set[str],
+    settings_obj: Settings,
+    ports: DocsMutationPorts,
+) -> tuple[list[str], int, int | None]:
+    doc_repo = ports.doc_repo_factory()
+    list_external_ids_by_scope = getattr(doc_repo, "list_external_ids_by_scope", None)
+    if not callable(list_external_ids_by_scope):
+        raise RuntimeError("Configured document repository does not support scope-aware sync.")
+
+    existing_external_ids = {
+        str(ext_id).strip()
+        for ext_id in cast("Sequence[str]", list_external_ids_by_scope(scope))
+        if str(ext_id).strip()
+    }
+    stale_external_ids = sorted(existing_external_ids - keep_external_ids)
+    if not stale_external_ids:
+        return [], 0, (0 if uses_vector_index(settings_obj=settings_obj) else None)
+
+    snapshot_by_external_ids = getattr(doc_repo, "snapshot_by_external_ids", None)
+    stale_doc_ids: list[DocId] = []
+    if callable(snapshot_by_external_ids):
+        snapshots = cast("Sequence[dict[str, Any]]", snapshot_by_external_ids(stale_external_ids))
+        stale_doc_ids = [
+            DocId(str(snapshot.get("id")))
+            for snapshot in snapshots
+            if str(snapshot.get("id") or "").strip()
+        ]
+
+    hard_delete = getattr(doc_repo, "hard_delete_by_external_ids", None)
+    if not callable(hard_delete):
+        raise RuntimeError("Configured document repository does not support hard_delete_by_external_ids.")
+    deleted_sql_raw = hard_delete(stale_external_ids)
+    deleted_sql = int(deleted_sql_raw) if deleted_sql_raw is not None else len(stale_external_ids)
+
+    deleted_index: int | None = None
+    if uses_vector_index(settings_obj=settings_obj):
+        deleted_index = _delete_vectors_for_doc_ids(
+            doc_ids=stale_doc_ids,
+            settings_obj=settings_obj,
+            ports=ports,
+        )
+    return stale_external_ids, deleted_sql, deleted_index
+
+
+def _delete_vectors_for_doc_ids(
+    *,
+    doc_ids: Sequence[DocId],
+    settings_obj: Settings,
+    ports: DocsMutationPorts,
+) -> int:
+    deduped_doc_ids = [DocId(str(doc_id)) for doc_id in {str(doc_id) for doc_id in doc_ids if str(doc_id)}]
+    if not deduped_doc_ids:
+        return 0
+    vec_repo = ports.vector_repo_factory(
+        index_path=settings_obj.index_path,
+        id_map_path=settings_obj.id_map_path,
+        backend=getattr(settings_obj, "vector_backend", "auto"),
+        settings_obj=settings_obj,
+    )
+    apply_delta = getattr(vec_repo, "apply_delta_atomic", None)
+    if callable(apply_delta):
+        apply_delta(delete_ids=deduped_doc_ids, upserts=[])
+    else:
+        vec_repo.delete(deduped_doc_ids)
+    return len(deduped_doc_ids)
+
+
+__all__ = [
+    "CANONICAL_BATCH_SIZE",
+    "CanonicalImportDocumentInput",
+    "CanonicalImportRequestInput",
+    "execute_import_canonical_sync",
+]

--- a/src/local_rag_backend/core/use_cases/docs_import_canonical.py
+++ b/src/local_rag_backend/core/use_cases/docs_import_canonical.py
@@ -187,7 +187,9 @@ def _delete_stale_scope_documents(
 
     hard_delete = getattr(doc_repo, "hard_delete_by_external_ids", None)
     if not callable(hard_delete):
-        raise RuntimeError("Configured document repository does not support hard_delete_by_external_ids.")
+        raise RuntimeError(
+            "Configured document repository does not support hard_delete_by_external_ids."
+        )
     deleted_sql_raw = hard_delete(stale_external_ids)
     deleted_sql = int(deleted_sql_raw) if deleted_sql_raw is not None else len(stale_external_ids)
 
@@ -207,7 +209,9 @@ def _delete_vectors_for_doc_ids(
     settings_obj: Settings,
     ports: DocsMutationPorts,
 ) -> int:
-    deduped_doc_ids = [DocId(str(doc_id)) for doc_id in {str(doc_id) for doc_id in doc_ids if str(doc_id)}]
+    deduped_doc_ids = [
+        DocId(str(doc_id)) for doc_id in {str(doc_id) for doc_id in doc_ids if str(doc_id)}
+    ]
     if not deduped_doc_ids:
         return 0
     vec_repo = ports.vector_repo_factory(

--- a/src/local_rag_backend/core/use_cases/docs_mutation.py
+++ b/src/local_rag_backend/core/use_cases/docs_mutation.py
@@ -141,7 +141,9 @@ class MutationCoordinator:
                         )
                     else:
                         if journal is None:  # pragma: no cover
-                            raise RuntimeError("Mutation journal is required for durable saga mode.")
+                            raise RuntimeError(
+                                "Mutation journal is required for durable saga mode."
+                            )
                         item.result = self._saga.execute_locked(
                             prepared=cast("PreparedMutation", item.payload),
                             journal=journal,

--- a/src/local_rag_backend/core/use_cases/docs_mutation.py
+++ b/src/local_rag_backend/core/use_cases/docs_mutation.py
@@ -6,6 +6,8 @@ import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
+from local_rag_backend.core.domain.profiles import StorageCapability
+from local_rag_backend.core.use_cases._atomic_mutation_executor import AtomicMutationExecutor
 from local_rag_backend.core.use_cases._batch_coordinator import (
     MutationBatchCoordinator,
     MutationBatchItem,
@@ -44,6 +46,7 @@ class MutationCoordinator:
         self.ports = ports
         self._batcher = MutationBatchCoordinator()
         self._saga = MutationSagaExecutor(settings_obj=settings_obj, ports=ports)
+        self._atomic = AtomicMutationExecutor(settings_obj=settings_obj, ports=ports)
 
     def execute(self, intent: MutationIntent) -> MutationSummary:
         normalized = normalize_intent(intent=intent, new_op_id=_new_op_id)
@@ -53,13 +56,24 @@ class MutationCoordinator:
             ports=self.ports,
             vector_mode_enabled=vector_mode_enabled,
         )
-        if vector_mode_enabled:
+        profile = self.ports.storage_profile_registry.resolve(
+            profile_id=getattr(self.settings_obj, "storage_profile", ""),
+            persistence_backend=getattr(self.settings_obj, "persistence_backend", "local_split"),
+            retrieval_mode=self.settings_obj.retrieval_mode,
+            vector_backend=getattr(self.settings_obj, "vector_backend", "auto"),
+        )
+        use_atomic = profile.has(StorageCapability.ATOMIC) and not profile.has(
+            StorageCapability.DURABLE_SAGA
+        )
+        if vector_mode_enabled and not use_atomic:
             validate_rollback_contract(ports=self.ports)
 
-        journal = build_journal(ports=self.ports)
-        replay = self._saga.get_committed_replay_summary(journal=journal, intent=normalized)
-        if replay is not None:
-            return replay
+        journal = None
+        if not use_atomic:
+            journal = build_journal(ports=self.ports)
+            replay = self._saga.get_committed_replay_summary(journal=journal, intent=normalized)
+            if replay is not None:
+                return replay
 
         precomputed_vectors = self._saga.precompute_vectors_for_intent(
             intent=normalized,
@@ -78,11 +92,25 @@ class MutationCoordinator:
                 payload=prepared,
                 max_batch_size=self._batch_max_size(),
                 max_wait_ms=self._batch_max_wait_ms(),
-                process_batch=lambda batch: self._process_batch(batch=batch, journal=journal),
+                process_batch=lambda batch: self._process_batch(
+                    batch=batch,
+                    journal=journal,
+                    use_atomic=use_atomic,
+                ),
             ),
         )
 
     def recover_incomplete(self, *, limit: int = 100) -> int:
+        profile = self.ports.storage_profile_registry.resolve(
+            profile_id=getattr(self.settings_obj, "storage_profile", ""),
+            persistence_backend=getattr(self.settings_obj, "persistence_backend", "local_split"),
+            retrieval_mode=self.settings_obj.retrieval_mode,
+            vector_backend=getattr(self.settings_obj, "vector_backend", "auto"),
+        )
+        if profile.has(StorageCapability.ATOMIC) and not profile.has(
+            StorageCapability.DURABLE_SAGA
+        ):
+            return self._atomic.recover_incomplete(limit=limit)
         return self._saga.recover_incomplete(limit=limit)
 
     def _batch_state_key(self) -> str:
@@ -101,15 +129,23 @@ class MutationCoordinator:
         self,
         *,
         batch: list[MutationBatchItem],
-        journal: MutationJournalPort,
+        journal: MutationJournalPort | None,
+        use_atomic: bool,
     ) -> None:
         with write_lock_context(settings_obj=self.settings_obj, ports=self.ports):
             for item in batch:
                 try:
-                    item.result = self._saga.execute_locked(
-                        prepared=cast("PreparedMutation", item.payload),
-                        journal=journal,
-                    )
+                    if use_atomic:
+                        item.result = self._atomic.execute_locked(
+                            prepared=cast("PreparedMutation", item.payload)
+                        )
+                    else:
+                        if journal is None:  # pragma: no cover
+                            raise RuntimeError("Mutation journal is required for durable saga mode.")
+                        item.result = self._saga.execute_locked(
+                            prepared=cast("PreparedMutation", item.payload),
+                            journal=journal,
+                        )
                 except Exception as exc:
                     item.error = exc
                 finally:

--- a/src/local_rag_backend/core/use_cases/docs_mutation_contracts.py
+++ b/src/local_rag_backend/core/use_cases/docs_mutation_contracts.py
@@ -21,6 +21,8 @@ class MutationUpsertInput:
     external_id: str
     content: str
     source_id: str | None = None
+    scope: str | None = None
+    snapshot_id: str | None = None
     metadata: Mapping[str, Any] | None = None
 
 
@@ -43,6 +45,8 @@ def normalize_intent(
             external_id=str(it.external_id).strip(),
             content=str(it.content).strip(),
             source_id=(str(it.source_id) if it.source_id is not None else None),
+            scope=(str(it.scope) if it.scope is not None else None),
+            snapshot_id=(str(it.snapshot_id) if it.snapshot_id is not None else None),
             metadata=dict(it.metadata) if it.metadata is not None else None,
         )
         for it in list(intent.upserts)
@@ -136,6 +140,8 @@ def intent_to_dict(intent: MutationIntent) -> dict[str, Any]:
                 "external_id": u.external_id,
                 "content": u.content,
                 "source_id": u.source_id,
+                "scope": u.scope,
+                "snapshot_id": u.snapshot_id,
                 "metadata": dict(u.metadata) if u.metadata is not None else None,
             }
             for u in intent.upserts

--- a/src/local_rag_backend/core/use_cases/health.py
+++ b/src/local_rag_backend/core/use_cases/health.py
@@ -129,6 +129,10 @@ def check_mutation_journal(
     settings_obj: Settings,
     diagnostics: HealthDiagnosticsPort,
 ) -> None:
+    if str(getattr(settings_obj, "persistence_backend", "local_split")) == "elasticsearch":
+        checks["mutation_journal"] = {"status": "not_applicable"}
+        return
+
     try:
         incomplete = diagnostics.get_incomplete_mutation_records_count(
             coordination_dir=settings_obj.get_coordination_dir()

--- a/src/local_rag_backend/core/use_cases/index.py
+++ b/src/local_rag_backend/core/use_cases/index.py
@@ -25,5 +25,6 @@ def rebuild_index_sync(
         id_map_path=settings_obj.id_map_path,
         dim=embedder.dim,
         backend=getattr(settings_obj, "vector_backend", "auto"),
+        settings_obj=settings_obj,
     )
     return ports.rebuild_fn(doc_repo=doc_repo, vec_repo=vec, embedder=embedder)

--- a/src/local_rag_backend/core/use_cases/results.py
+++ b/src/local_rag_backend/core/use_cases/results.py
@@ -26,3 +26,17 @@ class MutationSummary:
     index_rebuilt: bool = False
     index_doc_count: int | None = None
     results: list[UpsertDocResult] | None = None
+
+
+@dataclass(frozen=True)
+class CanonicalImportSummary:
+    scope: str
+    snapshot_id: str
+    replace_scope: bool
+    inserted: int = 0
+    updated: int = 0
+    unchanged: int = 0
+    deleted_sql: int = 0
+    deleted_index: int | None = None
+    deleted_external_ids: list[str] | None = None
+    results: list[UpsertDocResult] | None = None

--- a/src/local_rag_backend/http/routers/docs.py
+++ b/src/local_rag_backend/http/routers/docs.py
@@ -34,7 +34,6 @@ from local_rag_backend.core.use_cases.errors import (
 from local_rag_backend.core.use_cases.mutations import run_api_mutation
 from local_rag_backend.http.dependencies import (
     get_app_container_dependency,
-    get_db,
     get_settings_dependency,
     reset_rag_service,
 )
@@ -55,8 +54,6 @@ from local_rag_backend.infrastructure.observability.observability import (
 )
 
 if TYPE_CHECKING:
-    from sqlalchemy.orm import Session
-
     from local_rag_backend.composition.container import AppContainer
     from local_rag_backend.core.use_cases.results import MutationSummary
     from local_rag_backend.settings import Settings
@@ -104,10 +101,9 @@ async def _run_docs_mutation_operation(
 async def list_docs(
     limit: int = Query(100, ge=1, le=1000, description="Max number of docs"),
     offset: int = Query(0, ge=0, description="Offset for pagination"),
-    db: Session = Depends(get_db),
     container: AppContainer = Depends(get_app_container_dependency),
 ) -> list[DocumentInDB]:
-    docs_reader = container.build_docs_read_port(db=db)
+    docs_reader = container.build_docs_read_port()
     docs = docs_reader.list_docs_page(limit=limit, offset=offset)
     return [DocumentInDB(id=item.id, content=item.content) for item in docs]
 

--- a/src/local_rag_backend/http/routers/docs.py
+++ b/src/local_rag_backend/http/routers/docs.py
@@ -20,6 +20,11 @@ from local_rag_backend.core.use_cases.docs_import import (
     UnsupportedImportFormatError,
     execute_import_docs_sync,
 )
+from local_rag_backend.core.use_cases.docs_import_canonical import (
+    CanonicalImportDocumentInput,
+    CanonicalImportRequestInput,
+    execute_import_canonical_sync,
+)
 from local_rag_backend.core.use_cases.docs_ingest import ingest_docs_sync
 from local_rag_backend.core.use_cases.docs_mutation import (
     MutationCoordinator,
@@ -38,6 +43,8 @@ from local_rag_backend.http.dependencies import (
     reset_rag_service,
 )
 from local_rag_backend.http.schemas.docs import (
+    CanonicalImportRequest,
+    CanonicalImportResponse,
     DocsMutateRequest,
     DocsMutateResponse,
     ImportResponse,
@@ -84,13 +91,14 @@ async def _run_docs_mutation_operation(
     *,
     operation: Callable[[], Any],
     container: AppContainer,
+    run_locked: Callable[[Callable[[], Any]], Any] | None = None,
     map_error: Callable[
         [Exception], PayloadTooLargeError | UnprocessableEntityError | BadRequestError | None
     ],
 ) -> Any:
     return await run_api_mutation(
         operation=operation,
-        run_locked=lambda fn: fn(),
+        run_locked=(run_locked or (lambda fn: fn())),
         reset_after=reset_rag_service,
         blocking_executor=container.blocking_executor(run_blocking_fn=run_blocking),
         map_error=map_error,
@@ -150,6 +158,8 @@ async def mutate_docs(
                         external_id=item.external_id,
                         content=item.content,
                         source_id=item.source_id,
+                        scope=item.scope,
+                        snapshot_id=item.snapshot_id,
                         metadata=item.metadata,
                     )
                     for item in payload.upserts
@@ -188,6 +198,68 @@ async def mutate_docs(
             )
             for r in list(summary.results or [])
         ],
+    )
+
+
+@router.post("/docs/import-canonical", response_model=CanonicalImportResponse)
+async def import_canonical_docs(
+    payload: Annotated[CanonicalImportRequest, Body(...)],
+    container: AppContainer = Depends(get_app_container_dependency),
+    settings_obj: Settings = Depends(get_settings_dependency),
+) -> CanonicalImportResponse:
+    mutation_bundle = container.build_docs_mutation_bundle(
+        missing_backend_message=DEFAULT_DENSE_BACKEND_MESSAGE
+    )
+
+    def _import_operation() -> CanonicalImportResponse:
+        summary = execute_import_canonical_sync(
+            request=CanonicalImportRequestInput(
+                scope=payload.scope,
+                snapshot_id=payload.snapshot_id,
+                replace_scope=payload.replace_scope,
+                documents=tuple(
+                    CanonicalImportDocumentInput(
+                        external_id=item.external_id,
+                        content=item.content,
+                        source_id=item.source_id,
+                        metadata=item.metadata,
+                    )
+                    for item in payload.documents
+                ),
+                source="api:/docs/import-canonical",
+            ),
+            settings_obj=settings_obj,
+            ports=mutation_bundle.ports,
+        )
+        return CanonicalImportResponse(
+            scope=summary.scope,
+            snapshot_id=summary.snapshot_id,
+            replace_scope=summary.replace_scope,
+            inserted=summary.inserted,
+            updated=summary.updated,
+            unchanged=summary.unchanged,
+            deleted_sql=summary.deleted_sql,
+            deleted_index=summary.deleted_index,
+            deleted_external_ids=list(summary.deleted_external_ids or []),
+            results=[
+                UpsertDocResult(
+                    external_id=row.external_id,
+                    id=row.id,
+                    action=row.action,
+                    content_changed=row.content_changed,
+                )
+                for row in list(summary.results or [])
+            ],
+        )
+
+    return cast(
+        "CanonicalImportResponse",
+        await _run_docs_mutation_operation(
+            operation=_import_operation,
+            container=container,
+            map_error=lambda exc: _map_docs_error(exc, operation="mutate"),
+            run_locked=container.run_multi_store_write_locked,
+        ),
     )
 
 

--- a/src/local_rag_backend/http/routers/rag_router.py
+++ b/src/local_rag_backend/http/routers/rag_router.py
@@ -15,7 +15,6 @@ from local_rag_backend.core.use_cases.rag_query import (
 )
 from local_rag_backend.http.dependencies import (
     get_app_container_dependency,
-    get_db,
     get_rag_service,
     get_settings_dependency,
 )
@@ -37,8 +36,6 @@ from local_rag_backend.infrastructure.observability.observability import (
 )
 
 if TYPE_CHECKING:
-    from sqlalchemy.orm import Session
-
     from local_rag_backend.composition.container import AppContainer
     from local_rag_backend.core.services.rag_runtime import RagService
     from local_rag_backend.settings import Settings
@@ -92,11 +89,10 @@ async def ask(
 async def history(
     limit: int = Query(10, ge=1, le=100, description="Max number of history items to retrieve"),
     offset: int = Query(0, ge=0, description="Number of items to skip (useful for pagination)"),
-    db: Session = Depends(get_db),
     container: AppContainer = Depends(get_app_container_dependency),
 ) -> list[HistoryItem]:
     """Retrieve historical Q&A pairs from the database."""
-    history_reader = container.build_history_read_port(db=db)
+    history_reader = container.build_history_read_port()
     history_entries = list_history_entries_sync(
         history_reader=history_reader,
         limit=limit,

--- a/src/local_rag_backend/http/schemas/__init__.py
+++ b/src/local_rag_backend/http/schemas/__init__.py
@@ -1,6 +1,9 @@
 """HTTP transport schemas grouped by bounded context."""
 
 from local_rag_backend.http.schemas.docs import (
+    CanonicalImportDocItem,
+    CanonicalImportRequest,
+    CanonicalImportResponse,
     DocsMutateRequest,
     DocsMutateResponse,
     ImportResponse,
@@ -33,6 +36,9 @@ __all__ = [
     "AskEvalResponse",
     "AskRequest",
     "AskResponse",
+    "CanonicalImportDocItem",
+    "CanonicalImportRequest",
+    "CanonicalImportResponse",
     "ConfigResponse",
     "DocsMutateRequest",
     "DocsMutateResponse",

--- a/src/local_rag_backend/http/schemas/docs.py
+++ b/src/local_rag_backend/http/schemas/docs.py
@@ -25,6 +25,8 @@ class UpsertDocItem(BaseModel):
     external_id: str = Field(..., min_length=1, max_length=512)
     content: str = Field(..., min_length=1, max_length=20000)
     source_id: str | None = Field(default=None, max_length=1024)
+    scope: str | None = Field(default=None, min_length=1, max_length=512)
+    snapshot_id: str | None = Field(default=None, min_length=1, max_length=512)
     metadata: dict[str, Any] | None = None
 
     @field_validator("external_id")
@@ -49,6 +51,73 @@ class UpsertDocResult(BaseModel):
     id: str
     action: str
     content_changed: bool
+
+
+class CanonicalImportDocItem(BaseModel):
+    external_id: str = Field(..., min_length=1, max_length=512)
+    content: str = Field(..., min_length=1, max_length=20000)
+    source_id: str | None = Field(default=None, max_length=1024)
+    metadata: dict[str, Any] | None = None
+
+    @field_validator("external_id")
+    @classmethod
+    def _canonical_external_id_not_blank(cls, v: str) -> str:
+        v2 = v.strip()
+        if not v2:
+            raise ValueError("external_id must not be blank")
+        return v2
+
+    @field_validator("content")
+    @classmethod
+    def _canonical_content_not_blank(cls, v: str) -> str:
+        v2 = v.strip()
+        if not v2:
+            raise ValueError("content must not be blank")
+        return v2
+
+
+class CanonicalImportRequest(BaseModel):
+    scope: str = Field(..., min_length=1, max_length=512)
+    snapshot_id: str = Field(..., min_length=1, max_length=512)
+    replace_scope: bool = False
+    documents: list[CanonicalImportDocItem] = Field(default_factory=list, min_length=1, max_length=5000)
+
+    @field_validator("scope", "snapshot_id")
+    @classmethod
+    def _not_blank(cls, v: str) -> str:
+        v2 = v.strip()
+        if not v2:
+            raise ValueError("value must not be blank")
+        return v2
+
+    @model_validator(mode="after")
+    def _validate_unique_external_ids(self) -> CanonicalImportRequest:
+        seen: set[str] = set()
+        duplicates: list[str] = []
+        for document in self.documents:
+            external_id = str(document.external_id).strip()
+            if external_id in seen:
+                duplicates.append(external_id)
+            seen.add(external_id)
+        if duplicates:
+            raise ValueError(
+                "documents.external_id values must be unique per canonical import: "
+                + ", ".join(sorted(set(duplicates))[:10])
+            )
+        return self
+
+
+class CanonicalImportResponse(BaseModel):
+    scope: str
+    snapshot_id: str
+    replace_scope: bool
+    inserted: int = 0
+    updated: int = 0
+    unchanged: int = 0
+    deleted_sql: int = 0
+    deleted_index: int | None = None
+    deleted_external_ids: list[str] = Field(default_factory=list)
+    results: list[UpsertDocResult] = Field(default_factory=list)
 
 
 class ImportResponse(BaseModel):

--- a/src/local_rag_backend/http/schemas/docs.py
+++ b/src/local_rag_backend/http/schemas/docs.py
@@ -80,7 +80,9 @@ class CanonicalImportRequest(BaseModel):
     scope: str = Field(..., min_length=1, max_length=512)
     snapshot_id: str = Field(..., min_length=1, max_length=512)
     replace_scope: bool = False
-    documents: list[CanonicalImportDocItem] = Field(default_factory=list, min_length=1, max_length=5000)
+    documents: list[CanonicalImportDocItem] = Field(
+        default_factory=list, min_length=1, max_length=5000
+    )
 
     @field_validator("scope", "snapshot_id")
     @classmethod

--- a/src/local_rag_backend/infrastructure/persistence/elasticsearch/__init__.py
+++ b/src/local_rag_backend/infrastructure/persistence/elasticsearch/__init__.py
@@ -1,0 +1,16 @@
+from .client import ElasticBackendError, ElasticClient
+from .diagnostics import ElasticHealthDiagnostics, purge_index_artifacts_noop
+from .document_storage import ElasticDocsRepository, ElasticVectorRepo
+from .history_storage import ElasticHistoryStorage
+from .system_state import ElasticSystemStateStorage
+
+__all__ = [
+    "ElasticBackendError",
+    "ElasticClient",
+    "ElasticDocsRepository",
+    "ElasticHealthDiagnostics",
+    "ElasticHistoryStorage",
+    "ElasticSystemStateStorage",
+    "ElasticVectorRepo",
+    "purge_index_artifacts_noop",
+]

--- a/src/local_rag_backend/infrastructure/persistence/elasticsearch/client.py
+++ b/src/local_rag_backend/infrastructure/persistence/elasticsearch/client.py
@@ -1,0 +1,260 @@
+"""Thin HTTP client for Elasticsearch/OpenSearch-like backends."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any
+
+import httpx
+
+from local_rag_backend.settings import Settings, settings as global_settings
+
+
+class ElasticBackendError(RuntimeError):
+    """Backend operation failed."""
+
+
+class ElasticClient:
+    def __init__(
+        self,
+        *,
+        settings_obj: Settings | None = None,
+        client: httpx.Client | None = None,
+    ) -> None:
+        self._settings = settings_obj or global_settings
+        self._owns_client = client is None
+        self._client = client or httpx.Client(
+            base_url=str(self._settings.es_base_url or ""),
+            timeout=float(self._settings.es_request_timeout_s),
+            verify=bool(self._settings.es_verify_tls),
+            auth=self._resolve_auth(),
+            headers=self._resolve_headers(),
+        )
+
+    def close(self) -> None:
+        if self._owns_client:
+            self._client.close()
+
+    def _resolve_auth(self) -> tuple[str, str] | None:
+        if self._settings.es_username and self._settings.es_password:
+            return (str(self._settings.es_username), str(self._settings.es_password))
+        return None
+
+    def _resolve_headers(self) -> dict[str, str]:
+        headers = {"Content-Type": "application/json"}
+        if self._settings.es_api_key:
+            headers["Authorization"] = f"ApiKey {self._settings.es_api_key}"
+        return headers
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json_body: Any | None = None,
+        content: bytes | str | None = None,
+        params: Mapping[str, Any] | None = None,
+        expected: Sequence[int] = (200,),
+    ) -> httpx.Response:
+        response = self._client.request(
+            method,
+            path,
+            json=json_body,
+            content=content,
+            params=params,
+        )
+        if response.status_code not in expected:
+            raise ElasticBackendError(
+                f"{method} {path} failed with status {response.status_code}: {response.text}"
+            )
+        return response
+
+    def request_json(
+        self,
+        method: str,
+        path: str,
+        *,
+        json_body: Any | None = None,
+        content: bytes | str | None = None,
+        params: Mapping[str, Any] | None = None,
+        expected: Sequence[int] = (200,),
+    ) -> dict[str, Any]:
+        response = self._request(
+            method,
+            path,
+            json_body=json_body,
+            content=content,
+            params=params,
+            expected=expected,
+        )
+        if not response.content:
+            return {}
+        return dict(response.json())
+
+    def head_ok(self, path: str) -> bool:
+        response = self._client.request("HEAD", path)
+        if response.status_code == 404:
+            return False
+        if response.status_code >= 400:
+            raise ElasticBackendError(
+                f"HEAD {path} failed with status {response.status_code}: {response.text}"
+            )
+        return True
+
+    def bulk(self, operations: Iterable[dict[str, Any]]) -> dict[str, Any]:
+        lines = [json.dumps(op) for op in operations]
+        payload = "\n".join(lines) + ("\n" if lines else "")
+        return self.request_json(
+            "POST",
+            "/_bulk",
+            content=payload.encode("utf-8"),
+            params={"refresh": "true"},
+            expected=(200,),
+        )
+
+    def mget(self, *, index: str, ids: Sequence[str]) -> list[dict[str, Any]]:
+        if not ids:
+            return []
+        payload = {"ids": [str(x) for x in ids]}
+        data = self.request_json("POST", f"/{index}/_mget", json_body=payload)
+        docs = data.get("docs")
+        if not isinstance(docs, list):
+            return []
+        return [dict(doc) for doc in docs if isinstance(doc, dict)]
+
+    def search(
+        self,
+        *,
+        index: str,
+        body: Mapping[str, Any],
+        params: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        return self.request_json("POST", f"/{index}/_search", json_body=dict(body), params=params)
+
+    def count(self, *, index: str, query: Mapping[str, Any] | None = None) -> int:
+        body = {"query": dict(query or {"match_all": {}})}
+        data = self.request_json("POST", f"/{index}/_count", json_body=body)
+        return int(data.get("count") or 0)
+
+    def delete(self, *, index: str, id_: str) -> None:
+        self._request("DELETE", f"/{index}/_doc/{id_}", expected=(200, 202, 404))
+
+    def index_document(self, *, index: str, id_: str, body: Mapping[str, Any]) -> None:
+        self._request(
+            "PUT",
+            f"/{index}/_doc/{id_}",
+            json_body=dict(body),
+            params={"refresh": "true"},
+            expected=(200, 201),
+        )
+
+    def get_mapping(self, *, index: str) -> dict[str, Any]:
+        return self.request_json("GET", f"/{index}/_mapping")
+
+    def ensure_indices(self, *, embed_dim: int | None) -> None:
+        docs_index = str(self._settings.es_docs_index)
+        history_index = str(self._settings.es_history_index)
+        system_index = str(self._settings.es_system_index)
+        tombstones_index = str(self._settings.es_tombstones_index)
+
+        self._ensure_docs_index(index=docs_index, embed_dim=embed_dim)
+        self._ensure_history_index(index=history_index)
+        self._ensure_system_index(index=system_index)
+        self._ensure_tombstones_index(index=tombstones_index)
+
+    def _ensure_docs_index(self, *, index: str, embed_dim: int | None) -> None:
+        if self.head_ok(f"/{index}"):
+            if embed_dim is None:
+                return
+            mapping = self.get_mapping(index=index)
+            props = (((mapping.get(index) or {}).get("mappings") or {}).get("properties") or {})
+            embedding = props.get(str(self._settings.es_embedding_field)) or {}
+            dims = embedding.get("dims")
+            if dims is not None and int(dims) != int(embed_dim):
+                raise ElasticBackendError(
+                    f"Elasticsearch index {index!r} embedding dims mismatch: {dims} != {embed_dim}"
+                )
+            if dims is None:
+                self.request_json(
+                    "PUT",
+                    f"/{index}/_mapping",
+                    json_body={
+                        "properties": {
+                            str(self._settings.es_embedding_field): {
+                                "type": "dense_vector",
+                                "dims": int(embed_dim),
+                                "index": True,
+                                "similarity": "cosine",
+                            }
+                        }
+                    },
+                    expected=(200,),
+                )
+            return
+
+        properties: dict[str, Any] = {
+            "external_id": {"type": "keyword"},
+            "source_id": {"type": "keyword"},
+            str(self._settings.es_content_field): {"type": "text"},
+            "metadata": {"type": "object", "dynamic": True},
+            "content_sha256": {"type": "keyword"},
+            "chunk_dedup_sha256": {"type": "keyword"},
+            "created_at": {"type": "date"},
+            "updated_at": {"type": "date"},
+        }
+        if embed_dim is not None:
+            properties[str(self._settings.es_embedding_field)] = {
+                "type": "dense_vector",
+                "dims": int(embed_dim),
+                "index": True,
+                "similarity": "cosine",
+            }
+        payload = {"mappings": {"dynamic": True, "properties": properties}}
+        self.request_json("PUT", f"/{index}", json_body=payload, expected=(200,))
+
+    def _ensure_history_index(self, *, index: str) -> None:
+        if self.head_ok(f"/{index}"):
+            return
+        payload = {
+            "mappings": {
+                "dynamic": False,
+                "properties": {
+                    "id": {"type": "long"},
+                    "question": {"type": "text"},
+                    "answer": {"type": "text"},
+                    "source_ids": {"type": "keyword"},
+                    "created_at": {"type": "date"},
+                },
+            }
+        }
+        self.request_json("PUT", f"/{index}", json_body=payload, expected=(200,))
+
+    def _ensure_system_index(self, *, index: str) -> None:
+        if self.head_ok(f"/{index}"):
+            return
+        payload = {
+            "mappings": {
+                "dynamic": False,
+                "properties": {
+                    "key": {"type": "keyword"},
+                    "version": {"type": "long"},
+                    "updated_at": {"type": "date"},
+                },
+            }
+        }
+        self.request_json("PUT", f"/{index}", json_body=payload, expected=(200,))
+
+    def _ensure_tombstones_index(self, *, index: str) -> None:
+        if self.head_ok(f"/{index}"):
+            return
+        payload = {
+            "mappings": {
+                "dynamic": False,
+                "properties": {
+                    "external_id": {"type": "keyword"},
+                    "deleted_at": {"type": "date"},
+                },
+            }
+        }
+        self.request_json("PUT", f"/{index}", json_body=payload, expected=(200,))

--- a/src/local_rag_backend/infrastructure/persistence/elasticsearch/client.py
+++ b/src/local_rag_backend/infrastructure/persistence/elasticsearch/client.py
@@ -166,12 +166,12 @@ class ElasticClient:
     def _ensure_docs_index(self, *, index: str, embed_dim: int | None) -> None:
         if self.head_ok(f"/{index}"):
             mapping = self.get_mapping(index=index)
-            props = (((mapping.get(index) or {}).get("mappings") or {}).get("properties") or {})
+            props = ((mapping.get(index) or {}).get("mappings") or {}).get("properties") or {}
             properties_to_add: dict[str, Any] = {
                 field_name: field_mapping
                 for field_name, field_mapping in {
-                "scope": {"type": "keyword"},
-                "snapshot_id": {"type": "keyword"},
+                    "scope": {"type": "keyword"},
+                    "snapshot_id": {"type": "keyword"},
                 }.items()
                 if field_name not in props
             }

--- a/src/local_rag_backend/infrastructure/persistence/elasticsearch/client.py
+++ b/src/local_rag_backend/infrastructure/persistence/elasticsearch/client.py
@@ -165,30 +165,37 @@ class ElasticClient:
 
     def _ensure_docs_index(self, *, index: str, embed_dim: int | None) -> None:
         if self.head_ok(f"/{index}"):
-            if embed_dim is None:
-                return
             mapping = self.get_mapping(index=index)
             props = (((mapping.get(index) or {}).get("mappings") or {}).get("properties") or {})
-            embedding = props.get(str(self._settings.es_embedding_field)) or {}
-            dims = embedding.get("dims")
-            if dims is not None and int(dims) != int(embed_dim):
-                raise ElasticBackendError(
-                    f"Elasticsearch index {index!r} embedding dims mismatch: {dims} != {embed_dim}"
-                )
-            if dims is None:
+            properties_to_add: dict[str, Any] = {
+                field_name: field_mapping
+                for field_name, field_mapping in {
+                "scope": {"type": "keyword"},
+                "snapshot_id": {"type": "keyword"},
+                }.items()
+                if field_name not in props
+            }
+
+            if embed_dim is not None:
+                embedding = props.get(str(self._settings.es_embedding_field)) or {}
+                dims = embedding.get("dims")
+                if dims is not None and int(dims) != int(embed_dim):
+                    raise ElasticBackendError(
+                        f"Elasticsearch index {index!r} embedding dims mismatch: {dims} != {embed_dim}"
+                    )
+                if dims is None:
+                    properties_to_add[str(self._settings.es_embedding_field)] = {
+                        "type": "dense_vector",
+                        "dims": int(embed_dim),
+                        "index": True,
+                        "similarity": "cosine",
+                    }
+
+            if properties_to_add:
                 self.request_json(
                     "PUT",
                     f"/{index}/_mapping",
-                    json_body={
-                        "properties": {
-                            str(self._settings.es_embedding_field): {
-                                "type": "dense_vector",
-                                "dims": int(embed_dim),
-                                "index": True,
-                                "similarity": "cosine",
-                            }
-                        }
-                    },
+                    json_body={"properties": properties_to_add},
                     expected=(200,),
                 )
             return
@@ -196,6 +203,8 @@ class ElasticClient:
         properties: dict[str, Any] = {
             "external_id": {"type": "keyword"},
             "source_id": {"type": "keyword"},
+            "scope": {"type": "keyword"},
+            "snapshot_id": {"type": "keyword"},
             str(self._settings.es_content_field): {"type": "text"},
             "metadata": {"type": "object", "dynamic": True},
             "content_sha256": {"type": "keyword"},

--- a/src/local_rag_backend/infrastructure/persistence/elasticsearch/diagnostics.py
+++ b/src/local_rag_backend/infrastructure/persistence/elasticsearch/diagnostics.py
@@ -1,0 +1,93 @@
+"""Health/readiness diagnostics for Elasticsearch backend."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from local_rag_backend.infrastructure.persistence.elasticsearch.client import ElasticClient
+from local_rag_backend.infrastructure.persistence.elasticsearch.document_storage import (
+    ElasticDocsRepository,
+    ElasticVectorRepo,
+)
+from local_rag_backend.infrastructure.persistence.elasticsearch.history_storage import (
+    ElasticHistoryStorage,
+)
+from local_rag_backend.settings import Settings, settings as global_settings
+
+
+class ElasticHealthDiagnostics:
+    def __init__(
+        self,
+        *,
+        settings_obj: Settings | None = None,
+        client: ElasticClient | None = None,
+    ) -> None:
+        self._settings = settings_obj or global_settings
+        self._client = client or ElasticClient(settings_obj=self._settings)
+        self._docs = ElasticDocsRepository(settings_obj=self._settings, client=self._client)
+        self._vector = ElasticVectorRepo(settings_obj=self._settings, client=self._client)
+        self._history = ElasticHistoryStorage(settings_obj=self._settings, client=self._client)
+
+    def ping_database(self) -> None:
+        self._client.request_json("GET", "/", expected=(200,))
+
+    def get_documents_count(self) -> int:
+        return len(self._docs.get_all_documents())
+
+    def get_history_count(self) -> int:
+        return self._client.count(index=str(self._settings.es_history_index))
+
+    def get_document_ids(self) -> tuple[str, ...]:
+        return tuple(str(doc.id) for doc in self._docs.get_all_documents())
+
+    def get_index_ids(self, *, id_map_path: str) -> tuple[str, ...]:
+        _ = id_map_path
+        body = {
+            "size": 1000,
+            "_source": False,
+            "query": {"exists": {"field": str(self._settings.es_embedding_field)}},
+            "sort": [{"external_id": "asc"}],
+        }
+        data = self._client.search(index=str(self._settings.es_docs_index), body=body)
+        hits = (((data.get("hits") or {}).get("hits")) or [])
+        return tuple(str(hit.get("_id")) for hit in hits if str(hit.get("_id") or "").strip())
+
+    def get_retrieval_index_stats(
+        self,
+        *,
+        index_path: str,
+        id_map_path: str,
+        vector_backend: str,
+        dim: int | None = None,
+        expected_manifest: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        _ = (index_path, id_map_path, vector_backend, dim, expected_manifest)
+        mapping_dim = self._vector.get_mapping_dimension()
+        docs_count = self.get_documents_count()
+        vector_count = self._vector.count_indexed_docs()
+        return {
+            "status": "ok",
+            "backend": "elasticsearch",
+            "index_path": str(self._settings.es_docs_index),
+            "id_map_path": str(self._settings.es_docs_index),
+            "manifest_path": None,
+            "dim": mapping_dim,
+            "vectors": vector_count,
+            "id_map_len": vector_count,
+            "unique_ids": vector_count,
+            "duplicates": 0,
+            "documents": docs_count,
+        }
+
+    def get_incomplete_mutation_records_count(self, *, coordination_dir: Path) -> int:
+        _ = coordination_dir
+        return 0
+
+
+def purge_index_artifacts_noop(*, index_path: str, id_map_path: str) -> None:
+    _ = (index_path, id_map_path)
+    return None
+
+
+__all__ = ["ElasticHealthDiagnostics", "purge_index_artifacts_noop"]

--- a/src/local_rag_backend/infrastructure/persistence/elasticsearch/diagnostics.py
+++ b/src/local_rag_backend/infrastructure/persistence/elasticsearch/diagnostics.py
@@ -50,7 +50,7 @@ class ElasticHealthDiagnostics:
             "sort": [{"external_id": "asc"}],
         }
         data = self._client.search(index=str(self._settings.es_docs_index), body=body)
-        hits = (((data.get("hits") or {}).get("hits")) or [])
+        hits = ((data.get("hits") or {}).get("hits")) or []
         return tuple(str(hit.get("_id")) for hit in hits if str(hit.get("_id") or "").strip())
 
     def get_retrieval_index_stats(

--- a/src/local_rag_backend/infrastructure/persistence/elasticsearch/document_storage.py
+++ b/src/local_rag_backend/infrastructure/persistence/elasticsearch/document_storage.py
@@ -1,0 +1,546 @@
+"""Unified Elasticsearch-backed document and vector storage."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from local_rag_backend.core.domain.entities import Document as DomainDocument
+from local_rag_backend.core.domain.types import DocId, new_doc_id
+from local_rag_backend.core.ports import DocumentRepoPort, VectorRepoPort
+from local_rag_backend.infrastructure.persistence.elasticsearch.client import (
+    ElasticBackendError,
+    ElasticClient,
+)
+from local_rag_backend.settings import Settings, settings as global_settings
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+@dataclass(frozen=True)
+class _SearchResult:
+    id: str
+    score: float
+
+
+class ElasticDocsRepository(DocumentRepoPort):
+    @dataclass(frozen=True)
+    class UpsertDoc:
+        external_id: str
+        content: str
+        source_id: str | None = None
+        metadata: Mapping[str, Any] | None = None
+        chunk_dedup_sha256: str | None = None
+        embedding: Sequence[float] | None = None
+
+    @dataclass(frozen=True)
+    class UpsertResult:
+        external_id: str
+        id: DocId
+        action: Literal["inserted", "updated", "unchanged"]
+        content_changed: bool
+
+    @dataclass(frozen=True)
+    class ExistingDocState:
+        id: DocId
+        external_id: str
+        content: str
+        content_sha256: str | None
+        source_id: str | None
+        metadata: dict[str, Any] | None
+        chunk_dedup_sha256: str | None
+
+    def __init__(
+        self,
+        *,
+        settings_obj: Settings | None = None,
+        client: ElasticClient | None = None,
+    ) -> None:
+        self._settings = settings_obj or global_settings
+        self._client = client or ElasticClient(settings_obj=self._settings)
+        self._client.ensure_indices(embed_dim=None)
+
+    def store_documents(self, texts: Sequence[str]) -> list[DocId]:
+        items = [
+            ElasticDocsRepository.UpsertDoc(
+                external_id=str(new_doc_id(prefix="doc")),
+                content=str(text),
+            )
+            for text in texts
+            if str(text).strip()
+        ]
+        results, _changed, _updated = self.upsert_documents_by_external_id(items)
+        return [DocId(str(result.id)) for result in results]
+
+    def delete_documents(self, ids: Sequence[DocId]) -> None:
+        ops = [
+            {"delete": {"_index": str(self._settings.es_docs_index), "_id": str(doc_id)}}
+            for doc_id in ids
+            if str(doc_id).strip()
+        ]
+        if ops:
+            self._client.bulk(ops)
+
+    def get(self, ids: Sequence[DocId]) -> Sequence[DomainDocument]:
+        docs = self._client.mget(index=str(self._settings.es_docs_index), ids=[str(x) for x in ids])
+        docs_by_id = {
+            str(doc.get("_id")): self._to_domain_document(doc)
+            for doc in docs
+            if bool(doc.get("found"))
+        }
+        return [docs_by_id[str(doc_id)] for doc_id in ids if str(doc_id) in docs_by_id]
+
+    def get_all_documents(self) -> Sequence[DomainDocument]:
+        return self._scan_documents()
+
+    def get_existing_doc_states_by_external_id(
+        self, external_ids: Sequence[str]
+    ) -> dict[str, ExistingDocState]:
+        docs = self._client.mget(
+            index=str(self._settings.es_docs_index),
+            ids=[str(x) for x in external_ids if str(x).strip()],
+        )
+        out: dict[str, ElasticDocsRepository.ExistingDocState] = {}
+        for doc in docs:
+            if not bool(doc.get("found")):
+                continue
+            source = dict(doc.get("_source") or {})
+            ext_id = str(source.get("external_id") or doc.get("_id") or "")
+            if not ext_id:
+                continue
+            out[ext_id] = ElasticDocsRepository.ExistingDocState(
+                id=DocId(ext_id),
+                external_id=ext_id,
+                content=str(source.get(self._settings.es_content_field) or ""),
+                content_sha256=(
+                    str(source.get("content_sha256"))
+                    if source.get("content_sha256") is not None
+                    else None
+                ),
+                source_id=(
+                    str(source.get("source_id")) if source.get("source_id") is not None else None
+                ),
+                metadata=dict(source.get("metadata") or {}),
+                chunk_dedup_sha256=(
+                    str(source.get("chunk_dedup_sha256"))
+                    if source.get("chunk_dedup_sha256") is not None
+                    else None
+                ),
+            )
+        return out
+
+    def upsert_documents_by_external_id(
+        self, items: Sequence[UpsertDoc]
+    ) -> tuple[list[UpsertResult], list[tuple[DocId, str]], list[DocId]]:
+        items_list = [item for item in items if str(item.external_id).strip()]
+        if not items_list:
+            return [], [], []
+
+        ext_ids = [str(item.external_id).strip() for item in items_list]
+        if len(set(ext_ids)) != len(ext_ids):
+            raise ValueError("external_id values must be unique within the request")
+
+        existing = self.get_existing_doc_states_by_external_id(ext_ids)
+        results: list[ElasticDocsRepository.UpsertResult] = []
+        changed: list[tuple[DocId, str]] = []
+        updated_ids: list[DocId] = []
+        ops: list[dict[str, Any]] = []
+
+        for item in items_list:
+            external_id = str(item.external_id).strip()
+            content = str(item.content)
+            content_sha = hashlib.sha256(content.encode("utf-8")).hexdigest()
+            existing_doc = existing.get(external_id)
+
+            action: Literal["inserted", "updated", "unchanged"]
+            content_changed = True
+            if existing_doc is None:
+                action = "inserted"
+            else:
+                content_changed = (
+                    (existing_doc.content_sha256 or "") != content_sha
+                    or existing_doc.content != content
+                )
+                metadata_changed = (
+                    item.metadata is not None
+                    and dict(item.metadata) != dict(existing_doc.metadata or {})
+                )
+                source_changed = (
+                    item.source_id is not None and str(item.source_id) != existing_doc.source_id
+                )
+                dedup_changed = (
+                    item.chunk_dedup_sha256 is not None
+                    and str(item.chunk_dedup_sha256) != existing_doc.chunk_dedup_sha256
+                )
+                if content_changed or metadata_changed or source_changed or dedup_changed:
+                    action = "updated"
+                else:
+                    action = "unchanged"
+
+            if action != "unchanged":
+                body: dict[str, Any] = {
+                    "external_id": external_id,
+                    str(self._settings.es_content_field): content,
+                    "content_sha256": content_sha,
+                    "updated_at": _utc_now_iso(),
+                }
+                if existing_doc is None:
+                    body["created_at"] = body["updated_at"]
+                if item.source_id is not None:
+                    body["source_id"] = str(item.source_id)
+                if item.metadata is not None:
+                    body["metadata"] = dict(item.metadata)
+                if item.chunk_dedup_sha256 is not None:
+                    body["chunk_dedup_sha256"] = str(item.chunk_dedup_sha256)
+                if item.embedding is not None:
+                    body[str(self._settings.es_embedding_field)] = list(item.embedding)
+                ops.extend(
+                    [
+                        {
+                            "index": {
+                                "_index": str(self._settings.es_docs_index),
+                                "_id": external_id,
+                            }
+                        },
+                        body,
+                    ]
+                )
+                if content_changed:
+                    changed.append((DocId(external_id), content))
+                    if existing_doc is not None:
+                        updated_ids.append(DocId(external_id))
+
+            results.append(
+                ElasticDocsRepository.UpsertResult(
+                    external_id=external_id,
+                    id=DocId(external_id),
+                    action=action,
+                    content_changed=content_changed,
+                )
+            )
+
+        if ops:
+            self._client.bulk(ops)
+
+        return results, changed, updated_ids
+
+    def list_ids_by_external_id_prefix(self, prefix: str) -> list[tuple[DocId, str]]:
+        if not str(prefix).strip():
+            return []
+        body = {
+            "size": 1000,
+            "_source": ["external_id"],
+            "query": {"prefix": {"external_id": str(prefix)}},
+            "sort": [{"external_id": "asc"}],
+        }
+        data = self._client.search(index=str(self._settings.es_docs_index), body=body)
+        hits = (((data.get("hits") or {}).get("hits")) or [])
+        out: list[tuple[DocId, str]] = []
+        for hit in hits:
+            source = dict(hit.get("_source") or {})
+            ext_id = str(source.get("external_id") or hit.get("_id") or "")
+            if ext_id:
+                out.append((DocId(ext_id), ext_id))
+        return out
+
+    def snapshot_by_ids(self, ids: Sequence[DocId]) -> list[dict[str, Any]]:
+        docs = self.get(ids)
+        return [
+            {
+                "id": str(doc.id),
+                "external_id": doc.external_id,
+                "content": doc.content,
+                "source_id": doc.source_id,
+                "metadata": dict(doc.metadata or {}),
+                "content_sha256": hashlib.sha256(doc.content.encode("utf-8")).hexdigest(),
+            }
+            for doc in docs
+        ]
+
+    def snapshot_by_external_ids(self, external_ids: Sequence[str]) -> list[dict[str, Any]]:
+        docs = self._client.mget(
+            index=str(self._settings.es_docs_index),
+            ids=[str(x) for x in external_ids if str(x).strip()],
+        )
+        out: list[dict[str, Any]] = []
+        for doc in docs:
+            if not bool(doc.get("found")):
+                continue
+            source = dict(doc.get("_source") or {})
+            out.append(
+                {
+                    "id": str(source.get("external_id") or doc.get("_id") or ""),
+                    "external_id": str(source.get("external_id") or doc.get("_id") or ""),
+                    "content": str(source.get(self._settings.es_content_field) or ""),
+                    "source_id": source.get("source_id"),
+                    "metadata": dict(source.get("metadata") or {}),
+                    "content_sha256": source.get("content_sha256"),
+                    "chunk_dedup_sha256": source.get("chunk_dedup_sha256"),
+                }
+            )
+        return out
+
+    def restore_from_snapshots(self, snapshots: Sequence[dict[str, Any]]) -> None:
+        ops: list[dict[str, Any]] = []
+        for snap in snapshots:
+            external_id = str(snap.get("external_id") or snap.get("id") or "").strip()
+            if not external_id:
+                continue
+            body = {
+                "external_id": external_id,
+                str(self._settings.es_content_field): str(snap.get("content") or ""),
+                "source_id": snap.get("source_id"),
+                "metadata": dict(snap.get("metadata") or {}),
+                "content_sha256": snap.get("content_sha256"),
+                "chunk_dedup_sha256": snap.get("chunk_dedup_sha256"),
+                "updated_at": _utc_now_iso(),
+            }
+            ops.extend(
+                [
+                    {"index": {"_index": str(self._settings.es_docs_index), "_id": external_id}},
+                    body,
+                ]
+            )
+        if ops:
+            self._client.bulk(ops)
+
+    def hard_delete_by_external_ids(self, external_ids: Sequence[str]) -> None:
+        ops: list[dict[str, Any]] = []
+        for external_id in external_ids:
+            ext = str(external_id).strip()
+            if not ext:
+                continue
+            ops.append({"delete": {"_index": str(self._settings.es_docs_index), "_id": ext}})
+            ops.append({"delete": {"_index": str(self._settings.es_tombstones_index), "_id": ext}})
+        if ops:
+            self._client.bulk(ops)
+
+    def delete_tombstones(self, external_ids: Sequence[str]) -> int:
+        ext_ids = [str(x).strip() for x in external_ids if str(x).strip()]
+        if not ext_ids:
+            return 0
+        existing = self.get_tombstoned_external_ids(ext_ids)
+        if not existing:
+            return 0
+        ops = [
+            {"delete": {"_index": str(self._settings.es_tombstones_index), "_id": ext}}
+            for ext in sorted(existing)
+        ]
+        self._client.bulk(ops)
+        return len(existing)
+
+    def get_tombstoned_external_ids(self, external_ids: Sequence[str]) -> set[str]:
+        docs = self._client.mget(
+            index=str(self._settings.es_tombstones_index),
+            ids=[str(x) for x in external_ids if str(x).strip()],
+        )
+        return {
+            str(doc.get("_id"))
+            for doc in docs
+            if bool(doc.get("found")) and str(doc.get("_id") or "").strip()
+        }
+
+    def delete_by_external_ids(
+        self, external_ids: Sequence[str]
+    ) -> tuple[int, list[DocId], list[str], int]:
+        ext_ids = [str(x).strip() for x in external_ids if str(x).strip()]
+        if not ext_ids:
+            return 0, [], [], 0
+
+        docs = self._client.mget(index=str(self._settings.es_docs_index), ids=ext_ids)
+        found = {
+            str(doc.get("_id")): DocId(str(doc.get("_id")))
+            for doc in docs
+            if bool(doc.get("found")) and str(doc.get("_id") or "").strip()
+        }
+        missing = [ext for ext in ext_ids if ext not in found]
+        already_ts = self.get_tombstoned_external_ids(ext_ids)
+        to_tombstone = [ext for ext in ext_ids if ext not in already_ts]
+
+        ops: list[dict[str, Any]] = [
+            {"delete": {"_index": str(self._settings.es_docs_index), "_id": ext}}
+            for ext in found
+        ]
+        now = _utc_now_iso()
+        for ext in to_tombstone:
+            ops.extend(
+                [
+                    {
+                        "index": {
+                            "_index": str(self._settings.es_tombstones_index),
+                            "_id": ext,
+                        }
+                    },
+                    {"external_id": ext, "deleted_at": now},
+                ]
+            )
+        if ops:
+            self._client.bulk(ops)
+        return len(found), list(found.values()), missing, len(to_tombstone)
+
+    def _scan_documents(self) -> list[DomainDocument]:
+        docs: list[DomainDocument] = []
+        search_after: list[Any] | None = None
+        while True:
+            body: dict[str, Any] = {
+                "size": 500,
+                "query": {"match_all": {}},
+                "sort": [{"external_id": "asc"}],
+            }
+            if search_after is not None:
+                body["search_after"] = list(search_after)
+            data = self._client.search(index=str(self._settings.es_docs_index), body=body)
+            hits = (((data.get("hits") or {}).get("hits")) or [])
+            if not hits:
+                break
+            docs.extend(self._to_domain_document(hit) for hit in hits)
+            search_after = hits[-1].get("sort")
+            if not search_after:
+                break
+        return docs
+
+    def _to_domain_document(self, hit: Mapping[str, Any]) -> DomainDocument:
+        source = dict(hit.get("_source") or {})
+        external_id = str(source.get("external_id") or hit.get("_id") or "")
+        return DomainDocument(
+            id=DocId(external_id),
+            content=str(source.get(self._settings.es_content_field) or ""),
+            external_id=external_id,
+            source_id=(str(source.get("source_id")) if source.get("source_id") is not None else None),
+            metadata=dict(source.get("metadata") or {}),
+        )
+
+
+class ElasticVectorRepo(VectorRepoPort):
+    def __init__(
+        self,
+        *,
+        settings_obj: Settings | None = None,
+        client: ElasticClient | None = None,
+        dim: int | None = None,
+        **_: Any,
+    ) -> None:
+        self._settings = settings_obj or global_settings
+        self._client = client or ElasticClient(settings_obj=self._settings)
+        self._client.ensure_indices(embed_dim=dim)
+
+    @property
+    def ntotal(self) -> int:
+        return self._client.count(
+            index=str(self._settings.es_docs_index),
+            query={"exists": {"field": str(self._settings.es_embedding_field)}},
+        )
+
+    def upsert(self, ids: Sequence[DocId], vectors: Sequence[Sequence[float]]) -> None:
+        self.apply_delta_atomic(delete_ids=(), upserts=list(zip(ids, vectors, strict=False)))
+
+    def apply_delta_atomic(
+        self,
+        *,
+        delete_ids: Sequence[DocId],
+        upserts: Sequence[tuple[DocId, Sequence[float]]],
+    ) -> None:
+        ops: list[dict[str, Any]] = []
+        for doc_id in delete_ids:
+            ext = str(doc_id).strip()
+            if not ext:
+                continue
+            ops.extend(
+                [
+                    {"update": {"_index": str(self._settings.es_docs_index), "_id": ext}},
+                    {"script": {"source": f"ctx._source.remove('{self._settings.es_embedding_field}')"}},
+                ]
+            )
+        for doc_id, vector in upserts:
+            ext = str(doc_id).strip()
+            if not ext:
+                continue
+            ops.extend(
+                [
+                    {"update": {"_index": str(self._settings.es_docs_index), "_id": ext}},
+                    {"doc": {str(self._settings.es_embedding_field): list(vector)}},
+                ]
+            )
+        if ops:
+            self._client.bulk(ops)
+
+    def delete(self, ids: Sequence[DocId]) -> int:
+        count = len([x for x in ids if str(x).strip()])
+        self.apply_delta_atomic(delete_ids=ids, upserts=())
+        return count
+
+    def rebuild(self, ids: Sequence[DocId], vectors: Sequence[Sequence[float]]) -> None:
+        self.apply_delta_atomic(delete_ids=(), upserts=list(zip(ids, vectors, strict=False)))
+
+    def similar(self, vector: Sequence[float], k: int) -> Sequence[tuple[DocId, float]]:
+        if k <= 0:
+            return []
+        body = {
+            "size": int(k),
+            "knn": {
+                "field": str(self._settings.es_embedding_field),
+                "query_vector": list(vector),
+                "k": int(k),
+                "num_candidates": max(int(k), int(self._settings.es_hybrid_vector_k)),
+            },
+            "_source": False,
+        }
+        data = self._client.search(index=str(self._settings.es_docs_index), body=body)
+        hits = (((data.get("hits") or {}).get("hits")) or [])
+        if not hits:
+            return []
+        scores = [float(hit.get("_score") or 0.0) for hit in hits]
+        min_s = min(scores)
+        max_s = max(scores)
+        if max_s == min_s:
+            normalized = [1.0] * len(scores)
+        else:
+            normalized = [(score - min_s) / (max_s - min_s) for score in scores]
+        return [
+            (DocId(str(hit.get("_id"))), score)
+            for hit, score in zip(hits, normalized, strict=False)
+            if str(hit.get("_id") or "").strip()
+        ]
+
+    def count_indexed_docs(self) -> int:
+        return self.ntotal
+
+    def lexical_search(self, query: str, *, k: int) -> list[tuple[DocId, float]]:
+        if not query.strip() or k <= 0:
+            return []
+        body = {
+            "size": int(k),
+            "query": {"match": {str(self._settings.es_content_field): {"query": query}}},
+            "_source": False,
+        }
+        data = self._client.search(index=str(self._settings.es_docs_index), body=body)
+        hits = (((data.get("hits") or {}).get("hits")) or [])
+        if not hits:
+            return []
+        scores = [float(hit.get("_score") or 0.0) for hit in hits]
+        min_s = min(scores)
+        max_s = max(scores)
+        if max_s == min_s:
+            normalized = [1.0] * len(scores)
+        else:
+            normalized = [(score - min_s) / (max_s - min_s) for score in scores]
+        return [
+            (DocId(str(hit.get("_id"))), score)
+            for hit, score in zip(hits, normalized, strict=False)
+            if str(hit.get("_id") or "").strip()
+        ]
+
+    def get_mapping_dimension(self) -> int | None:
+        mapping = self._client.get_mapping(index=str(self._settings.es_docs_index))
+        props = (((mapping.get(str(self._settings.es_docs_index)) or {}).get("mappings") or {}).get("properties") or {})
+        field = props.get(str(self._settings.es_embedding_field)) or {}
+        dims = field.get("dims")
+        return int(dims) if dims is not None else None
+
+
+__all__ = ["ElasticBackendError", "ElasticDocsRepository", "ElasticVectorRepo"]

--- a/src/local_rag_backend/infrastructure/persistence/elasticsearch/document_storage.py
+++ b/src/local_rag_backend/infrastructure/persistence/elasticsearch/document_storage.py
@@ -34,6 +34,8 @@ class ElasticDocsRepository(DocumentRepoPort):
         external_id: str
         content: str
         source_id: str | None = None
+        scope: str | None = None
+        snapshot_id: str | None = None
         metadata: Mapping[str, Any] | None = None
         chunk_dedup_sha256: str | None = None
         embedding: Sequence[float] | None = None
@@ -52,6 +54,8 @@ class ElasticDocsRepository(DocumentRepoPort):
         content: str
         content_sha256: str | None
         source_id: str | None
+        scope: str | None
+        snapshot_id: str | None
         metadata: dict[str, Any] | None
         chunk_dedup_sha256: str | None
 
@@ -125,6 +129,12 @@ class ElasticDocsRepository(DocumentRepoPort):
                 source_id=(
                     str(source.get("source_id")) if source.get("source_id") is not None else None
                 ),
+                scope=(str(source.get("scope")) if source.get("scope") is not None else None),
+                snapshot_id=(
+                    str(source.get("snapshot_id"))
+                    if source.get("snapshot_id") is not None
+                    else None
+                ),
                 metadata=dict(source.get("metadata") or {}),
                 chunk_dedup_sha256=(
                     str(source.get("chunk_dedup_sha256"))
@@ -173,11 +183,23 @@ class ElasticDocsRepository(DocumentRepoPort):
                 source_changed = (
                     item.source_id is not None and str(item.source_id) != existing_doc.source_id
                 )
+                scope_changed = item.scope is not None and str(item.scope) != existing_doc.scope
+                snapshot_changed = (
+                    item.snapshot_id is not None
+                    and str(item.snapshot_id) != existing_doc.snapshot_id
+                )
                 dedup_changed = (
                     item.chunk_dedup_sha256 is not None
                     and str(item.chunk_dedup_sha256) != existing_doc.chunk_dedup_sha256
                 )
-                if content_changed or metadata_changed or source_changed or dedup_changed:
+                if (
+                    content_changed
+                    or metadata_changed
+                    or source_changed
+                    or scope_changed
+                    or snapshot_changed
+                    or dedup_changed
+                ):
                     action = "updated"
                 else:
                     action = "unchanged"
@@ -193,6 +215,10 @@ class ElasticDocsRepository(DocumentRepoPort):
                     body["created_at"] = body["updated_at"]
                 if item.source_id is not None:
                     body["source_id"] = str(item.source_id)
+                if item.scope is not None:
+                    body["scope"] = str(item.scope)
+                if item.snapshot_id is not None:
+                    body["snapshot_id"] = str(item.snapshot_id)
                 if item.metadata is not None:
                     body["metadata"] = dict(item.metadata)
                 if item.chunk_dedup_sha256 is not None:
@@ -256,7 +282,13 @@ class ElasticDocsRepository(DocumentRepoPort):
                 "external_id": doc.external_id,
                 "content": doc.content,
                 "source_id": doc.source_id,
-                "metadata": dict(doc.metadata or {}),
+                "scope": (doc.metadata or {}).get("scope"),
+                "snapshot_id": (doc.metadata or {}).get("snapshot_id"),
+                "metadata": {
+                    key: value
+                    for key, value in dict(doc.metadata or {}).items()
+                    if key not in {"scope", "snapshot_id"}
+                },
                 "content_sha256": hashlib.sha256(doc.content.encode("utf-8")).hexdigest(),
             }
             for doc in docs
@@ -278,6 +310,8 @@ class ElasticDocsRepository(DocumentRepoPort):
                     "external_id": str(source.get("external_id") or doc.get("_id") or ""),
                     "content": str(source.get(self._settings.es_content_field) or ""),
                     "source_id": source.get("source_id"),
+                    "scope": source.get("scope"),
+                    "snapshot_id": source.get("snapshot_id"),
                     "metadata": dict(source.get("metadata") or {}),
                     "content_sha256": source.get("content_sha256"),
                     "chunk_dedup_sha256": source.get("chunk_dedup_sha256"),
@@ -295,6 +329,8 @@ class ElasticDocsRepository(DocumentRepoPort):
                 "external_id": external_id,
                 str(self._settings.es_content_field): str(snap.get("content") or ""),
                 "source_id": snap.get("source_id"),
+                "scope": snap.get("scope"),
+                "snapshot_id": snap.get("snapshot_id"),
                 "metadata": dict(snap.get("metadata") or {}),
                 "content_sha256": snap.get("content_sha256"),
                 "chunk_dedup_sha256": snap.get("chunk_dedup_sha256"),
@@ -319,6 +355,24 @@ class ElasticDocsRepository(DocumentRepoPort):
             ops.append({"delete": {"_index": str(self._settings.es_tombstones_index), "_id": ext}})
         if ops:
             self._client.bulk(ops)
+
+    def list_external_ids_by_scope(self, scope: str) -> list[str]:
+        scope_s = str(scope).strip()
+        if not scope_s:
+            return []
+        body = {
+            "size": 1000,
+            "_source": ["external_id"],
+            "query": {"term": {"scope": scope_s}},
+            "sort": [{"external_id": "asc"}],
+        }
+        data = self._client.search(index=str(self._settings.es_docs_index), body=body)
+        hits = (((data.get("hits") or {}).get("hits")) or [])
+        return [
+            str((hit.get("_source") or {}).get("external_id") or hit.get("_id") or "")
+            for hit in hits
+            if str((hit.get("_source") or {}).get("external_id") or hit.get("_id") or "").strip()
+        ]
 
     def delete_tombstones(self, external_ids: Sequence[str]) -> int:
         ext_ids = [str(x).strip() for x in external_ids if str(x).strip()]
@@ -407,12 +461,17 @@ class ElasticDocsRepository(DocumentRepoPort):
     def _to_domain_document(self, hit: Mapping[str, Any]) -> DomainDocument:
         source = dict(hit.get("_source") or {})
         external_id = str(source.get("external_id") or hit.get("_id") or "")
+        metadata = dict(source.get("metadata") or {})
+        if source.get("scope") is not None:
+            metadata["scope"] = source.get("scope")
+        if source.get("snapshot_id") is not None:
+            metadata["snapshot_id"] = source.get("snapshot_id")
         return DomainDocument(
             id=DocId(external_id),
             content=str(source.get(self._settings.es_content_field) or ""),
             external_id=external_id,
             source_id=(str(source.get("source_id")) if source.get("source_id") is not None else None),
-            metadata=dict(source.get("metadata") or {}),
+            metadata=metadata,
         )
 
 

--- a/src/local_rag_backend/infrastructure/persistence/elasticsearch/document_storage.py
+++ b/src/local_rag_backend/infrastructure/persistence/elasticsearch/document_storage.py
@@ -173,12 +173,10 @@ class ElasticDocsRepository(DocumentRepoPort):
                 action = "inserted"
             else:
                 content_changed = (
-                    (existing_doc.content_sha256 or "") != content_sha
-                    or existing_doc.content != content
-                )
-                metadata_changed = (
-                    item.metadata is not None
-                    and dict(item.metadata) != dict(existing_doc.metadata or {})
+                    existing_doc.content_sha256 or ""
+                ) != content_sha or existing_doc.content != content
+                metadata_changed = item.metadata is not None and dict(item.metadata) != dict(
+                    existing_doc.metadata or {}
                 )
                 source_changed = (
                     item.source_id is not None and str(item.source_id) != existing_doc.source_id
@@ -265,7 +263,7 @@ class ElasticDocsRepository(DocumentRepoPort):
             "sort": [{"external_id": "asc"}],
         }
         data = self._client.search(index=str(self._settings.es_docs_index), body=body)
-        hits = (((data.get("hits") or {}).get("hits")) or [])
+        hits = ((data.get("hits") or {}).get("hits")) or []
         out: list[tuple[DocId, str]] = []
         for hit in hits:
             source = dict(hit.get("_source") or {})
@@ -367,7 +365,7 @@ class ElasticDocsRepository(DocumentRepoPort):
             "sort": [{"external_id": "asc"}],
         }
         data = self._client.search(index=str(self._settings.es_docs_index), body=body)
-        hits = (((data.get("hits") or {}).get("hits")) or [])
+        hits = ((data.get("hits") or {}).get("hits")) or []
         return [
             str((hit.get("_source") or {}).get("external_id") or hit.get("_id") or "")
             for hit in hits
@@ -417,8 +415,7 @@ class ElasticDocsRepository(DocumentRepoPort):
         to_tombstone = [ext for ext in ext_ids if ext not in already_ts]
 
         ops: list[dict[str, Any]] = [
-            {"delete": {"_index": str(self._settings.es_docs_index), "_id": ext}}
-            for ext in found
+            {"delete": {"_index": str(self._settings.es_docs_index), "_id": ext}} for ext in found
         ]
         now = _utc_now_iso()
         for ext in to_tombstone:
@@ -449,7 +446,7 @@ class ElasticDocsRepository(DocumentRepoPort):
             if search_after is not None:
                 body["search_after"] = list(search_after)
             data = self._client.search(index=str(self._settings.es_docs_index), body=body)
-            hits = (((data.get("hits") or {}).get("hits")) or [])
+            hits = ((data.get("hits") or {}).get("hits")) or []
             if not hits:
                 break
             docs.extend(self._to_domain_document(hit) for hit in hits)
@@ -470,7 +467,9 @@ class ElasticDocsRepository(DocumentRepoPort):
             id=DocId(external_id),
             content=str(source.get(self._settings.es_content_field) or ""),
             external_id=external_id,
-            source_id=(str(source.get("source_id")) if source.get("source_id") is not None else None),
+            source_id=(
+                str(source.get("source_id")) if source.get("source_id") is not None else None
+            ),
             metadata=metadata,
         )
 
@@ -512,7 +511,11 @@ class ElasticVectorRepo(VectorRepoPort):
             ops.extend(
                 [
                     {"update": {"_index": str(self._settings.es_docs_index), "_id": ext}},
-                    {"script": {"source": f"ctx._source.remove('{self._settings.es_embedding_field}')"}},
+                    {
+                        "script": {
+                            "source": f"ctx._source.remove('{self._settings.es_embedding_field}')"
+                        }
+                    },
                 ]
             )
         for doc_id, vector in upserts:
@@ -550,7 +553,7 @@ class ElasticVectorRepo(VectorRepoPort):
             "_source": False,
         }
         data = self._client.search(index=str(self._settings.es_docs_index), body=body)
-        hits = (((data.get("hits") or {}).get("hits")) or [])
+        hits = ((data.get("hits") or {}).get("hits")) or []
         if not hits:
             return []
         scores = [float(hit.get("_score") or 0.0) for hit in hits]
@@ -578,7 +581,7 @@ class ElasticVectorRepo(VectorRepoPort):
             "_source": False,
         }
         data = self._client.search(index=str(self._settings.es_docs_index), body=body)
-        hits = (((data.get("hits") or {}).get("hits")) or [])
+        hits = ((data.get("hits") or {}).get("hits")) or []
         if not hits:
             return []
         scores = [float(hit.get("_score") or 0.0) for hit in hits]
@@ -596,7 +599,9 @@ class ElasticVectorRepo(VectorRepoPort):
 
     def get_mapping_dimension(self) -> int | None:
         mapping = self._client.get_mapping(index=str(self._settings.es_docs_index))
-        props = (((mapping.get(str(self._settings.es_docs_index)) or {}).get("mappings") or {}).get("properties") or {})
+        props = ((mapping.get(str(self._settings.es_docs_index)) or {}).get("mappings") or {}).get(
+            "properties"
+        ) or {}
         field = props.get(str(self._settings.es_embedding_field)) or {}
         dims = field.get("dims")
         return int(dims) if dims is not None else None

--- a/src/local_rag_backend/infrastructure/persistence/elasticsearch/history_storage.py
+++ b/src/local_rag_backend/infrastructure/persistence/elasticsearch/history_storage.py
@@ -1,0 +1,73 @@
+"""History storage backed by Elasticsearch."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from local_rag_backend.core.domain.types import DocId
+from local_rag_backend.core.ports import QAHistoryPort
+from local_rag_backend.infrastructure.persistence.elasticsearch.client import ElasticClient
+from local_rag_backend.settings import Settings, settings as global_settings
+
+
+@dataclass(frozen=True)
+class ElasticHistoryEntry:
+    id: int
+    question: str
+    answer: str
+    created_at: str
+    source_ids: tuple[str, ...]
+
+
+class ElasticHistoryStorage(QAHistoryPort):
+    def __init__(
+        self,
+        *,
+        settings_obj: Settings | None = None,
+        client: ElasticClient | None = None,
+    ) -> None:
+        self._settings = settings_obj or global_settings
+        self._client = client or ElasticClient(settings_obj=self._settings)
+        self._client.ensure_indices(embed_dim=None)
+
+    def save(self, q: str, a: str, source_ids: Sequence[DocId]) -> None:
+        created_at = datetime.now(UTC).isoformat()
+        history_id = int(time.time_ns())
+        self._client.index_document(
+            index=str(self._settings.es_history_index),
+            id_=str(history_id),
+            body={
+                "id": history_id,
+                "question": str(q),
+                "answer": str(a),
+                "created_at": created_at,
+                "source_ids": [str(x) for x in source_ids],
+            },
+        )
+
+    def list_entries(self, *, limit: int, offset: int) -> tuple[ElasticHistoryEntry, ...]:
+        body = {
+            "size": int(limit),
+            "from": int(offset),
+            "sort": [{"created_at": {"order": "desc"}}],
+            "query": {"match_all": {}},
+        }
+        data = self._client.search(index=str(self._settings.es_history_index), body=body)
+        hits = (((data.get("hits") or {}).get("hits")) or [])
+        return tuple(
+            ElasticHistoryEntry(
+                id=int((hit.get("_source") or {}).get("id") or 0),
+                question=str((hit.get("_source") or {}).get("question") or ""),
+                answer=str((hit.get("_source") or {}).get("answer") or ""),
+                created_at=str((hit.get("_source") or {}).get("created_at") or ""),
+                source_ids=tuple(str(x) for x in ((hit.get("_source") or {}).get("source_ids") or [])),
+            )
+            for hit in hits
+            if isinstance(hit, dict)
+        )
+
+
+__all__ = ["ElasticHistoryEntry", "ElasticHistoryStorage"]

--- a/src/local_rag_backend/infrastructure/persistence/elasticsearch/history_storage.py
+++ b/src/local_rag_backend/infrastructure/persistence/elasticsearch/history_storage.py
@@ -56,14 +56,16 @@ class ElasticHistoryStorage(QAHistoryPort):
             "query": {"match_all": {}},
         }
         data = self._client.search(index=str(self._settings.es_history_index), body=body)
-        hits = (((data.get("hits") or {}).get("hits")) or [])
+        hits = ((data.get("hits") or {}).get("hits")) or []
         return tuple(
             ElasticHistoryEntry(
                 id=int((hit.get("_source") or {}).get("id") or 0),
                 question=str((hit.get("_source") or {}).get("question") or ""),
                 answer=str((hit.get("_source") or {}).get("answer") or ""),
                 created_at=str((hit.get("_source") or {}).get("created_at") or ""),
-                source_ids=tuple(str(x) for x in ((hit.get("_source") or {}).get("source_ids") or [])),
+                source_ids=tuple(
+                    str(x) for x in ((hit.get("_source") or {}).get("source_ids") or [])
+                ),
             )
             for hit in hits
             if isinstance(hit, dict)

--- a/src/local_rag_backend/infrastructure/persistence/elasticsearch/system_state.py
+++ b/src/local_rag_backend/infrastructure/persistence/elasticsearch/system_state.py
@@ -1,0 +1,50 @@
+"""System-state storage backed by Elasticsearch."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from local_rag_backend.infrastructure.persistence.elasticsearch.client import ElasticClient
+from local_rag_backend.settings import Settings, settings as global_settings
+
+
+class ElasticSystemStateStorage:
+    def __init__(
+        self,
+        *,
+        settings_obj: Settings | None = None,
+        client: ElasticClient | None = None,
+    ) -> None:
+        self._settings = settings_obj or global_settings
+        self._client = client or ElasticClient(settings_obj=self._settings)
+        self._client.ensure_indices(embed_dim=None)
+
+    def get_version(self, key: str) -> int:
+        state_key = str(key).strip()
+        if not state_key:
+            raise ValueError("system_state key must not be blank")
+        docs = self._client.mget(index=str(self._settings.es_system_index), ids=[state_key])
+        if not docs or not bool(docs[0].get("found")):
+            return 0
+        source = dict(docs[0].get("_source") or {})
+        return int(source.get("version") or 0)
+
+    def bump_version(self, key: str) -> int:
+        state_key = str(key).strip()
+        if not state_key:
+            raise ValueError("system_state key must not be blank")
+        current = self.get_version(state_key)
+        new_version = current + 1
+        self._client.index_document(
+            index=str(self._settings.es_system_index),
+            id_=state_key,
+            body={
+                "key": state_key,
+                "version": new_version,
+                "updated_at": datetime.now(UTC).isoformat(),
+            },
+        )
+        return new_version
+
+
+__all__ = ["ElasticSystemStateStorage"]

--- a/src/local_rag_backend/infrastructure/persistence/sql/document_storage.py
+++ b/src/local_rag_backend/infrastructure/persistence/sql/document_storage.py
@@ -93,6 +93,7 @@ class SqlDocumentStorage(DocumentRepoPort):
         source_id: str | None = None
         metadata: Mapping[str, Any] | None = None
         chunk_dedup_sha256: str | None = None
+        embedding: Sequence[float] | None = None
 
     @dataclass(frozen=True)
     class UpsertResult:

--- a/src/local_rag_backend/infrastructure/persistence/sql/document_storage.py
+++ b/src/local_rag_backend/infrastructure/persistence/sql/document_storage.py
@@ -35,21 +35,30 @@ class _DocumentChanges:
     content: bool
     metadata: bool
     source: bool
+    scope: bool
+    snapshot: bool
     dedup: bool
 
     @property
     def any_changed(self) -> bool:
-        return self.content or self.metadata or self.source or self.dedup
+        return self.content or self.metadata or self.source or self.scope or self.snapshot or self.dedup
 
 
 def _to_domain_document(d: DbDocument) -> DomainDocument:
     """Map a single ORM row to its domain entity."""
+    metadata: dict[str, Any] | None = dict(d.metadata_ or {}) if d.metadata_ is not None else None
+    if d.scope is not None or d.snapshot_id is not None:
+        metadata = metadata or {}
+        if d.scope is not None:
+            metadata["scope"] = d.scope
+        if d.snapshot_id is not None:
+            metadata["snapshot_id"] = d.snapshot_id
     return DomainDocument(
         id=DocId(d.doc_id),
         content=d.content,
         external_id=d.external_id,
         source_id=d.source_id,
-        metadata=d.metadata_,
+        metadata=metadata,
     )
 
 
@@ -91,6 +100,8 @@ class SqlDocumentStorage(DocumentRepoPort):
         external_id: str
         content: str
         source_id: str | None = None
+        scope: str | None = None
+        snapshot_id: str | None = None
         metadata: Mapping[str, Any] | None = None
         chunk_dedup_sha256: str | None = None
         embedding: Sequence[float] | None = None
@@ -108,6 +119,8 @@ class SqlDocumentStorage(DocumentRepoPort):
         external_id: str
         content: str
         content_sha256: str | None
+        scope: str | None
+        snapshot_id: str | None
 
     @dataclass(frozen=True)
     class DocumentSnapshot:
@@ -115,6 +128,8 @@ class SqlDocumentStorage(DocumentRepoPort):
         external_id: str | None
         content: str
         source_id: str | None
+        scope: str | None
+        snapshot_id: str | None
         metadata: Mapping[str, Any] | None
         content_sha256: str | None
         chunk_dedup_sha256: str | None
@@ -125,6 +140,8 @@ class SqlDocumentStorage(DocumentRepoPort):
                 "external_id": self.external_id,
                 "content": self.content,
                 "source_id": self.source_id,
+                "scope": self.scope,
+                "snapshot_id": self.snapshot_id,
                 "metadata": dict(self.metadata) if self.metadata is not None else None,
                 "content_sha256": self.content_sha256,
                 "chunk_dedup_sha256": self.chunk_dedup_sha256,
@@ -143,13 +160,15 @@ class SqlDocumentStorage(DocumentRepoPort):
                     DbDocument.external_id,
                     DbDocument.content,
                     DbDocument.content_sha256,
+                    DbDocument.scope,
+                    DbDocument.snapshot_id,
                 )
                 .filter(DbDocument.external_id.is_not(None))
                 .filter(DbDocument.external_id.in_(ext_ids))
                 .all()
             )
             out: dict[str, SqlDocumentStorage.ExistingDocState] = {}
-            for doc_id, ext_id, content, content_sha in rows:
+            for doc_id, ext_id, content, content_sha, scope, snapshot_id in rows:
                 if ext_id is None:
                     continue
                 out[str(ext_id)] = SqlDocumentStorage.ExistingDocState(
@@ -157,6 +176,8 @@ class SqlDocumentStorage(DocumentRepoPort):
                     external_id=str(ext_id),
                     content=str(content or ""),
                     content_sha256=(str(content_sha) if content_sha is not None else None),
+                    scope=(str(scope) if scope is not None else None),
+                    snapshot_id=(str(snapshot_id) if snapshot_id is not None else None),
                 )
             return out
 
@@ -207,6 +228,8 @@ class SqlDocumentStorage(DocumentRepoPort):
                         content=content,
                         external_id=external_id,
                         source_id=item.source_id,
+                        scope=item.scope,
+                        snapshot_id=item.snapshot_id,
                         metadata_=dict(item.metadata) if item.metadata is not None else None,
                         content_sha256=sha,
                         chunk_dedup_sha256=item.chunk_dedup_sha256,
@@ -244,6 +267,10 @@ class SqlDocumentStorage(DocumentRepoPort):
 
                 if item.source_id is not None:
                     db_doc.source_id = item.source_id
+                if item.scope is not None:
+                    db_doc.scope = item.scope
+                if item.snapshot_id is not None:
+                    db_doc.snapshot_id = item.snapshot_id
                 if item.metadata is not None:
                     db_doc.metadata_ = dict(item.metadata)
                 if item.chunk_dedup_sha256 is not None:
@@ -304,6 +331,8 @@ class SqlDocumentStorage(DocumentRepoPort):
                     DbDocument.external_id,
                     DbDocument.content,
                     DbDocument.source_id,
+                    DbDocument.scope,
+                    DbDocument.snapshot_id,
                     DbDocument.metadata_,
                     DbDocument.content_sha256,
                     DbDocument.chunk_dedup_sha256,
@@ -317,6 +346,8 @@ class SqlDocumentStorage(DocumentRepoPort):
                     external_id=(str(external_id) if external_id is not None else None),
                     content=str(content),
                     source_id=(str(source_id) if source_id is not None else None),
+                    scope=(str(scope) if scope is not None else None),
+                    snapshot_id=(str(snapshot_id) if snapshot_id is not None else None),
                     metadata=(dict(metadata_) if isinstance(metadata_, dict) else None),
                     content_sha256=(str(content_sha256) if content_sha256 is not None else None),
                     chunk_dedup_sha256=(
@@ -328,6 +359,8 @@ class SqlDocumentStorage(DocumentRepoPort):
                     external_id,
                     content,
                     source_id,
+                    scope,
+                    snapshot_id,
                     metadata_,
                     content_sha256,
                     chunk_dedup_sha256,
@@ -346,6 +379,8 @@ class SqlDocumentStorage(DocumentRepoPort):
                     DbDocument.external_id,
                     DbDocument.content,
                     DbDocument.source_id,
+                    DbDocument.scope,
+                    DbDocument.snapshot_id,
                     DbDocument.metadata_,
                     DbDocument.content_sha256,
                     DbDocument.chunk_dedup_sha256,
@@ -360,6 +395,8 @@ class SqlDocumentStorage(DocumentRepoPort):
                     external_id=(str(external_id) if external_id is not None else None),
                     content=str(content),
                     source_id=(str(source_id) if source_id is not None else None),
+                    scope=(str(scope) if scope is not None else None),
+                    snapshot_id=(str(snapshot_id) if snapshot_id is not None else None),
                     metadata=(dict(metadata_) if isinstance(metadata_, dict) else None),
                     content_sha256=(str(content_sha256) if content_sha256 is not None else None),
                     chunk_dedup_sha256=(
@@ -371,6 +408,8 @@ class SqlDocumentStorage(DocumentRepoPort):
                     external_id,
                     content,
                     source_id,
+                    scope,
+                    snapshot_id,
                     metadata_,
                     content_sha256,
                     chunk_dedup_sha256,
@@ -440,6 +479,10 @@ class SqlDocumentStorage(DocumentRepoPort):
                 external_id = str(external_id_raw) if external_id_raw is not None else None
                 source_id_raw = snap.get("source_id")
                 source_id = str(source_id_raw) if source_id_raw is not None else None
+                scope_raw = snap.get("scope")
+                scope = str(scope_raw) if scope_raw is not None else None
+                snapshot_id_raw = snap.get("snapshot_id")
+                snapshot_id = str(snapshot_id_raw) if snapshot_id_raw is not None else None
                 metadata_raw = snap.get("metadata")
                 metadata_ = dict(metadata_raw) if isinstance(metadata_raw, Mapping) else None
                 chunk_dedup_raw = snap.get("chunk_dedup_sha256")
@@ -453,6 +496,8 @@ class SqlDocumentStorage(DocumentRepoPort):
                             content=content,
                             external_id=external_id,
                             source_id=source_id,
+                            scope=scope,
+                            snapshot_id=snapshot_id,
                             metadata_=metadata_,
                             content_sha256=content_sha,
                             chunk_dedup_sha256=chunk_dedup,
@@ -462,6 +507,8 @@ class SqlDocumentStorage(DocumentRepoPort):
                     row.content = content
                     row.external_id = external_id
                     row.source_id = source_id
+                    row.scope = scope
+                    row.snapshot_id = snapshot_id
                     row.metadata_ = metadata_
                     row.content_sha256 = content_sha
                     row.chunk_dedup_sha256 = chunk_dedup
@@ -552,6 +599,20 @@ class SqlDocumentStorage(DocumentRepoPort):
                 session.flush()
             return int(deleted_sql or 0), deleted_ids, missing, len(to_tombstone)
 
+    def list_external_ids_by_scope(self, scope: str) -> list[str]:
+        scope_s = str(scope).strip()
+        if not scope_s:
+            return []
+        with get_managed_session(self._session_factory) as (session, _owns_session):
+            rows = (
+                session.query(DbDocument.external_id)
+                .filter(DbDocument.scope == scope_s)
+                .filter(DbDocument.external_id.is_not(None))
+                .order_by(DbDocument.external_id.asc())
+                .all()
+            )
+            return [str(row[0]) for row in rows if row and row[0] is not None]
+
 
 def _detect_document_changes(
     db_doc: DbDocument,
@@ -570,6 +631,14 @@ def _detect_document_changes(
     if item.source_id is not None:
         source_changed = item.source_id != db_doc.source_id
 
+    scope_changed = False
+    if item.scope is not None:
+        scope_changed = item.scope != db_doc.scope
+
+    snapshot_changed = False
+    if item.snapshot_id is not None:
+        snapshot_changed = item.snapshot_id != db_doc.snapshot_id
+
     dedup_changed = False
     if item.chunk_dedup_sha256 is not None:
         dedup_changed = item.chunk_dedup_sha256 != db_doc.chunk_dedup_sha256
@@ -578,6 +647,8 @@ def _detect_document_changes(
         content=content_changed,
         metadata=metadata_changed,
         source=source_changed,
+        scope=scope_changed,
+        snapshot=snapshot_changed,
         dedup=dedup_changed,
     )
 

--- a/src/local_rag_backend/infrastructure/persistence/sql/document_storage.py
+++ b/src/local_rag_backend/infrastructure/persistence/sql/document_storage.py
@@ -41,7 +41,14 @@ class _DocumentChanges:
 
     @property
     def any_changed(self) -> bool:
-        return self.content or self.metadata or self.source or self.scope or self.snapshot or self.dedup
+        return (
+            self.content
+            or self.metadata
+            or self.source
+            or self.scope
+            or self.snapshot
+            or self.dedup
+        )
 
 
 def _to_domain_document(d: DbDocument) -> DomainDocument:

--- a/src/local_rag_backend/infrastructure/persistence/sql/models.py
+++ b/src/local_rag_backend/infrastructure/persistence/sql/models.py
@@ -19,6 +19,8 @@ class Document(Base):
     content: Mapped[str] = mapped_column(Text, nullable=False)
     external_id: Mapped[str | None] = mapped_column(Text, nullable=True, unique=True)
     source_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    scope: Mapped[str | None] = mapped_column(Text, nullable=True)
+    snapshot_id: Mapped[str | None] = mapped_column(Text, nullable=True)
     metadata_: Mapped[dict[str, Any] | None] = mapped_column("metadata", JSON, nullable=True)
     content_sha256: Mapped[str | None] = mapped_column(Text, nullable=True)
     chunk_dedup_sha256: Mapped[str | None] = mapped_column(Text, nullable=True, unique=True)

--- a/src/local_rag_backend/settings.py
+++ b/src/local_rag_backend/settings.py
@@ -339,9 +339,7 @@ class Settings(BaseSettings):
                     "PERSISTENCE_BACKEND=elasticsearch supports only retrieval_mode=dense|hybrid"
                 )
             if not self.es_base_url:
-                raise ValueError(
-                    "ES_BASE_URL is required when PERSISTENCE_BACKEND=elasticsearch"
-                )
+                raise ValueError("ES_BASE_URL is required when PERSISTENCE_BACKEND=elasticsearch")
         else:
             if not self.sqlite_url.startswith("sqlite:///"):
                 raise ValueError("SQLite URL must start with 'sqlite:///'")

--- a/src/local_rag_backend/settings.py
+++ b/src/local_rag_backend/settings.py
@@ -19,7 +19,7 @@ from contextlib import suppress
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import Field, field_validator, model_validator
+from pydantic import Field, ValidationInfo, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -33,6 +33,15 @@ class Settings(BaseSettings):
     if False:
 
         def __init__(self, **kwargs: Any) -> None: ...
+
+    persistence_backend: Literal["local_split", "elasticsearch"] = Field(
+        "local_split",
+        description=(
+            "Persistence backend topology. "
+            "'local_split' uses SQLite + local vector index; "
+            "'elasticsearch' uses Elasticsearch as unified storage."
+        ),
+    )
 
     # --- Core --- #
     app_host: str = Field("127.0.0.1", description="Server host IP.")
@@ -175,6 +184,30 @@ class Settings(BaseSettings):
         le=3600.0,
         description="Background interval (seconds) for retrying incomplete mutation recovery.",
     )
+    es_base_url: str | None = Field(None, description="Elasticsearch base URL.")
+    es_api_key: str | None = Field(None, description="Elasticsearch API key.")
+    es_username: str | None = Field(None, description="Elasticsearch username.")
+    es_password: str | None = Field(None, description="Elasticsearch password.")
+    es_verify_tls: bool = Field(True, description="Verify Elasticsearch TLS certificates.")
+    es_request_timeout_s: float = Field(
+        30.0, ge=0.5, le=600.0, description="Elasticsearch request timeout in seconds."
+    )
+    es_docs_index: str = Field("rag-docs", description="Elasticsearch index for documents.")
+    es_history_index: str = Field("rag-history", description="Elasticsearch index for history.")
+    es_system_index: str = Field("rag-system", description="Elasticsearch index for system state.")
+    es_tombstones_index: str = Field(
+        "rag-tombstones", description="Elasticsearch index for document tombstones."
+    )
+    es_content_field: str = Field("content", description="Elasticsearch content field name.")
+    es_embedding_field: str = Field(
+        "embedding", description="Elasticsearch dense vector field name."
+    )
+    es_hybrid_lexical_k: int = Field(
+        50, ge=1, le=1000, description="Lexical candidate count for Elasticsearch hybrid."
+    )
+    es_hybrid_vector_k: int = Field(
+        50, ge=1, le=1000, description="Vector candidate count for Elasticsearch hybrid."
+    )
 
     # --- Ingestion --- #
     ingest_chunk_strategy: Literal["chars_v1"] = Field(
@@ -271,7 +304,10 @@ class Settings(BaseSettings):
 
     @field_validator("sqlite_url")
     @classmethod
-    def _validate_sqlite_url(cls, v: str) -> str:
+    def _validate_sqlite_url(cls, v: str, info: ValidationInfo) -> str:
+        persistence_backend = str(info.data.get("persistence_backend") or "local_split")
+        if persistence_backend == "elasticsearch":
+            return v
         if not v.startswith("sqlite:///"):
             raise ValueError("SQLite URL must start with 'sqlite:///'")
         return v
@@ -283,11 +319,32 @@ class Settings(BaseSettings):
             raise ValueError("Ollama URL must start with http:// or https://")
         return v.rstrip("/")
 
+    @field_validator("es_base_url")
+    @classmethod
+    def _validate_es_url(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        if not v.startswith(("http://", "https://")):
+            raise ValueError("Elasticsearch URL must start with http:// or https://")
+        return v.rstrip("/")
+
     @model_validator(mode="after")
     def _validate_chunking(self) -> Settings:
         """Ensure chunk overlap is strictly less than chunk size."""
         if self.ingest_chunk_overlap >= self.ingest_chunk_chars:
             raise ValueError("ingest_chunk_overlap must be strictly less than ingest_chunk_chars")
+        if self.persistence_backend == "elasticsearch":
+            if self.retrieval_mode == "sparse":
+                raise ValueError(
+                    "PERSISTENCE_BACKEND=elasticsearch supports only retrieval_mode=dense|hybrid"
+                )
+            if not self.es_base_url:
+                raise ValueError(
+                    "ES_BASE_URL is required when PERSISTENCE_BACKEND=elasticsearch"
+                )
+        else:
+            if not self.sqlite_url.startswith("sqlite:///"):
+                raise ValueError("SQLite URL must start with 'sqlite:///'")
         return self
 
     def get_database_path(self) -> Path:

--- a/tests/unit/http/services/test_mutation_ports.py
+++ b/tests/unit/http/services/test_mutation_ports.py
@@ -124,3 +124,34 @@ def test_from_settings_preserves_injectable_overrides() -> None:
 
     assert isinstance(ports.doc_repo_factory(), _Repo)
     assert ports.build_upsert_doc is _CustomUpsert
+
+
+def test_elasticsearch_defaults_bind_elastic_runtime() -> None:
+    es_settings = settings.model_copy(
+        update={
+            "persistence_backend": "elasticsearch",
+            "retrieval_mode": "dense",
+            "es_base_url": "http://localhost:9200",
+        }
+    )
+
+    class _DummySystemState:
+        def get_version(self, key: str) -> int:
+            _ = key
+            return 0
+
+        def bump_version(self, key: str) -> int:
+            _ = key
+            return 1
+
+    container = AppContainer(
+        settings_obj=es_settings,
+        system_state_factory=_DummySystemState,
+    )
+    ports = container.docs_mutation_ports(build_embedder=lambda: DummyEmbedder())
+
+    assert ports.build_upsert_doc.__qualname__.endswith("ElasticDocsRepository.UpsertDoc")
+    assert ports.mutation_uow_factory is None
+    assert container.doc_repo_factory.__name__ == "<lambda>"
+    assert container.history_repo_factory.__name__ == "<lambda>"
+    assert container.vector_repo_factory.__name__ == "<lambda>"

--- a/tests/unit/http/test_composition.py
+++ b/tests/unit/http/test_composition.py
@@ -129,6 +129,84 @@ def test_build_retriever_passes_vector_backend_to_repo_factory():
     }
 
 
+def test_build_retriever_rejects_sparse_for_elasticsearch_backend():
+    cfg = SimpleNamespace(
+        persistence_backend="elasticsearch",
+        retrieval_mode="sparse",
+        es_base_url="http://localhost:9200",
+        openai_api_key="k",
+        st_embedding_model="all-MiniLM-L6-v2",
+        hybrid_retrieval_alpha=0.5,
+        enable_reranker=False,
+        reranker_candidate_k=20,
+        reranker_strategy="overlap_v1",
+        index_path="index.faiss",
+        id_map_path="id_map.json",
+        vector_backend="auto",
+    )
+
+    with pytest.raises(ValueError, match="supports only retrieval_mode=dense\\|hybrid"):
+        build_retriever_with_default_embedder_from_settings(
+            settings_obj=cfg,
+            retrieval_mode="sparse",
+            doc_repo=SimpleNamespace(get_all_documents=lambda: []),
+            openai_embedder_factory=lambda: object(),
+            st_embedder_factory=lambda _model_name: object(),
+        )
+
+
+def test_build_retriever_hybrid_uses_elasticsearch_lexical_path():
+    cfg = SimpleNamespace(
+        persistence_backend="elasticsearch",
+        openai_api_key="k",
+        st_embedding_model="all-MiniLM-L6-v2",
+        hybrid_retrieval_alpha=0.25,
+        enable_reranker=False,
+        reranker_candidate_k=20,
+        reranker_strategy="overlap_v1",
+        index_path="index.faiss",
+        id_map_path="id_map.json",
+        vector_backend="auto",
+    )
+    seen: dict[str, object] = {}
+
+    class DummyEmbedder:
+        dim = 4
+
+    class DummyVectorRepo:
+        def similar(self, _vector, _k):
+            return []
+
+        def lexical_search(self, _query, *, k):
+            seen["lexical_k"] = k
+            return []
+
+    def _dense_retriever_factory(**kwargs):
+        seen["dense_kwargs"] = kwargs
+        return SimpleNamespace(retrieve=lambda _query, _k=5: ([], []))
+
+    def _hybrid_retriever_factory(**kwargs):
+        seen["hybrid_kwargs"] = kwargs
+        kwargs["sparse"].retrieve("hello", 3)
+        return "hybrid-retriever"
+
+    out = build_retriever_with_default_embedder_from_settings(
+        settings_obj=cfg,
+        retrieval_mode="hybrid",
+        doc_repo=SimpleNamespace(get=lambda _ids: []),
+        openai_embedder_factory=lambda: DummyEmbedder(),
+        st_embedder_factory=lambda _model_name: DummyEmbedder(),
+        vector_repo_factory=lambda **kwargs: DummyVectorRepo(),
+        dense_retriever_factory=_dense_retriever_factory,
+        hybrid_retriever_factory=_hybrid_retriever_factory,
+    )
+
+    assert out == "hybrid-retriever"
+    assert seen["lexical_k"] == 3
+    assert seen["dense_kwargs"]["doc_repo"] is not None
+    assert seen["hybrid_kwargs"]["alpha"] == 0.25
+
+
 @pytest.mark.parametrize(
     ("openai_api_key", "ollama_enabled", "expected"),
     [

--- a/tests/unit/http/test_docs_import_canonical_endpoint.py
+++ b/tests/unit/http/test_docs_import_canonical_endpoint.py
@@ -115,7 +115,10 @@ async def test_import_canonical_replace_scope_hard_deletes_stale_docs(
     r3 = await asgi_client.post("/api/docs/import-canonical", json=third)
     assert r3.status_code == 200
     assert r3.json()["inserted"] == 1
-    assert {doc.external_id for doc in SqlDocumentStorage().get_all_documents()} == {"doc-1", "doc-2"}
+    assert {doc.external_id for doc in SqlDocumentStorage().get_all_documents()} == {
+        "doc-1",
+        "doc-2",
+    }
 
 
 async def test_import_canonical_rejects_duplicate_external_ids(

--- a/tests/unit/http/test_docs_import_canonical_endpoint.py
+++ b/tests/unit/http/test_docs_import_canonical_endpoint.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from local_rag_backend.infrastructure.persistence.sql import SqlDocumentStorage
+from local_rag_backend.settings import settings
+
+
+async def test_import_canonical_upsert_only_and_reimport_is_unchanged(
+    asgi_client, in_memory_sqlite, monkeypatch
+):
+    monkeypatch.setattr(settings, "retrieval_mode", "sparse", raising=False)
+
+    payload = {
+        "scope": "repogpt:demo",
+        "snapshot_id": "snap-1",
+        "documents": [
+            {
+                "external_id": "doc-1",
+                "source_id": "file:a.py",
+                "content": "def alpha():\n    return 1\n",
+                "metadata": {"path": "a.py", "unit_type": "function"},
+            }
+        ],
+    }
+
+    r1 = await asgi_client.post("/api/docs/import-canonical", json=payload)
+    assert r1.status_code == 200
+    body1 = r1.json()
+    assert body1["inserted"] == 1
+    assert body1["updated"] == 0
+    assert body1["unchanged"] == 0
+    assert body1["deleted_sql"] == 0
+
+    r2 = await asgi_client.post("/api/docs/import-canonical", json=payload)
+    assert r2.status_code == 200
+    body2 = r2.json()
+    assert body2["inserted"] == 0
+    assert body2["updated"] == 0
+    assert body2["unchanged"] == 1
+
+    docs = SqlDocumentStorage().get_all_documents()
+    assert len(docs) == 1
+    assert docs[0].external_id == "doc-1"
+    assert docs[0].metadata == {
+        "path": "a.py",
+        "unit_type": "function",
+        "scope": "repogpt:demo",
+        "snapshot_id": "snap-1",
+    }
+
+
+async def test_import_canonical_replace_scope_hard_deletes_stale_docs(
+    asgi_client, in_memory_sqlite, monkeypatch
+):
+    monkeypatch.setattr(settings, "retrieval_mode", "sparse", raising=False)
+
+    first = {
+        "scope": "repogpt:demo",
+        "snapshot_id": "snap-1",
+        "replace_scope": True,
+        "documents": [
+            {
+                "external_id": "doc-1",
+                "source_id": "file:a.py",
+                "content": "def alpha():\n    return 1\n",
+                "metadata": {"path": "a.py", "unit_type": "function"},
+            },
+            {
+                "external_id": "doc-2",
+                "source_id": "file:b.py",
+                "content": "def beta():\n    return 2\n",
+                "metadata": {"path": "b.py", "unit_type": "function"},
+            },
+        ],
+    }
+    second = {
+        "scope": "repogpt:demo",
+        "snapshot_id": "snap-2",
+        "replace_scope": True,
+        "documents": [
+            {
+                "external_id": "doc-2",
+                "source_id": "file:b.py",
+                "content": "def beta():\n    return 20\n",
+                "metadata": {"path": "b.py", "unit_type": "function"},
+            }
+        ],
+    }
+
+    r1 = await asgi_client.post("/api/docs/import-canonical", json=first)
+    assert r1.status_code == 200
+    r2 = await asgi_client.post("/api/docs/import-canonical", json=second)
+    assert r2.status_code == 200
+    body2 = r2.json()
+    assert body2["inserted"] == 0
+    assert body2["updated"] == 1
+    assert body2["deleted_sql"] == 1
+    assert body2["deleted_external_ids"] == ["doc-1"]
+
+    docs = SqlDocumentStorage().get_all_documents()
+    assert {doc.external_id for doc in docs} == {"doc-2"}
+
+    third = {
+        "scope": "repogpt:demo",
+        "snapshot_id": "snap-3",
+        "replace_scope": False,
+        "documents": [
+            {
+                "external_id": "doc-1",
+                "source_id": "file:a.py",
+                "content": "def alpha():\n    return 10\n",
+                "metadata": {"path": "a.py", "unit_type": "function"},
+            }
+        ],
+    }
+    r3 = await asgi_client.post("/api/docs/import-canonical", json=third)
+    assert r3.status_code == 200
+    assert r3.json()["inserted"] == 1
+    assert {doc.external_id for doc in SqlDocumentStorage().get_all_documents()} == {"doc-1", "doc-2"}
+
+
+async def test_import_canonical_rejects_duplicate_external_ids(
+    asgi_client, in_memory_sqlite, monkeypatch
+):
+    monkeypatch.setattr(settings, "retrieval_mode", "sparse", raising=False)
+
+    payload = {
+        "scope": "repogpt:demo",
+        "snapshot_id": "snap-1",
+        "documents": [
+            {"external_id": "doc-1", "content": "alpha"},
+            {"external_id": "doc-1", "content": "beta"},
+        ],
+    }
+
+    response = await asgi_client.post("/api/docs/import-canonical", json=payload)
+    assert response.status_code == 422

--- a/tests/unit/http/test_multistore_write_lock.py
+++ b/tests/unit/http/test_multistore_write_lock.py
@@ -22,6 +22,8 @@ async def test_concurrent_mutations_are_serialized_and_keep_sql_vector_consisten
         external_id: str
         content: str
         source_id: str | None = None
+        scope: str | None = None
+        snapshot_id: str | None = None
         metadata: dict[str, object] | None = None
         chunk_dedup_sha256: str | None = None
 

--- a/tests/unit/infrastructure/persistence/elasticsearch/test_backend_runtime.py
+++ b/tests/unit/infrastructure/persistence/elasticsearch/test_backend_runtime.py
@@ -147,7 +147,9 @@ class _ElasticTestState:
                         hits = [
                             hit
                             for hit in hits
-                            if str((hit.get("_source") or {}).get(str(field)) or hit.get("_id") or "")
+                            if str(
+                                (hit.get("_source") or {}).get(str(field)) or hit.get("_id") or ""
+                            )
                             > cursor
                         ]
                 elif hits and any(float(hit.get("_score") or 0.0) != 1.0 for hit in hits):
@@ -342,10 +344,15 @@ def test_elastic_client_index_management_and_errors() -> None:
         error_client.request_json("GET", "/")
 
     api_key_settings = backend.settings.model_copy(update={"es_api_key": "secret"})
-    assert ElasticClient(
-        settings_obj=api_key_settings,
-        client=httpx.Client(base_url="http://example.test", transport=backend.state.transport()),
-    )._resolve_headers()["Authorization"] == "ApiKey secret"
+    assert (
+        ElasticClient(
+            settings_obj=api_key_settings,
+            client=httpx.Client(
+                base_url="http://example.test", transport=backend.state.transport()
+            ),
+        )._resolve_headers()["Authorization"]
+        == "ApiKey secret"
+    )
 
 
 def test_document_repository_crud_snapshot_restore_and_scan() -> None:
@@ -410,7 +417,9 @@ def test_document_repository_crud_snapshot_restore_and_scan() -> None:
     assert len(snapshots_by_id) == 2
     assert len(snapshots_by_external_id) == 2
 
-    deleted_count, deleted_ids, missing, tombstoned = repo.delete_by_external_ids(["doc-2", "missing"])
+    deleted_count, deleted_ids, missing, tombstoned = repo.delete_by_external_ids(
+        ["doc-2", "missing"]
+    )
     assert deleted_count == 1
     assert deleted_ids == [DocId("doc-2")]
     assert missing == ["missing"]
@@ -524,9 +533,12 @@ def test_vector_history_system_and_diagnostics_roundtrip() -> None:
         "documents": 3,
     }
     with TemporaryDirectory() as tmp_dir:
-        assert backend.diagnostics.get_incomplete_mutation_records_count(
-            coordination_dir=Path(tmp_dir)
-        ) == 0
+        assert (
+            backend.diagnostics.get_incomplete_mutation_records_count(
+                coordination_dir=Path(tmp_dir)
+            )
+            == 0
+        )
     assert purge_index_artifacts_noop(index_path="x", id_map_path="y") is None
 
 

--- a/tests/unit/infrastructure/persistence/elasticsearch/test_backend_runtime.py
+++ b/tests/unit/infrastructure/persistence/elasticsearch/test_backend_runtime.py
@@ -1,0 +1,598 @@
+from __future__ import annotations
+
+import json
+import math
+import re
+from contextlib import nullcontext
+from dataclasses import dataclass
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+
+import httpx
+import pytest
+
+from local_rag_backend.core.domain.profiles import StorageProfileRegistry
+from local_rag_backend.core.domain.types import DocId
+from local_rag_backend.core.ports.contracts import DocsMutationPorts
+from local_rag_backend.core.use_cases._atomic_mutation_executor import AtomicMutationExecutor
+from local_rag_backend.core.use_cases._mutation_saga_executor import PreparedMutation
+from local_rag_backend.core.use_cases.docs_mutation_contracts import (
+    MutationIntent,
+    MutationUpsertInput,
+)
+from local_rag_backend.infrastructure.persistence.elasticsearch.client import (
+    ElasticBackendError,
+    ElasticClient,
+)
+from local_rag_backend.infrastructure.persistence.elasticsearch.diagnostics import (
+    ElasticHealthDiagnostics,
+    purge_index_artifacts_noop,
+)
+from local_rag_backend.infrastructure.persistence.elasticsearch.document_storage import (
+    ElasticDocsRepository,
+    ElasticVectorRepo,
+)
+from local_rag_backend.infrastructure.persistence.elasticsearch.history_storage import (
+    ElasticHistoryStorage,
+)
+from local_rag_backend.infrastructure.persistence.elasticsearch.system_state import (
+    ElasticSystemStateStorage,
+)
+from local_rag_backend.settings import Settings
+
+
+def _score_text(query: str, text: str) -> float:
+    tokens = [token for token in query.lower().split() if token]
+    haystack = text.lower()
+    return float(sum(1 for token in tokens if token in haystack))
+
+
+@dataclass
+class _ElasticTestState:
+    indices: dict[str, dict[str, Any]]
+
+    def __init__(self) -> None:
+        self.indices = {}
+
+    def docs_for(self, index: str) -> dict[str, dict[str, Any]]:
+        bucket = self.indices.setdefault(index, {"docs": {}, "mapping": {}})
+        return bucket["docs"]  # type: ignore[return-value]
+
+    def mapping_for(self, index: str) -> dict[str, Any]:
+        bucket = self.indices.setdefault(index, {"docs": {}, "mapping": {}})
+        return bucket["mapping"]  # type: ignore[return-value]
+
+    def transport(self) -> httpx.MockTransport:
+        def _json(request: httpx.Request) -> dict[str, Any]:
+            content = request.content.decode("utf-8")
+            return dict(json.loads(content)) if content else {}
+
+        def _bulk_ops(request: httpx.Request) -> list[dict[str, Any]]:
+            lines = [line for line in request.content.decode("utf-8").splitlines() if line.strip()]
+            return [dict(json.loads(line)) for line in lines]
+
+        def _cosine(query_vector: list[float], vector: list[float]) -> float:
+            dot = sum(a * b for a, b in zip(query_vector, vector, strict=False))
+            lhs = math.sqrt(sum(a * a for a in query_vector))
+            rhs = math.sqrt(sum(b * b for b in vector))
+            if lhs == 0.0 or rhs == 0.0:
+                return 0.0
+            return dot / (lhs * rhs)
+
+        def _search_hits(index: str, body: dict[str, Any]) -> list[dict[str, Any]]:
+            docs = self.docs_for(index)
+            sort_spec = list(body.get("sort") or [])
+            include_source = body.get("_source", True) is not False
+            hits: list[dict[str, Any]] = []
+
+            knn = body.get("knn")
+            if isinstance(knn, dict):
+                field = str(knn.get("field") or "")
+                query_vector = [float(x) for x in list(knn.get("query_vector") or [])]
+                size = int(body.get("size") or knn.get("k") or 10)
+                for doc_id, source in docs.items():
+                    vector = source.get(field)
+                    if not isinstance(vector, list):
+                        continue
+                    score = _cosine(query_vector, [float(x) for x in vector])
+                    hits.append({"_id": doc_id, "_source": dict(source), "_score": score})
+                hits.sort(key=lambda hit: float(hit.get("_score") or 0.0), reverse=True)
+                hits = hits[:size]
+            else:
+                query = dict(body.get("query") or {"match_all": {}})
+                for doc_id, source in docs.items():
+                    score = 1.0
+                    if "match_all" in query:
+                        pass
+                    elif "prefix" in query:
+                        field, prefix = next(iter(dict(query["prefix"]).items()))
+                        if not str(source.get(str(field)) or doc_id).startswith(str(prefix)):
+                            continue
+                    elif "exists" in query:
+                        field = str((query["exists"] or {}).get("field") or "")
+                        if field not in source or source.get(field) is None:
+                            continue
+                    elif "match" in query:
+                        field, raw_value = next(iter(dict(query["match"]).items()))
+                        search_query = (
+                            str((raw_value or {}).get("query") or "")
+                            if isinstance(raw_value, dict)
+                            else str(raw_value)
+                        )
+                        score = _score_text(search_query, str(source.get(str(field)) or ""))
+                        if score <= 0.0:
+                            continue
+                    else:
+                        raise AssertionError(f"Unsupported query: {query}")
+                    hits.append({"_id": doc_id, "_source": dict(source), "_score": score})
+
+                if sort_spec:
+                    sort_entry = dict(sort_spec[0])
+                    field, order = next(iter(sort_entry.items()))
+                    reverse = False
+                    if isinstance(order, dict):
+                        reverse = str(order.get("order") or "asc").lower() == "desc"
+                    else:
+                        reverse = str(order).lower() == "desc"
+                    hits.sort(
+                        key=lambda hit: str(
+                            (hit.get("_source") or {}).get(str(field)) or hit.get("_id") or ""
+                        ),
+                        reverse=reverse,
+                    )
+                    search_after = list(body.get("search_after") or [])
+                    if search_after:
+                        cursor = str(search_after[0])
+                        hits = [
+                            hit
+                            for hit in hits
+                            if str((hit.get("_source") or {}).get(str(field)) or hit.get("_id") or "")
+                            > cursor
+                        ]
+                elif hits and any(float(hit.get("_score") or 0.0) != 1.0 for hit in hits):
+                    hits.sort(key=lambda hit: float(hit.get("_score") or 0.0), reverse=True)
+
+                if "from" in body:
+                    hits = hits[int(body.get("from") or 0) :]
+                if "size" in body:
+                    hits = hits[: int(body.get("size") or 10)]
+
+            out: list[dict[str, Any]] = []
+            for hit in hits:
+                entry: dict[str, Any] = {"_id": str(hit["_id"]), "_score": float(hit["_score"])}
+                if include_source:
+                    entry["_source"] = dict(hit["_source"])
+                if sort_spec:
+                    field = next(iter(dict(sort_spec[0]).keys()))
+                    entry["sort"] = [
+                        str((hit.get("_source") or {}).get(str(field)) or hit.get("_id") or "")
+                    ]
+                out.append(entry)
+            return out
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            method = request.method
+
+            if method == "HEAD":
+                index = path.strip("/")
+                return httpx.Response(200 if index in self.indices else 404)
+
+            if method == "GET" and path == "/":
+                return httpx.Response(200, json={"status": "ok"})
+
+            if method == "PUT" and path.count("/") == 1:
+                index = path.strip("/")
+                body = _json(request)
+                mapping = dict(((body.get("mappings") or {}).get("properties")) or {})
+                self.indices[index] = {"docs": {}, "mapping": mapping}
+                return httpx.Response(200, json={"acknowledged": True})
+
+            if method == "PUT" and path.endswith("/_mapping"):
+                index = path.strip("/").split("/")[0]
+                body = _json(request)
+                self.mapping_for(index).update(dict(body.get("properties") or {}))
+                return httpx.Response(200, json={"acknowledged": True})
+
+            if method == "GET" and path.endswith("/_mapping"):
+                index = path.strip("/").split("/")[0]
+                return httpx.Response(
+                    200,
+                    json={index: {"mappings": {"properties": dict(self.mapping_for(index))}}},
+                )
+
+            if method == "POST" and path.endswith("/_mget"):
+                index = path.strip("/").split("/")[0]
+                docs = self.docs_for(index)
+                body = _json(request)
+                found = []
+                for doc_id in list(body.get("ids") or []):
+                    source = docs.get(str(doc_id))
+                    if source is None:
+                        found.append({"_id": str(doc_id), "found": False})
+                    else:
+                        found.append({"_id": str(doc_id), "found": True, "_source": dict(source)})
+                return httpx.Response(200, json={"docs": found})
+
+            if method == "POST" and path == "/_bulk":
+                ops = _bulk_ops(request)
+                items: list[dict[str, Any]] = []
+                i = 0
+                while i < len(ops):
+                    op = ops[i]
+                    if "index" in op:
+                        meta = dict(op["index"])
+                        body = dict(ops[i + 1])
+                        self.docs_for(str(meta["_index"]))[str(meta["_id"])] = body
+                        items.append({"index": {"_id": str(meta["_id"]), "status": 201}})
+                        i += 2
+                        continue
+                    if "delete" in op:
+                        meta = dict(op["delete"])
+                        self.docs_for(str(meta["_index"])).pop(str(meta["_id"]), None)
+                        items.append({"delete": {"_id": str(meta["_id"]), "status": 200}})
+                        i += 1
+                        continue
+                    if "update" in op:
+                        meta = dict(op["update"])
+                        body = dict(ops[i + 1])
+                        doc = self.docs_for(str(meta["_index"])).setdefault(str(meta["_id"]), {})
+                        if "script" in body:
+                            source = str((body["script"] or {}).get("source") or "")
+                            match = re.search(r"remove\('([^']+)'\)", source)
+                            if match:
+                                doc.pop(match.group(1), None)
+                        elif "doc" in body:
+                            doc.update(dict(body.get("doc") or {}))
+                        else:
+                            raise AssertionError(f"Unsupported update body: {body}")
+                        items.append({"update": {"_id": str(meta["_id"]), "status": 200}})
+                        i += 2
+                        continue
+                    raise AssertionError(f"Unexpected bulk op: {op}")
+                return httpx.Response(200, json={"errors": False, "items": items})
+
+            if method == "POST" and path.endswith("/_search"):
+                index = path.strip("/").split("/")[0]
+                body = _json(request)
+                hits = _search_hits(index, body)
+                return httpx.Response(200, json={"hits": {"hits": hits}})
+
+            if method == "POST" and path.endswith("/_count"):
+                index = path.strip("/").split("/")[0]
+                body = _json(request)
+                hits = _search_hits(index, {"query": body.get("query") or {"match_all": {}}})
+                return httpx.Response(200, json={"count": len(hits)})
+
+            if method == "DELETE" and "/_doc/" in path:
+                index, doc_id = path.strip("/").split("/_doc/")
+                self.docs_for(index).pop(doc_id, None)
+                return httpx.Response(200, json={"result": "deleted"})
+
+            if method == "PUT" and "/_doc/" in path:
+                index, doc_id = path.strip("/").split("/_doc/")
+                self.docs_for(index)[doc_id] = _json(request)
+                return httpx.Response(201, json={"result": "created"})
+
+            raise AssertionError(f"Unhandled {method} {path}")
+
+        return httpx.MockTransport(handler)
+
+
+@dataclass(frozen=True)
+class _BackendFixture:
+    settings: Settings
+    client: ElasticClient
+    docs: ElasticDocsRepository
+    vector: ElasticVectorRepo
+    history: ElasticHistoryStorage
+    system: ElasticSystemStateStorage
+    diagnostics: ElasticHealthDiagnostics
+    state: _ElasticTestState
+
+
+def _build_backend(*, dim: int = 3) -> _BackendFixture:
+    settings_obj = Settings(
+        persistence_backend="elasticsearch",
+        retrieval_mode="dense",
+        es_base_url="http://example.test",
+    )
+    state = _ElasticTestState()
+    client = ElasticClient(
+        settings_obj=settings_obj,
+        client=httpx.Client(base_url="http://example.test", transport=state.transport()),
+    )
+    docs = ElasticDocsRepository(settings_obj=settings_obj, client=client)
+    vector = ElasticVectorRepo(settings_obj=settings_obj, client=client, dim=dim)
+    history = ElasticHistoryStorage(settings_obj=settings_obj, client=client)
+    system = ElasticSystemStateStorage(settings_obj=settings_obj, client=client)
+    diagnostics = ElasticHealthDiagnostics(settings_obj=settings_obj, client=client)
+    return _BackendFixture(settings_obj, client, docs, vector, history, system, diagnostics, state)
+
+
+def test_elastic_client_index_management_and_errors() -> None:
+    backend = _build_backend()
+
+    assert backend.client.head_ok(f"/{backend.settings.es_docs_index}") is True
+    assert backend.client.head_ok("/missing-index") is False
+    assert (
+        backend.state.mapping_for(str(backend.settings.es_docs_index))[
+            str(backend.settings.es_embedding_field)
+        ]["dims"]
+        == 3
+    )
+
+    backend.state.mapping_for(str(backend.settings.es_docs_index))[
+        str(backend.settings.es_embedding_field)
+    ] = {"type": "dense_vector", "dims": 9}
+    with pytest.raises(ElasticBackendError):
+        backend.client.ensure_indices(embed_dim=3)
+
+    error_client = ElasticClient(
+        settings_obj=backend.settings,
+        client=httpx.Client(
+            base_url="http://example.test",
+            transport=httpx.MockTransport(lambda request: httpx.Response(500, text="boom")),
+        ),
+    )
+    with pytest.raises(ElasticBackendError):
+        error_client.head_ok("/broken")
+    with pytest.raises(ElasticBackendError):
+        error_client.request_json("GET", "/")
+
+    api_key_settings = backend.settings.model_copy(update={"es_api_key": "secret"})
+    assert ElasticClient(
+        settings_obj=api_key_settings,
+        client=httpx.Client(base_url="http://example.test", transport=backend.state.transport()),
+    )._resolve_headers()["Authorization"] == "ApiKey secret"
+
+
+def test_document_repository_crud_snapshot_restore_and_scan() -> None:
+    backend = _build_backend()
+    repo = backend.docs
+
+    stored_ids = repo.store_documents(["alpha", " ", "beta"])
+    assert len(stored_ids) == 2
+
+    results, changed, updated_ids = repo.upsert_documents_by_external_id(
+        [
+            ElasticDocsRepository.UpsertDoc(
+                external_id="doc-1",
+                content="alpha bravo",
+                source_id="src-1",
+                metadata={"kind": "faq"},
+                chunk_dedup_sha256="dedup-1",
+                embedding=[0.1, 0.2, 0.3],
+            ),
+            ElasticDocsRepository.UpsertDoc(
+                external_id="doc-2",
+                content="charlie delta",
+                source_id="src-2",
+                metadata={"kind": "kb"},
+            ),
+        ]
+    )
+    assert [row.action for row in results] == ["inserted", "inserted"]
+    assert len(changed) == 2
+    assert updated_ids == []
+
+    results, changed, updated_ids = repo.upsert_documents_by_external_id(
+        [
+            ElasticDocsRepository.UpsertDoc(
+                external_id="doc-1",
+                content="alpha bravo",
+                source_id="src-1",
+                metadata={"kind": "faq"},
+                chunk_dedup_sha256="dedup-1",
+            ),
+            ElasticDocsRepository.UpsertDoc(
+                external_id="doc-2",
+                content="charlie delta echo",
+                source_id="src-2b",
+                metadata={"kind": "kb", "priority": 1},
+                chunk_dedup_sha256="dedup-2",
+            ),
+        ]
+    )
+    assert [row.action for row in results] == ["unchanged", "updated"]
+    assert changed == [(DocId("doc-2"), "charlie delta echo")]
+    assert updated_ids == [DocId("doc-2")]
+
+    assert repo.list_ids_by_external_id_prefix("doc-") == [
+        (DocId("doc-1"), "doc-1"),
+        (DocId("doc-2"), "doc-2"),
+    ]
+    assert repo.list_ids_by_external_id_prefix(" ") == []
+
+    snapshots_by_id = repo.snapshot_by_ids([DocId("doc-1"), DocId("doc-2")])
+    snapshots_by_external_id = repo.snapshot_by_external_ids(["doc-1", "doc-2", "missing"])
+    assert len(snapshots_by_id) == 2
+    assert len(snapshots_by_external_id) == 2
+
+    deleted_count, deleted_ids, missing, tombstoned = repo.delete_by_external_ids(["doc-2", "missing"])
+    assert deleted_count == 1
+    assert deleted_ids == [DocId("doc-2")]
+    assert missing == ["missing"]
+    assert tombstoned == 2
+    assert repo.get_tombstoned_external_ids(["doc-2", "missing"]) == {"doc-2", "missing"}
+    assert repo.delete_tombstones(["doc-2", "missing"]) == 2
+    assert repo.get_tombstoned_external_ids(["doc-2", "missing"]) == set()
+
+    repo.restore_from_snapshots(snapshots_by_external_id)
+    restored = repo.get([DocId("doc-1"), DocId("doc-2")])
+    assert [doc.external_id for doc in restored] == ["doc-1", "doc-2"]
+
+    repo.delete_documents([DocId("doc-1")])
+    assert [doc.external_id for doc in repo.get([DocId("doc-1"), DocId("doc-2")])] == ["doc-2"]
+
+    repo.delete_by_external_ids(["doc-2"])
+    repo.hard_delete_by_external_ids(["doc-2"])
+    assert repo.get([DocId("doc-2")]) == []
+    assert repo.get_tombstoned_external_ids(["doc-2"]) == set()
+
+    with pytest.raises(ValueError):
+        repo.upsert_documents_by_external_id(
+            [
+                ElasticDocsRepository.UpsertDoc(external_id="dup", content="a"),
+                ElasticDocsRepository.UpsertDoc(external_id="dup", content="b"),
+            ]
+        )
+
+    bulk_items = [
+        ElasticDocsRepository.UpsertDoc(external_id=f"scan-{idx:03d}", content=f"text {idx}")
+        for idx in range(505)
+    ]
+    repo.upsert_documents_by_external_id(bulk_items)
+    all_docs = repo.get_all_documents()
+    assert len([doc for doc in all_docs if doc.external_id.startswith("scan-")]) == 505
+
+
+def test_vector_history_system_and_diagnostics_roundtrip() -> None:
+    backend = _build_backend()
+    backend.docs.upsert_documents_by_external_id(
+        [
+            ElasticDocsRepository.UpsertDoc(external_id="vec-1", content="alpha bravo"),
+            ElasticDocsRepository.UpsertDoc(external_id="vec-2", content="alpha charlie"),
+            ElasticDocsRepository.UpsertDoc(external_id="vec-3", content="zulu"),
+        ]
+    )
+
+    backend.vector.upsert(
+        [DocId("vec-1"), DocId("vec-2"), DocId("vec-3")],
+        [
+            [1.0, 0.0, 0.0],
+            [0.9, 0.1, 0.0],
+            [0.0, 1.0, 0.0],
+        ],
+    )
+    assert backend.vector.ntotal == 3
+    assert backend.vector.count_indexed_docs() == 3
+    assert backend.vector.get_mapping_dimension() == 3
+    assert [doc_id for doc_id, _score in backend.vector.similar([1.0, 0.0, 0.0], 2)] == [
+        DocId("vec-1"),
+        DocId("vec-2"),
+    ]
+    assert [doc_id for doc_id, _score in backend.vector.lexical_search("alpha", k=2)] == [
+        DocId("vec-1"),
+        DocId("vec-2"),
+    ]
+    assert backend.vector.lexical_search(" ", k=2) == []
+    assert backend.vector.similar([1.0, 0.0, 0.0], 0) == []
+
+    assert backend.vector.delete([DocId("vec-3")]) == 1
+    assert backend.vector.ntotal == 2
+    backend.vector.rebuild([DocId("vec-3")], [[0.0, 1.0, 0.0]])
+    assert backend.vector.ntotal == 3
+
+    backend.history.save("q1", "a1", [DocId("vec-1"), DocId("vec-2")])
+    backend.history.save("q2", "a2", [DocId("vec-3")])
+    entries = backend.history.list_entries(limit=1, offset=0)
+    assert len(entries) == 1
+    assert entries[0].question == "q2"
+    assert entries[0].source_ids == ("vec-3",)
+
+    assert backend.system.get_version("rag-service") == 0
+    assert backend.system.bump_version("rag-service") == 1
+    assert backend.system.bump_version("rag-service") == 2
+    assert backend.system.get_version("rag-service") == 2
+    with pytest.raises(ValueError):
+        backend.system.get_version(" ")
+    with pytest.raises(ValueError):
+        backend.system.bump_version("")
+
+    backend.diagnostics.ping_database()
+    assert backend.diagnostics.get_documents_count() == 3
+    assert backend.diagnostics.get_history_count() == 2
+    assert backend.diagnostics.get_document_ids() == ("vec-1", "vec-2", "vec-3")
+    assert backend.diagnostics.get_index_ids(id_map_path="ignored") == ("vec-1", "vec-2", "vec-3")
+    assert backend.diagnostics.get_retrieval_index_stats(
+        index_path="ignored",
+        id_map_path="ignored",
+        vector_backend="ignored",
+    ) == {
+        "status": "ok",
+        "backend": "elasticsearch",
+        "index_path": "rag-docs",
+        "id_map_path": "rag-docs",
+        "manifest_path": None,
+        "dim": 3,
+        "vectors": 3,
+        "id_map_len": 3,
+        "unique_ids": 3,
+        "duplicates": 0,
+        "documents": 3,
+    }
+    with TemporaryDirectory() as tmp_dir:
+        assert backend.diagnostics.get_incomplete_mutation_records_count(
+            coordination_dir=Path(tmp_dir)
+        ) == 0
+    assert purge_index_artifacts_noop(index_path="x", id_map_path="y") is None
+
+
+def test_atomic_mutation_executor_handles_unified_elastic_mutation_flow() -> None:
+    backend = _build_backend()
+    repo = backend.docs
+    repo.upsert_documents_by_external_id(
+        [
+            ElasticDocsRepository.UpsertDoc(external_id="doc-delete", content="delete me"),
+            ElasticDocsRepository.UpsertDoc(external_id="doc-tombstone", content="old"),
+        ]
+    )
+    repo.delete_by_external_ids(["doc-tombstone"])
+
+    ports = DocsMutationPorts(
+        build_embedder=lambda: None,  # type: ignore[arg-type]
+        doc_repo_factory=lambda: repo,
+        build_upsert_doc=ElasticDocsRepository.UpsertDoc,
+        vector_repo_factory=lambda **kwargs: backend.vector,
+        rebuild_fn=lambda **kwargs: 0,
+        write_lock=lambda **kwargs: nullcontext(),
+        mutation_journal_factory=lambda: None,  # type: ignore[arg-type]
+        storage_profile_registry=StorageProfileRegistry(),
+        mutation_uow_factory=None,
+    )
+    executor = AtomicMutationExecutor(settings_obj=backend.settings, ports=ports)
+    prepared = PreparedMutation(
+        intent=MutationIntent(
+            op_id="op-1",
+            upserts=(
+                MutationUpsertInput(
+                    external_id="doc-new",
+                    content="brand new",
+                    source_id="src-new",
+                    metadata={"tier": "gold"},
+                ),
+                MutationUpsertInput(
+                    external_id="doc-tombstone",
+                    content="restored",
+                    source_id="src-restore",
+                ),
+            ),
+            delete_ids=("doc-delete",),
+            delete_external_ids=("missing-doc",),
+            source="test",
+        ),
+        vector_mode_enabled=True,
+        precomputed_vectors_by_external_id={
+            "doc-new": [1.0, 0.0, 0.0],
+            "doc-tombstone": [0.5, 0.5, 0.0],
+        },
+    )
+
+    summary = executor.execute_locked(prepared=prepared)
+
+    assert summary.op_id == "op-1"
+    assert summary.inserted == 2
+    assert summary.updated == 0
+    assert summary.unchanged == 0
+    assert summary.deleted_sql == 1
+    assert summary.deleted_index == 1
+    assert summary.tombstoned == 1
+    assert summary.missing_external_ids == ["missing-doc"]
+    assert summary.index_doc_count == 2
+    assert [row.external_id for row in list(summary.results or [])] == ["doc-new", "doc-tombstone"]
+    assert repo.get_tombstoned_external_ids(["doc-tombstone", "missing-doc"]) == {"missing-doc"}
+    docs = repo.get([DocId("doc-new"), DocId("doc-tombstone"), DocId("doc-delete")])
+    assert [doc.external_id for doc in docs] == ["doc-new", "doc-tombstone"]
+    assert executor.recover_incomplete() == 0

--- a/tests/unit/infrastructure/persistence/elasticsearch/test_document_storage.py
+++ b/tests/unit/infrastructure/persistence/elasticsearch/test_document_storage.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+
+from local_rag_backend.infrastructure.persistence.elasticsearch.client import ElasticClient
+from local_rag_backend.infrastructure.persistence.elasticsearch.document_storage import (
+    ElasticDocsRepository,
+)
+from local_rag_backend.settings import Settings
+
+
+def _build_transport() -> httpx.MockTransport:
+    indices: dict[str, dict[str, object]] = {}
+
+    def _json(request: httpx.Request) -> dict[str, object]:
+        content = request.content.decode("utf-8")
+        return dict(json.loads(content)) if content else {}
+
+    def _bulk_ops(request: httpx.Request) -> list[dict[str, object]]:
+        lines = [line for line in request.content.decode("utf-8").splitlines() if line.strip()]
+        return [dict(json.loads(line)) for line in lines]
+
+    def _docs(index: str) -> dict[str, dict[str, object]]:
+        bucket = indices.setdefault(index, {"docs": {}, "mapping": {}})
+        return bucket["docs"]  # type: ignore[return-value]
+
+    def _mapping(index: str) -> dict[str, object]:
+        bucket = indices.setdefault(index, {"docs": {}, "mapping": {}})
+        return bucket["mapping"]  # type: ignore[return-value]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        method = request.method
+
+        if method == "HEAD":
+            index = path.strip("/")
+            return httpx.Response(200 if index in indices else 404)
+
+        if method == "GET" and path == "/":
+            return httpx.Response(200, json={"status": "ok"})
+
+        if method == "PUT" and path.count("/") == 1:
+            index = path.strip("/")
+            body = _json(request)
+            mapping = (((body.get("mappings") or {}).get("properties")) or {})
+            indices[index] = {"docs": {}, "mapping": dict(mapping)}
+            return httpx.Response(200, json={"acknowledged": True})
+
+        if method == "PUT" and path.endswith("/_mapping"):
+            index = path.strip("/").split("/")[0]
+            body = _json(request)
+            _mapping(index).update(dict(body.get("properties") or {}))
+            return httpx.Response(200, json={"acknowledged": True})
+
+        if method == "GET" and path.endswith("/_mapping"):
+            index = path.strip("/").split("/")[0]
+            return httpx.Response(
+                200,
+                json={index: {"mappings": {"properties": dict(_mapping(index))}}},
+            )
+
+        if method == "POST" and path.endswith("/_mget"):
+            index = path.strip("/").split("/")[0]
+            docs = _docs(index)
+            body = _json(request)
+            found = []
+            for doc_id in list(body.get("ids") or []):
+                source = docs.get(str(doc_id))
+                if source is None:
+                    found.append({"_id": str(doc_id), "found": False})
+                else:
+                    found.append({"_id": str(doc_id), "found": True, "_source": dict(source)})
+            return httpx.Response(200, json={"docs": found})
+
+        if method == "POST" and path == "/_bulk":
+            ops = _bulk_ops(request)
+            i = 0
+            while i < len(ops):
+                op = ops[i]
+                if "index" in op:
+                    meta = dict(op["index"])
+                    body = dict(ops[i + 1])
+                    _docs(str(meta["_index"]))[str(meta["_id"])] = body
+                    i += 2
+                    continue
+                if "delete" in op:
+                    meta = dict(op["delete"])
+                    _docs(str(meta["_index"])).pop(str(meta["_id"]), None)
+                    i += 1
+                    continue
+                raise AssertionError(f"unexpected bulk op: {op}")
+            return httpx.Response(200, json={"errors": False})
+
+        raise AssertionError(f"Unhandled {method} {path}")
+
+    return httpx.MockTransport(handler)
+
+
+def _build_repo() -> ElasticDocsRepository:
+    settings_obj = Settings(
+        persistence_backend="elasticsearch",
+        retrieval_mode="dense",
+        es_base_url="http://example.test",
+    )
+    client = ElasticClient(
+        settings_obj=settings_obj,
+        client=httpx.Client(base_url="http://example.test", transport=_build_transport()),
+    )
+    return ElasticDocsRepository(settings_obj=settings_obj, client=client)
+
+
+def test_upsert_is_unchanged_when_metadata_matches() -> None:
+    repo = _build_repo()
+    item = ElasticDocsRepository.UpsertDoc(
+        external_id="doc-1",
+        content="hello world",
+        source_id="src-1",
+        metadata={"kind": "faq"},
+        chunk_dedup_sha256="dedup-1",
+    )
+
+    first_results, _first_changed, _first_updated = repo.upsert_documents_by_external_id([item])
+    second_results, second_changed, second_updated = repo.upsert_documents_by_external_id([item])
+
+    assert first_results[0].action == "inserted"
+    assert second_results[0].action == "unchanged"
+    assert second_changed == []
+    assert second_updated == []
+
+
+def test_delete_by_external_id_creates_tombstone() -> None:
+    repo = _build_repo()
+    repo.upsert_documents_by_external_id(
+        [
+            ElasticDocsRepository.UpsertDoc(
+                external_id="doc-1",
+                content="hello world",
+            )
+        ]
+    )
+
+    deleted_count, deleted_ids, missing, tombstoned = repo.delete_by_external_ids(["doc-1"])
+
+    assert deleted_count == 1
+    assert [str(doc_id) for doc_id in deleted_ids] == ["doc-1"]
+    assert missing == []
+    assert tombstoned == 1
+    assert repo.get_tombstoned_external_ids(["doc-1"]) == {"doc-1"}

--- a/tests/unit/infrastructure/persistence/elasticsearch/test_document_storage.py
+++ b/tests/unit/infrastructure/persistence/elasticsearch/test_document_storage.py
@@ -44,7 +44,7 @@ def _build_transport() -> httpx.MockTransport:
         if method == "PUT" and path.count("/") == 1:
             index = path.strip("/")
             body = _json(request)
-            mapping = (((body.get("mappings") or {}).get("properties")) or {})
+            mapping = ((body.get("mappings") or {}).get("properties")) or {}
             indices[index] = {"docs": {}, "mapping": dict(mapping)}
             return httpx.Response(200, json={"acknowledged": True})
 
@@ -99,21 +99,35 @@ def _build_transport() -> httpx.MockTransport:
             body = _json(request)
             query = dict(body.get("query") or {})
             sort = list(body.get("sort") or [])
-            term_scope = ((query.get("term") or {}).get("scope")) if isinstance(query, dict) else None
+            term_scope = (
+                ((query.get("term") or {}).get("scope")) if isinstance(query, dict) else None
+            )
             prefix_external_id = (
-                ((query.get("prefix") or {}).get("external_id")) if isinstance(query, dict) else None
+                ((query.get("prefix") or {}).get("external_id"))
+                if isinstance(query, dict)
+                else None
             )
             hits = []
             for doc_id, source in docs.items():
                 if term_scope is not None and source.get("scope") != term_scope:
                     continue
-                if prefix_external_id is not None and not str(source.get("external_id") or "").startswith(
-                    str(prefix_external_id)
-                ):
+                if prefix_external_id is not None and not str(
+                    source.get("external_id") or ""
+                ).startswith(str(prefix_external_id)):
                     continue
-                hits.append({"_id": str(doc_id), "_source": dict(source), "sort": [source.get("external_id")]})
+                hits.append(
+                    {
+                        "_id": str(doc_id),
+                        "_source": dict(source),
+                        "sort": [source.get("external_id")],
+                    }
+                )
             if sort:
-                hits.sort(key=lambda hit: str((hit.get("_source") or {}).get("external_id") or hit.get("_id") or ""))
+                hits.sort(
+                    key=lambda hit: str(
+                        (hit.get("_source") or {}).get("external_id") or hit.get("_id") or ""
+                    )
+                )
             return httpx.Response(200, json={"hits": {"hits": hits}})
 
         raise AssertionError(f"Unhandled {method} {path}")

--- a/tests/unit/infrastructure/persistence/elasticsearch/test_document_storage.py
+++ b/tests/unit/infrastructure/persistence/elasticsearch/test_document_storage.py
@@ -93,6 +93,29 @@ def _build_transport() -> httpx.MockTransport:
                 raise AssertionError(f"unexpected bulk op: {op}")
             return httpx.Response(200, json={"errors": False})
 
+        if method == "POST" and path.endswith("/_search"):
+            index = path.strip("/").split("/")[0]
+            docs = _docs(index)
+            body = _json(request)
+            query = dict(body.get("query") or {})
+            sort = list(body.get("sort") or [])
+            term_scope = ((query.get("term") or {}).get("scope")) if isinstance(query, dict) else None
+            prefix_external_id = (
+                ((query.get("prefix") or {}).get("external_id")) if isinstance(query, dict) else None
+            )
+            hits = []
+            for doc_id, source in docs.items():
+                if term_scope is not None and source.get("scope") != term_scope:
+                    continue
+                if prefix_external_id is not None and not str(source.get("external_id") or "").startswith(
+                    str(prefix_external_id)
+                ):
+                    continue
+                hits.append({"_id": str(doc_id), "_source": dict(source), "sort": [source.get("external_id")]})
+            if sort:
+                hits.sort(key=lambda hit: str((hit.get("_source") or {}).get("external_id") or hit.get("_id") or ""))
+            return httpx.Response(200, json={"hits": {"hits": hits}})
+
         raise AssertionError(f"Unhandled {method} {path}")
 
     return httpx.MockTransport(handler)
@@ -148,3 +171,26 @@ def test_delete_by_external_id_creates_tombstone() -> None:
     assert missing == []
     assert tombstoned == 1
     assert repo.get_tombstoned_external_ids(["doc-1"]) == {"doc-1"}
+
+
+def test_scope_and_snapshot_are_persisted_and_queryable() -> None:
+    repo = _build_repo()
+    repo.upsert_documents_by_external_id(
+        [
+            ElasticDocsRepository.UpsertDoc(
+                external_id="doc-1",
+                content="hello world",
+                scope="repogpt:demo",
+                snapshot_id="snap-1",
+                metadata={"kind": "code"},
+            )
+        ]
+    )
+
+    doc = repo.get(["doc-1"])[0]
+    assert doc.metadata == {
+        "kind": "code",
+        "scope": "repogpt:demo",
+        "snapshot_id": "snap-1",
+    }
+    assert repo.list_external_ids_by_scope("repogpt:demo") == ["doc-1"]

--- a/tests/unit/infrastructure/persistence/sql/test_sql_upsert_documents_by_external_id.py
+++ b/tests/unit/infrastructure/persistence/sql/test_sql_upsert_documents_by_external_id.py
@@ -93,6 +93,52 @@ def test_upsert_source_only_change(in_memory_sqlite):
     assert repo.get([doc_id])[0].source_id == "src-b"
 
 
+def test_upsert_scope_and_snapshot_are_persisted_and_queryable(in_memory_sqlite):
+    repo = SqlDocumentStorage(session_factory=in_memory_sqlite)
+
+    first, *_ = repo.upsert_documents_by_external_id(
+        [
+            SqlDocumentStorage.UpsertDoc(
+                external_id="doc-1",
+                content="text",
+                scope="repogpt:demo",
+                snapshot_id="snap-1",
+                metadata={"kind": "code"},
+            )
+        ]
+    )
+    doc_id = first[0].id
+
+    doc = repo.get([doc_id])[0]
+    assert doc.metadata == {
+        "kind": "code",
+        "scope": "repogpt:demo",
+        "snapshot_id": "snap-1",
+    }
+    assert repo.list_external_ids_by_scope("repogpt:demo") == ["doc-1"]
+
+    second, changed, updated_ids = repo.upsert_documents_by_external_id(
+        [
+            SqlDocumentStorage.UpsertDoc(
+                external_id="doc-1",
+                content="text",
+                scope="repogpt:demo",
+                snapshot_id="snap-2",
+                metadata={"kind": "code"},
+            )
+        ]
+    )
+    assert second[0].action == "updated"
+    assert second[0].content_changed is False
+    assert changed == []
+    assert updated_ids == []
+    assert repo.get([doc_id])[0].metadata == {
+        "kind": "code",
+        "scope": "repogpt:demo",
+        "snapshot_id": "snap-2",
+    }
+
+
 def test_upsert_dedup_only_change(in_memory_sqlite):
     """chunk_dedup_sha256 update triggers action=updated with content_changed=False."""
     repo = SqlDocumentStorage(session_factory=in_memory_sqlite)

--- a/tests/unit/infrastructure/persistence/sql/test_sqlite_document_identity_columns.py
+++ b/tests/unit/infrastructure/persistence/sql/test_sqlite_document_identity_columns.py
@@ -36,6 +36,8 @@ def test_fresh_schema_contains_doc_id_and_identity_columns(tmp_path):
             "doc_id",
             "external_id",
             "source_id",
+            "scope",
+            "snapshot_id",
             "metadata",
             "content_sha256",
             "chunk_dedup_sha256",

--- a/tests/unit/settings/test_settings_validators.py
+++ b/tests/unit/settings/test_settings_validators.py
@@ -11,6 +11,34 @@ def test_sqlite_url_validator():
         Settings(sqlite_url="postgres://x")
 
 
+def test_elasticsearch_backend_requires_es_base_url():
+    with pytest.raises(ValueError, match="ES_BASE_URL is required"):
+        Settings(
+            persistence_backend="elasticsearch",
+            retrieval_mode="dense",
+            es_base_url=None,
+        )
+
+
+def test_elasticsearch_backend_rejects_sparse():
+    with pytest.raises(ValueError, match="supports only retrieval_mode=dense\\|hybrid"):
+        Settings(
+            persistence_backend="elasticsearch",
+            retrieval_mode="sparse",
+            es_base_url="http://localhost:9200",
+        )
+
+
+def test_elasticsearch_backend_does_not_validate_sqlite_url():
+    s = Settings(
+        persistence_backend="elasticsearch",
+        retrieval_mode="dense",
+        es_base_url="http://localhost:9200",
+        sqlite_url="postgres://ignored-in-es-mode",
+    )
+    assert s.sqlite_url == "postgres://ignored-in-es-mode"
+
+
 def test_ollama_url_validator():
     with pytest.raises(ValueError):
         Settings(ollama_base_url="localhost:11434")

--- a/tests/unit/test_cli_import_canonical.py
+++ b/tests/unit/test_cli_import_canonical.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from local_rag_backend.cli import cli
+from local_rag_backend.infrastructure.persistence.sql import SqlDocumentStorage
+from local_rag_backend.settings import settings
+
+
+def test_cli_import_canonical_syncs_scope(in_memory_sqlite, tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "retrieval_mode", "sparse", raising=False)
+
+    first = tmp_path / "snap1.json"
+    first.write_text(
+        json.dumps(
+            {
+                "scope": "repogpt:demo",
+                "snapshot_id": "snap-1",
+                "documents": [
+                    {
+                        "external_id": "doc-1",
+                        "source_id": "file:a.py",
+                        "content": "def alpha():\n    return 1\n",
+                        "metadata": {"path": "a.py"},
+                    },
+                    {
+                        "external_id": "doc-2",
+                        "source_id": "file:b.py",
+                        "content": "def beta():\n    return 2\n",
+                        "metadata": {"path": "b.py"},
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    second = tmp_path / "snap2.json"
+    second.write_text(
+        json.dumps(
+            {
+                "scope": "repogpt:demo",
+                "snapshot_id": "snap-2",
+                "documents": [
+                    {
+                        "external_id": "doc-2",
+                        "source_id": "file:b.py",
+                        "content": "def beta():\n    return 20\n",
+                        "metadata": {"path": "b.py"},
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    r1 = CliRunner().invoke(cli, ["import-canonical", "--json", str(first)])
+    assert r1.exit_code == 0, r1.output
+    assert "inserted=2" in r1.output
+
+    r2 = CliRunner().invoke(cli, ["import-canonical", "--json", str(second)])
+    assert r2.exit_code == 0, r2.output
+    assert "updated=1" in r2.output
+    assert "deleted_sql=1" in r2.output
+    assert {doc.external_id for doc in SqlDocumentStorage().get_all_documents()} == {"doc-2"}

--- a/tests/unit/test_cli_registry.py
+++ b/tests/unit/test_cli_registry.py
@@ -10,6 +10,7 @@ def test_cli_registers_all_expected_commands() -> None:
         "server",
         "rebuild-index",
         "mutate-docs",
+        "import-canonical",
         "bootstrap",
         "status",
         "eval",
@@ -27,6 +28,7 @@ def test_cli_registers_all_expected_commands() -> None:
         ("rag_eval", ["eval", "--flag"]),
         ("rag_rebuild_index", ["rebuild-index", "--flag"]),
         ("rag_mutate_docs", ["mutate-docs", "--flag"]),
+        ("rag_import_canonical", ["import-canonical", "--flag"]),
         ("rag_ingest", ["ingest", "--flag"]),
     ],
 )

--- a/uv.lock
+++ b/uv.lock
@@ -3698,7 +3698,7 @@ wheels = [
 
 [[package]]
 name = "rag-prototype"
-version = "1.0.0"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "click", marker = "python_full_version < '3.13'" },
@@ -4769,6 +4769,12 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/8b/4b61d6e13f7108f36910df9ab4b58fd389cc2520d54d81b88660804aad99/torch-2.10.0-2-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:418997cb02d0a0f1497cf6a09f63166f9f5df9f3e16c8a716ab76a72127c714f", size = 79423467, upload-time = "2026-02-10T21:44:48.711Z" },
     { url = "https://files.pythonhosted.org/packages/d3/54/a2ba279afcca44bbd320d4e73675b282fcee3d81400ea1b53934efca6462/torch-2.10.0-2-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:13ec4add8c3faaed8d13e0574f5cd4a323c11655546f91fbe6afa77b57423574", size = 79498202, upload-time = "2026-02-10T21:44:52.603Z" },
     { url = "https://files.pythonhosted.org/packages/ec/23/2c9fe0c9c27f7f6cb865abcea8a4568f29f00acaeadfc6a37f6801f84cb4/torch-2.10.0-2-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:e521c9f030a3774ed770a9c011751fb47c4d12029a3d6522116e48431f2ff89e", size = 79498254, upload-time = "2026-02-10T21:44:44.095Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ab/7b562f1808d3f65414cd80a4f7d4bb00979d9355616c034c171249e1a303/torch-2.10.0-3-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:ac5bdcbb074384c66fa160c15b1ead77839e3fe7ed117d667249afce0acabfac", size = 915518691, upload-time = "2026-03-11T14:15:43.147Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7a/abada41517ce0011775f0f4eacc79659bc9bc6c361e6bfe6f7052a6b9363/torch-2.10.0-3-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:98c01b8bb5e3240426dcde1446eed6f40c778091c8544767ef1168fc663a05a6", size = 915622781, upload-time = "2026-03-11T14:17:11.354Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/c6/4dfe238342ffdcec5aef1c96c457548762d33c40b45a1ab7033bb26d2ff2/torch-2.10.0-3-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:80b1b5bfe38eb0e9f5ff09f206dcac0a87aadd084230d4a36eea5ec5232c115b", size = 915627275, upload-time = "2026-03-11T14:16:11.325Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f0/72bf18847f58f877a6a8acf60614b14935e2f156d942483af1ffc081aea0/torch-2.10.0-3-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:46b3574d93a2a8134b3f5475cfb98e2eb46771794c57015f6ad1fb795ec25e49", size = 915523474, upload-time = "2026-03-11T14:17:44.422Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/39/590742415c3030551944edc2ddc273ea1fdfe8ffb2780992e824f1ebee98/torch-2.10.0-3-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:b1d5e2aba4eb7f8e87fbe04f86442887f9167a35f092afe4c237dfcaaef6e328", size = 915632474, upload-time = "2026-03-11T14:15:13.666Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/8e/34949484f764dde5b222b7fe3fede43e4a6f0da9d7f8c370bb617d629ee2/torch-2.10.0-3-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:0228d20b06701c05a8f978357f657817a4a63984b0c90745def81c18aedfa591", size = 915523882, upload-time = "2026-03-11T14:14:46.311Z" },
     { url = "https://files.pythonhosted.org/packages/78/89/f5554b13ebd71e05c0b002f95148033e730d3f7067f67423026cc9c69410/torch-2.10.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:3282d9febd1e4e476630a099692b44fdc214ee9bf8ee5377732d9d9dfe5712e4", size = 145992610, upload-time = "2026-01-21T16:25:26.327Z" },
     { url = "https://files.pythonhosted.org/packages/ae/30/a3a2120621bf9c17779b169fc17e3dc29b230c29d0f8222f499f5e159aa8/torch-2.10.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:a2f9edd8dbc99f62bc4dfb78af7bf89499bca3d753423ac1b4e06592e467b763", size = 915607863, upload-time = "2026-01-21T16:25:06.696Z" },
     { url = "https://files.pythonhosted.org/packages/6f/3d/c87b33c5f260a2a8ad68da7147e105f05868c281c63d65ed85aa4da98c66/torch-2.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:29b7009dba4b7a1c960260fc8ac85022c784250af43af9fb0ebafc9883782ebd", size = 113723116, upload-time = "2026-01-21T16:25:21.916Z" },


### PR DESCRIPTION
## Summary

- **Elasticsearch persistence backend**: full document storage, history,
  system state, diagnostics, and index mapping management; wired through
  composition and runtime alongside the existing SQL backend.
- **scope / snapshot_id fields**: propagated across the domain model,
  mutation contracts, both persistence adapters (SQL + ES), HTTP schemas,
  and CLI — enabling documents to be tagged with an origin scope and version.
- **Canonical import endpoint** (`POST /api/docs/import-canonical`) and
  **CLI command** (`rag-import-canonical`): declarative snapshot-based sync
  that upserts a scoped document collection and optionally hard-deletes stale
  docs not present in the current snapshot (`replace_scope` mode).

## Test plan

- [ ] Unit tests pass for SQL and Elasticsearch document storage (scope persistence, `list_external_ids_by_scope`)
- [ ] Unit tests pass for canonical import endpoint (upsert-only and replace_scope paths, duplicate external_id rejection)
- [ ] Unit tests pass for `rag-import-canonical` CLI (sync + cross-snapshot deletion)
- [ ] CLI registry test confirms `import-canonical` command and entry point are wired
- [ ] Elasticsearch backend runtime tests pass (client, mappings, diagnostics)
- [ ] Spin up stack with `docker-compose up`, index docs via `rag-import-canonical`, verify scope-aware deletion
