### PR TITLE
feat(eval): migrate rag-eval to ir_measures and harden dataset semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,8 @@ rag-mutate-docs --json /tmp/mutate_delete_external_ids.json
 rag-status
 
 
-# Offline retrieval evaluation (reproducible gate; default dataset from `datasets/rag_eval_v1.jsonl`)
+# Offline IR evaluation with standard metrics via `ir_measures`
+# (reproducible gate; default dataset from `datasets/rag_eval_v1.jsonl`)
 rag-eval --retrieval-mode sparse
 ```
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -371,6 +371,8 @@ rag-eval --retrieval-mode sparse
 ```
 
 Dataset por defecto: `datasets/rag_eval_v1.jsonl` (o `RAG_EVAL_DATASET_PATH`).
+El comando reporta métricas estándar de IR a `@k` (`nDCG`, `MAP`, `MRR`, `P`, `Recall`).
+El dataset se valida de forma estricta: IDs duplicados, relevantes vacíos o relevantes fuera del corpus fallan al cargar.
 
 Reranker opcional (mejora de calidad medible con `rag-eval`):
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ classifiers = [
 dependencies = [
   # AI/ML Core (lightweight defaults; heavy deps are optional extras)
   "rank-bm25>=0.2,<1.0",
+  "ir-measures>=0.4,<1.0",
   "numpy>=2.0,<2.3",
   # LLM Integrations
   "openai>=1.24,<2.0",

--- a/src/local_rag_backend/cli_commands/eval.py
+++ b/src/local_rag_backend/cli_commands/eval.py
@@ -83,10 +83,7 @@ def eval_cmd(
 
         if failures:
             click.echo(
-                "[ERROR] Eval regression: "
-                + format_eval_result(res)
-                + " | "
-                + "; ".join(failures),
+                "[ERROR] Eval regression: " + format_eval_result(res) + " | " + "; ".join(failures),
                 err=True,
             )
             raise SystemExit(1)

--- a/src/local_rag_backend/cli_commands/eval.py
+++ b/src/local_rag_backend/cli_commands/eval.py
@@ -27,7 +27,8 @@ from local_rag_backend.cli_commands.runtime import get_cli_container
 @click.option("--k", type=int, default=3, show_default=True)
 @click.option("--max-queries", type=int, default=None, help="Evaluate only the first N queries.")
 @click.option("--reranker/--no-reranker", default=False, show_default=True)
-@click.option("--fail-below-hit-rate", type=float, default=1.0, show_default=True)
+@click.option("--fail-below-ndcg", type=float, default=1.0, show_default=True)
+@click.option("--fail-below-map", type=float, default=0.9, show_default=True)
 @click.option("--fail-below-mrr", type=float, default=0.9, show_default=True)
 @click.option(
     "--json-out",
@@ -41,11 +42,12 @@ def eval_cmd(
     k: int,
     max_queries: int | None,
     reranker: bool,
-    fail_below_hit_rate: float,
+    fail_below_ndcg: float,
+    fail_below_map: float,
     fail_below_mrr: float,
     json_out: Path | None,
 ) -> None:
-    """Offline retrieval evaluation (reproducible, dependency-free by default)."""
+    """Offline IR evaluation with standard retrieval metrics."""
     try:
         from local_rag_backend.core.services.evaluation import (
             eval_result_to_json,
@@ -68,18 +70,27 @@ def eval_cmd(
             reranker_strategy=eval_bundle.reranker_strategy,
             max_queries=max_queries,
         )
-        click.echo(format_eval_result(res))
-
         if json_out is not None:
             json_out.write_text(json.dumps(eval_result_to_json(res)), encoding="utf-8")
 
-        if res.hit_rate < float(fail_below_hit_rate) or res.mrr < float(fail_below_mrr):
+        failures: list[str] = []
+        if res.ndcg_at_k < float(fail_below_ndcg):
+            failures.append(f"nDCG@{k}={res.ndcg_at_k:.3f} (min {fail_below_ndcg})")
+        if res.map_at_k < float(fail_below_map):
+            failures.append(f"MAP@{k}={res.map_at_k:.3f} (min {fail_below_map})")
+        if res.mrr_at_k < float(fail_below_mrr):
+            failures.append(f"MRR@{k}={res.mrr_at_k:.3f} (min {fail_below_mrr})")
+
+        if failures:
             click.echo(
-                f"[ERROR] Eval regression: hit_rate={res.hit_rate:.3f} (min {fail_below_hit_rate}), "
-                f"mrr={res.mrr:.3f} (min {fail_below_mrr})",
+                "[ERROR] Eval regression: "
+                + format_eval_result(res)
+                + " | "
+                + "; ".join(failures),
                 err=True,
             )
             raise SystemExit(1)
+        click.echo(format_eval_result(res))
     except SystemExit:
         raise
     except Exception as e:

--- a/src/local_rag_backend/core/services/evaluation.py
+++ b/src/local_rag_backend/core/services/evaluation.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import ir_measures
-from ir_measures import AP, P, R, RR, nDCG
+from ir_measures import AP, RR, P, R, nDCG
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
@@ -170,7 +170,9 @@ def run_retrieval_eval(
         raise ValueError("No queries to evaluate after max_queries.")
     if retrieve_external_ids is None:
         raise ValueError("retrieve_external_ids callback is required for sparse evaluation.")
-    known_doc_ids = {str(doc.external_id).strip() for doc in dataset.docs if str(doc.external_id).strip()}
+    known_doc_ids = {
+        str(doc.external_id).strip() for doc in dataset.docs if str(doc.external_id).strip()
+    }
     if not known_doc_ids:
         raise ValueError("Dataset contains no known corpus document IDs.")
 

--- a/src/local_rag_backend/core/services/evaluation.py
+++ b/src/local_rag_backend/core/services/evaluation.py
@@ -31,6 +31,15 @@ def _default_eval_dataset_path() -> Path:
     return Path(__file__).resolve().parents[4] / "datasets" / "rag_eval_v1.jsonl"
 
 
+def _parse_schema_version(raw_value: Any, *, lineno: int) -> int:
+    try:
+        return int(raw_value or 0)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"Invalid dataset line {lineno}: schema_version must be an integer."
+        ) from exc
+
+
 def load_eval_dataset(path: str | Path | None = None) -> EvalDataset:
     content: str
     if path is None:
@@ -50,6 +59,7 @@ def load_eval_dataset(path: str | Path | None = None) -> EvalDataset:
     schema_version = 0
     docs: list[EvalDoc] = []
     queries: list[EvalQuery] = []
+    known_doc_ids: set[str] = set()
 
     for lineno, line in enumerate(content.splitlines(), 1):
         s = line.strip()
@@ -61,11 +71,19 @@ def load_eval_dataset(path: str | Path | None = None) -> EvalDataset:
         t = obj.get("type")
         if t == "meta":
             dataset_id = str(obj.get("dataset_id") or dataset_id)
-            schema_version = int(obj.get("schema_version") or 0)
+            schema_version = _parse_schema_version(obj.get("schema_version"), lineno=lineno)
         elif t == "doc":
+            external_id = str(obj["external_id"]).strip()
+            if not external_id:
+                raise ValueError(f"Invalid dataset line {lineno}: external_id must not be blank.")
+            if external_id in known_doc_ids:
+                raise ValueError(
+                    f"Invalid dataset line {lineno}: duplicate doc external_id={external_id!r}."
+                )
+            known_doc_ids.add(external_id)
             docs.append(
                 EvalDoc(
-                    external_id=str(obj["external_id"]),
+                    external_id=external_id,
                     content=str(obj["content"]),
                     source_id=(
                         str(obj.get("source_id")) if obj.get("source_id") is not None else None
@@ -78,7 +96,21 @@ def load_eval_dataset(path: str | Path | None = None) -> EvalDataset:
                 raise ValueError(
                     f"Invalid dataset line {lineno}: relevant_external_ids must be list[str]."
                 )
-            queries.append(EvalQuery(query=str(obj["query"]), relevant_external_ids=tuple(rel)))
+            normalized_rel = tuple(str(external_id).strip() for external_id in rel)
+            if not normalized_rel:
+                raise ValueError(
+                    f"Invalid dataset line {lineno}: relevant_external_ids must not be empty."
+                )
+            if any(not external_id for external_id in normalized_rel):
+                raise ValueError(
+                    f"Invalid dataset line {lineno}: relevant_external_ids must not contain blank IDs."
+                )
+            queries.append(
+                EvalQuery(
+                    query=str(obj["query"]),
+                    relevant_external_ids=normalized_rel,
+                )
+            )
         else:
             raise ValueError(f"Invalid dataset line {lineno}: unknown type={t!r}")
 
@@ -88,6 +120,19 @@ def load_eval_dataset(path: str | Path | None = None) -> EvalDataset:
         raise ValueError("Dataset contains no docs.")
     if not queries:
         raise ValueError("Dataset contains no queries.")
+    for query in queries:
+        missing_ids = sorted(
+            {
+                external_id
+                for external_id in query.relevant_external_ids
+                if external_id not in known_doc_ids
+            }
+        )
+        if missing_ids:
+            raise ValueError(
+                "Dataset query references relevant_external_ids outside the corpus: "
+                + ", ".join(missing_ids[:10])
+            )
 
     return EvalDataset(
         dataset_id=str(dataset_id),
@@ -125,18 +170,33 @@ def run_retrieval_eval(
         raise ValueError("No queries to evaluate after max_queries.")
     if retrieve_external_ids is None:
         raise ValueError("retrieve_external_ids callback is required for sparse evaluation.")
+    known_doc_ids = {str(doc.external_id).strip() for doc in dataset.docs if str(doc.external_id).strip()}
+    if not known_doc_ids:
+        raise ValueError("Dataset contains no known corpus document IDs.")
 
     qrels: dict[str, dict[str, int]] = {}
     run: dict[str, dict[str, float]] = {}
     for idx, q in enumerate(qs, start=1):
         query_id = f"q{idx:06d}"
-        qrels[query_id] = {external_id: 1 for external_id in q.relevant_external_ids}
+        qrels[query_id] = {
+            external_id: 1
+            for external_id in q.relevant_external_ids
+            if external_id in known_doc_ids
+        }
+        if not qrels[query_id]:
+            raise ValueError(
+                f"Query {query_id} has no relevant corpus IDs after dataset validation."
+            )
 
         ranked_docs: dict[str, float] = {}
         seen_external_ids: set[str] = set()
         for external_id in retrieve_external_ids(q.query, k):
             normalized_external_id = str(external_id).strip()
-            if not normalized_external_id or normalized_external_id in seen_external_ids:
+            if (
+                not normalized_external_id
+                or normalized_external_id in seen_external_ids
+                or normalized_external_id not in known_doc_ids
+            ):
                 continue
             seen_external_ids.add(normalized_external_id)
             rank = len(ranked_docs) + 1

--- a/src/local_rag_backend/core/services/evaluation.py
+++ b/src/local_rag_backend/core/services/evaluation.py
@@ -1,5 +1,5 @@
 """
-Offline evaluation for retrieval quality.
+Offline IR evaluation for retrieval quality.
 
 Focus: reproducible retrieval metrics without requiring an LLM provider.
 """
@@ -10,6 +10,9 @@ import json
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+
+import ir_measures
+from ir_measures import AP, P, R, RR, nDCG
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
@@ -110,7 +113,7 @@ def run_retrieval_eval(
     _ = (reranker_candidate_k, reranker_strategy)
     if retrieval_mode != "sparse":
         raise ValueError(
-            "This eval currently supports retrieval_mode=sparse only (dependency-free)."
+            "This offline IR evaluation currently supports retrieval_mode=sparse only."
         )
     if k <= 0:
         raise ValueError("k must be positive")
@@ -123,21 +126,33 @@ def run_retrieval_eval(
     if retrieve_external_ids is None:
         raise ValueError("retrieve_external_ids callback is required for sparse evaluation.")
 
-    hits = 0
-    rr_sum = 0.0
-    for q in qs:
-        relevant = set(q.relevant_external_ids)
-        retrieved_ext = [str(eid) for eid in retrieve_external_ids(q.query, k) if str(eid).strip()]
+    qrels: dict[str, dict[str, int]] = {}
+    run: dict[str, dict[str, float]] = {}
+    for idx, q in enumerate(qs, start=1):
+        query_id = f"q{idx:06d}"
+        qrels[query_id] = {external_id: 1 for external_id in q.relevant_external_ids}
 
-        rank = None
-        for i, eid in enumerate(retrieved_ext, 1):
-            if eid in relevant:
-                rank = i
+        ranked_docs: dict[str, float] = {}
+        seen_external_ids: set[str] = set()
+        for external_id in retrieve_external_ids(q.query, k):
+            normalized_external_id = str(external_id).strip()
+            if not normalized_external_id or normalized_external_id in seen_external_ids:
+                continue
+            seen_external_ids.add(normalized_external_id)
+            rank = len(ranked_docs) + 1
+            ranked_docs[normalized_external_id] = float(max(k - rank + 1, 1))
+            if len(ranked_docs) >= int(k):
                 break
-        if rank is not None:
-            hits += 1
-            rr_sum += 1.0 / float(rank)
+        run[query_id] = ranked_docs
 
+    measures = (
+        nDCG @ k,
+        AP @ k,
+        RR @ k,
+        P @ k,
+        R @ k,
+    )
+    aggregated = ir_measures.calc_aggregate(measures, qrels, run)
     n = len(qs)
     return EvalResult(
         dataset_id=dataset.dataset_id,
@@ -145,15 +160,23 @@ def run_retrieval_eval(
         reranker_enabled=bool(reranker_enabled),
         k=int(k),
         queries=n,
-        hit_rate=float(hits / n),
-        mrr=float(rr_sum / n),
+        ndcg_at_k=float(aggregated[nDCG @ k]),
+        map_at_k=float(aggregated[AP @ k]),
+        mrr_at_k=float(aggregated[RR @ k]),
+        precision_at_k=float(aggregated[P @ k]),
+        recall_at_k=float(aggregated[R @ k]),
     )
 
 
 def format_eval_result(result: EvalResult) -> str:
     return (
         f"dataset={result.dataset_id} mode={result.retrieval_mode} reranker={result.reranker_enabled} "
-        f"k={result.k} queries={result.queries} hit_rate={result.hit_rate:.3f} mrr={result.mrr:.3f}"
+        f"k={result.k} queries={result.queries} "
+        f"nDCG@{result.k}={result.ndcg_at_k:.3f} "
+        f"MAP@{result.k}={result.map_at_k:.3f} "
+        f"MRR@{result.k}={result.mrr_at_k:.3f} "
+        f"P@{result.k}={result.precision_at_k:.3f} "
+        f"Recall@{result.k}={result.recall_at_k:.3f}"
     )
 
 
@@ -164,6 +187,11 @@ def eval_result_to_json(result: EvalResult) -> dict[str, Any]:
         "reranker_enabled": result.reranker_enabled,
         "k": result.k,
         "queries": result.queries,
-        "hit_rate": result.hit_rate,
-        "mrr": result.mrr,
+        "metrics": {
+            f"nDCG@{result.k}": result.ndcg_at_k,
+            f"MAP@{result.k}": result.map_at_k,
+            f"MRR@{result.k}": result.mrr_at_k,
+            f"P@{result.k}": result.precision_at_k,
+            f"Recall@{result.k}": result.recall_at_k,
+        },
     }

--- a/src/local_rag_backend/core/services/types.py
+++ b/src/local_rag_backend/core/services/types.py
@@ -44,8 +44,11 @@ class EvalResult:
     reranker_enabled: bool
     k: int
     queries: int
-    hit_rate: float
-    mrr: float
+    ndcg_at_k: float
+    map_at_k: float
+    mrr_at_k: float
+    precision_at_k: float
+    recall_at_k: float
 
 
 # --- INFRASTRUCTURE INGESTION DETECTION ---

--- a/src/local_rag_backend/core/use_cases/evaluation.py
+++ b/src/local_rag_backend/core/use_cases/evaluation.py
@@ -28,24 +28,22 @@ def run_retrieval_eval(
 ) -> EvalResult:
     if retrieval_mode != "sparse":
         raise ValueError(
-            "This eval currently supports retrieval_mode=sparse only (dependency-free)."
+            "This offline IR evaluation currently supports retrieval_mode=sparse only."
         )
     if k <= 0:
         raise ValueError("k must be positive")
 
-    known_external_ids = set(
-        eval_storage_port.upsert_dataset_docs(
-            dataset_id=dataset.dataset_id,
-            docs=tuple(
-                EvalDatasetDocInput(
-                    external_id=d.external_id,
-                    content=d.content,
-                    source_id=d.source_id,
-                    metadata={"dataset_id": dataset.dataset_id},
-                )
-                for d in dataset.docs
-            ),
-        )
+    eval_storage_port.upsert_dataset_docs(
+        dataset_id=dataset.dataset_id,
+        docs=tuple(
+            EvalDatasetDocInput(
+                external_id=d.external_id,
+                content=d.content,
+                source_id=d.source_id,
+                metadata={"dataset_id": dataset.dataset_id},
+            )
+            for d in dataset.docs
+        ),
     )
 
     retriever = eval_retriever_factory_port.build_sparse_retriever(
@@ -60,7 +58,7 @@ def run_retrieval_eval(
         return [
             str(external_id)
             for external_id in (getattr(d, "external_id", None) for d in docs)
-            if external_id is not None and str(external_id) in known_external_ids
+            if external_id is not None and str(external_id).strip()
         ]
 
     return run_retrieval_eval_core(

--- a/tests/unit/application/services/test_app_evaluation_service.py
+++ b/tests/unit/application/services/test_app_evaluation_service.py
@@ -4,7 +4,8 @@ from local_rag_backend.composition.adapters import (
     build_eval_retriever_factory_port,
     build_eval_storage_port,
 )
-from local_rag_backend.core.services.evaluation import load_eval_dataset
+from local_rag_backend.core.ports import EvalDatasetDocInput
+from local_rag_backend.core.services.evaluation import load_eval_dataset, run_retrieval_eval as run_core_eval
 from local_rag_backend.core.use_cases.evaluation import run_retrieval_eval
 
 
@@ -20,5 +21,59 @@ def test_run_retrieval_eval_app_service_passes_on_default_repo_dataset() -> None
         reranker_strategy="overlap_v1",
     )
     assert res.queries > 0
-    assert 0.0 <= res.hit_rate <= 1.0
-    assert 0.0 <= res.mrr <= 1.0
+    assert 0.0 <= res.ndcg_at_k <= 1.0
+    assert 0.0 <= res.map_at_k <= 1.0
+    assert 0.0 <= res.mrr_at_k <= 1.0
+    assert 0.0 <= res.precision_at_k <= 1.0
+    assert 0.0 <= res.recall_at_k <= 1.0
+
+
+def test_run_retrieval_eval_app_service_matches_core_semantics() -> None:
+    ds = load_eval_dataset()
+    storage = build_eval_storage_port()
+    storage.upsert_dataset_docs(
+        dataset_id=ds.dataset_id,
+        docs=tuple(
+            EvalDatasetDocInput(
+                external_id=d.external_id,
+                content=d.content,
+                source_id=d.source_id,
+                metadata={"dataset_id": ds.dataset_id},
+            )
+            for d in ds.docs
+        ),
+    )
+    retriever = build_eval_retriever_factory_port().build_sparse_retriever(
+        storage=storage,
+        reranker_enabled=True,
+        candidate_k=20,
+        strategy="overlap_v1",
+    )
+
+    def _retrieve_external_ids(query: str, top_k: int) -> list[str]:
+        docs, _scores = retriever.retrieve(query, top_k)
+        return [
+            str(external_id)
+            for external_id in (getattr(d, "external_id", None) for d in docs)
+            if external_id is not None and str(external_id).strip()
+        ]
+
+    core_res = run_core_eval(
+        dataset=ds,
+        retrieve_external_ids=_retrieve_external_ids,
+        retrieval_mode="sparse",
+        k=3,
+        reranker_enabled=True,
+    )
+    app_res = run_retrieval_eval(
+        dataset=ds,
+        eval_storage_port=build_eval_storage_port(),
+        eval_retriever_factory_port=build_eval_retriever_factory_port(),
+        retrieval_mode="sparse",
+        k=3,
+        reranker_enabled=True,
+        reranker_candidate_k=20,
+        reranker_strategy="overlap_v1",
+    )
+
+    assert app_res == core_res

--- a/tests/unit/application/services/test_app_evaluation_service.py
+++ b/tests/unit/application/services/test_app_evaluation_service.py
@@ -5,7 +5,10 @@ from local_rag_backend.composition.adapters import (
     build_eval_storage_port,
 )
 from local_rag_backend.core.ports import EvalDatasetDocInput
-from local_rag_backend.core.services.evaluation import load_eval_dataset, run_retrieval_eval as run_core_eval
+from local_rag_backend.core.services.evaluation import (
+    load_eval_dataset,
+    run_retrieval_eval as run_core_eval,
+)
 from local_rag_backend.core.use_cases.evaluation import run_retrieval_eval
 
 

--- a/tests/unit/cli/test_cli_eval.py
+++ b/tests/unit/cli/test_cli_eval.py
@@ -1,5 +1,6 @@
 # tests/unit/test_cli_eval.py
 
+import json
 from pathlib import Path
 
 from click.testing import CliRunner
@@ -8,14 +9,15 @@ from local_rag_backend.cli import cli
 
 
 def test_rag_eval_fails_below_threshold(tmp_path: Path) -> None:
-    # Minimal dataset where the relevant_external_ids don't exist => hit_rate=0.
+    # Valid dataset where the retriever prefers a non-relevant doc => thresholds fail.
     ds = tmp_path / "ds.jsonl"
     ds.write_text(
         "\n".join(
             [
                 '{"type":"meta","dataset_id":"x","schema_version":1,"created_at":"2026-02-16"}',
-                '{"type":"doc","external_id":"doc:1","source_id":"eval","content":"alpha beta gamma"}',
-                '{"type":"query","query":"alpha","relevant_external_ids":["doc:missing"]}',
+                '{"type":"doc","external_id":"doc:1","source_id":"eval","content":"zzz zzz zzz"}',
+                '{"type":"doc","external_id":"doc:2","source_id":"eval","content":"alpha alpha alpha"}',
+                '{"type":"query","query":"alpha","relevant_external_ids":["doc:1"]}',
             ]
         )
         + "\n",
@@ -32,12 +34,14 @@ def test_rag_eval_fails_below_threshold(tmp_path: Path) -> None:
             "sparse",
             "--k",
             "1",
-            "--fail-below-hit-rate",
+            "--fail-below-ndcg",
             "0.5",
         ],
     )
     assert r.exit_code == 1, r.output
     assert "Eval regression" in r.output
+    assert "dataset=x mode=sparse" in r.output
+    assert r.output.count("\n") == 1
 
 
 def test_rag_eval_reports_invalid_jsonl_cleanly(tmp_path: Path) -> None:
@@ -56,3 +60,36 @@ def test_rag_eval_reports_empty_dataset_cleanly(tmp_path: Path) -> None:
     r = CliRunner().invoke(cli, ["eval", "--dataset", str(ds)])
     assert r.exit_code == 1
     assert "[ERROR] Error evaluating dataset:" in r.output
+
+
+def test_rag_eval_json_out_uses_metrics_only_shape(tmp_path: Path) -> None:
+    ds = tmp_path / "ds.jsonl"
+    json_out = tmp_path / "result.json"
+    ds.write_text(
+        "\n".join(
+            [
+                '{"type":"meta","dataset_id":"x","schema_version":1,"created_at":"2026-02-16"}',
+                '{"type":"doc","external_id":"doc:1","source_id":"eval","content":"alpha beta gamma"}',
+                '{"type":"query","query":"alpha","relevant_external_ids":["doc:1"]}',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    r = CliRunner().invoke(
+        cli,
+        ["eval", "--dataset", str(ds), "--k", "1", "--json-out", str(json_out)],
+    )
+
+    assert r.exit_code == 0, r.output
+    payload = json.loads(json_out.read_text(encoding="utf-8"))
+    assert set(payload.keys()) == {
+        "dataset_id",
+        "retrieval_mode",
+        "reranker_enabled",
+        "k",
+        "queries",
+        "metrics",
+    }
+    assert set(payload["metrics"].keys()) == {"nDCG@1", "MAP@1", "MRR@1", "P@1", "Recall@1"}

--- a/tests/unit/core/services/test_evaluation.py
+++ b/tests/unit/core/services/test_evaluation.py
@@ -32,6 +32,97 @@ def test_load_eval_dataset_rejects_unknown_type(tmp_path: Path) -> None:
         load_eval_dataset(p)
 
 
+def test_load_eval_dataset_rejects_non_integer_schema_version(tmp_path: Path) -> None:
+    p = tmp_path / "ds.jsonl"
+    p.write_text(
+        "\n".join(
+            [
+                '{"type":"meta","dataset_id":"x","schema_version":"rag_eval_v1"}',
+                '{"type":"doc","external_id":"doc:1","content":"alpha"}',
+                '{"type":"query","query":"alpha","relevant_external_ids":["doc:1"]}',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="schema_version must be an integer"):
+        load_eval_dataset(p)
+
+
+def test_load_eval_dataset_rejects_duplicate_doc_external_ids(tmp_path: Path) -> None:
+    p = tmp_path / "ds.jsonl"
+    p.write_text(
+        "\n".join(
+            [
+                '{"type":"meta","dataset_id":"x","schema_version":1}',
+                '{"type":"doc","external_id":"doc:1","content":"alpha"}',
+                '{"type":"doc","external_id":" doc:1 ","content":"beta"}',
+                '{"type":"query","query":"alpha","relevant_external_ids":["doc:1"]}',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="duplicate doc external_id"):
+        load_eval_dataset(p)
+
+
+def test_load_eval_dataset_rejects_empty_relevant_external_ids(tmp_path: Path) -> None:
+    p = tmp_path / "ds.jsonl"
+    p.write_text(
+        "\n".join(
+            [
+                '{"type":"meta","dataset_id":"x","schema_version":1}',
+                '{"type":"doc","external_id":"doc:1","content":"alpha"}',
+                '{"type":"query","query":"alpha","relevant_external_ids":[]}',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        load_eval_dataset(p)
+
+
+def test_load_eval_dataset_rejects_relevant_ids_outside_corpus(tmp_path: Path) -> None:
+    p = tmp_path / "ds.jsonl"
+    p.write_text(
+        "\n".join(
+            [
+                '{"type":"meta","dataset_id":"x","schema_version":1}',
+                '{"type":"doc","external_id":"doc:1","content":"alpha"}',
+                '{"type":"query","query":"alpha","relevant_external_ids":["doc:missing"]}',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="outside the corpus"):
+        load_eval_dataset(p)
+
+
+def test_load_eval_dataset_rejects_blank_ids_after_normalization(tmp_path: Path) -> None:
+    p = tmp_path / "ds.jsonl"
+    p.write_text(
+        "\n".join(
+            [
+                '{"type":"meta","dataset_id":"x","schema_version":1}',
+                '{"type":"doc","external_id":"   ","content":"alpha"}',
+                '{"type":"query","query":"alpha","relevant_external_ids":["doc:1"]}',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="external_id must not be blank"):
+        load_eval_dataset(p)
+
+
 def test_run_retrieval_eval_rejects_non_sparse_mode() -> None:
     ds = load_eval_dataset()
     with pytest.raises(ValueError, match="sparse only"):
@@ -42,3 +133,68 @@ def test_run_retrieval_eval_max_queries_zero_raises() -> None:
     ds: EvalDataset = load_eval_dataset()
     with pytest.raises(ValueError, match="No queries"):
         run_retrieval_eval(dataset=ds, retrieval_mode="sparse", max_queries=0)
+
+
+def test_run_retrieval_eval_reports_standard_ir_metrics_for_perfect_run() -> None:
+    ds = load_eval_dataset()
+
+    def _retrieve_external_ids(query: str, top_k: int) -> tuple[str, ...]:
+        if "France" in query:
+            return ("doc:paris",)
+        if "Spain" in query:
+            return ("doc:madrid",)
+        if "Germany" in query:
+            return ("doc:berlin",)
+        if "Portugal" in query:
+            return ("doc:lisbon",)
+        if "Italy" in query:
+            return ("doc:rome",)
+        return tuple()
+
+    res = run_retrieval_eval(
+        dataset=ds,
+        retrieve_external_ids=_retrieve_external_ids,
+        retrieval_mode="sparse",
+        k=3,
+    )
+
+    assert res.ndcg_at_k == pytest.approx(1.0)
+    assert res.map_at_k == pytest.approx(1.0)
+    assert res.mrr_at_k == pytest.approx(1.0)
+    assert 0.0 <= res.precision_at_k <= 1.0
+    assert res.recall_at_k == pytest.approx(1.0)
+
+
+def test_run_retrieval_eval_filters_unknown_ids_and_deduplicates_run() -> None:
+    ds = EvalDataset(
+        dataset_id="edge",
+        schema_version=1,
+        docs=(
+            load_eval_dataset().docs[0],
+            load_eval_dataset().docs[1],
+        ),
+        queries=(
+            load_eval_dataset().queries[0],
+            load_eval_dataset().queries[1],
+        ),
+    )
+
+    def _retrieve_external_ids(query: str, top_k: int) -> tuple[str, ...]:
+        if "France" in query:
+            return ("doc:unknown", "doc:paris", "doc:paris")
+        if "Spain" in query:
+            return ("doc:paris", "doc:madrid")
+        return tuple()
+
+    res = run_retrieval_eval(
+        dataset=ds,
+        retrieve_external_ids=_retrieve_external_ids,
+        retrieval_mode="sparse",
+        k=2,
+    )
+
+    assert res.ndcg_at_k == pytest.approx(0.8154648767)
+    assert res.map_at_k == pytest.approx(0.75)
+    assert res.mrr_at_k == pytest.approx(0.75)
+    assert res.precision_at_k == pytest.approx(0.5)
+    assert res.recall_at_k == pytest.approx(1.0)

--- a/tests/unit/core/services/test_evaluation.py
+++ b/tests/unit/core/services/test_evaluation.py
@@ -149,7 +149,7 @@ def test_run_retrieval_eval_reports_standard_ir_metrics_for_perfect_run() -> Non
             return ("doc:lisbon",)
         if "Italy" in query:
             return ("doc:rome",)
-        return tuple()
+        return ()
 
     res = run_retrieval_eval(
         dataset=ds,
@@ -184,7 +184,7 @@ def test_run_retrieval_eval_filters_unknown_ids_and_deduplicates_run() -> None:
             return ("doc:unknown", "doc:paris", "doc:paris")
         if "Spain" in query:
             return ("doc:paris", "doc:madrid")
-        return tuple()
+        return ()
 
     res = run_retrieval_eval(
         dataset=ds,

--- a/uv.lock
+++ b/uv.lock
@@ -1441,6 +1441,18 @@ wheels = [
 ]
 
 [[package]]
+name = "ir-measures"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytrec-eval-terrier", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/b4/d931aa71a73353cf0b8446b3d7ce9ed789e7fe595778d7e061e86faea28d/ir_measures-0.4.3.tar.gz", hash = "sha256:869a6019efefb02dda8b77ca0f68d6d57b01fe34998a46c76425b9fbb396e827", size = 51224, upload-time = "2025-11-25T17:36:52.06Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/62/15199767ad9f1e3f793dec253ba6f662cb36e7197fc647bc844a6ecb99bf/ir_measures-0.4.3-py3-none-any.whl", hash = "sha256:3d8b3b5283e4a77df85f9f6c8a1c2c99a7421b78fa014ef97f2ddab3037d3dcf", size = 61311, upload-time = "2025-11-25T17:36:51.183Z" },
+]
+
+[[package]]
 name = "isoduration"
 version = "20.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3634,6 +3646,36 @@ wheels = [
 ]
 
 [[package]]
+name = "pytrec-eval-terrier"
+version = "0.5.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", marker = "python_full_version < '3.13'" },
+    { name = "scipy", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/96/4925a95e4865a647bc74d3bb052243d12a3c8e8a34909d7d097b5a4d08c5/pytrec_eval_terrier-0.5.10.tar.gz", hash = "sha256:eaaf20580d17b5575a233e04dab8a4cbcc01a7e45be8cf547c07f0a2bb3e7eb9", size = 18634, upload-time = "2025-10-20T16:50:18.098Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/de/7659555355381e57a73e7ba31437dc31d3df146b5cc3fb66eb032683e84e/pytrec_eval_terrier-0.5.10-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:1036735d4a12d1c92eea38a14a071168a292f8696099e90742c2c701479f010b", size = 136866, upload-time = "2025-10-20T16:50:40.054Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/d7/1cbc2d3936eec51b57e1146840eb3ccd8a9fb2debc519d7aa748f13dd724/pytrec_eval_terrier-0.5.10-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b36a2fbdccc7669c4b8aba1f6de2a661e6f2f77c10f05855eda55dda60fc88f5", size = 304025, upload-time = "2025-10-20T16:54:15.957Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/a2/84c93f0a260d0dabca007a02b206981d235c7f4b4c569ec746b5ef6d965b/pytrec_eval_terrier-0.5.10-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9e4ca19110f24922d7435cf9ef9951a61f0b575488b6a1db86081d82b88dd621", size = 1327402, upload-time = "2025-10-20T16:54:16.842Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ee/3a20da0523228f54d8b89b9a11d7ec402625086cc3167fb940e36a9e2d5b/pytrec_eval_terrier-0.5.10-cp311-cp311-win_amd64.whl", hash = "sha256:d36e9a8966560ed10bc5aeb30c5c29a53d3fe8e4ccb6ff6bb026bffb21be3fe3", size = 58558, upload-time = "2025-10-20T16:51:46.032Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ca/f0edd9df08c08c96d2f088c298cfb824c3ee816302ac1f911ecb1bfdd681/pytrec_eval_terrier-0.5.10-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e28c3c14728713cdbad165964e2d1aba96b0fc7445a5a13168b398e9bd3bbd08", size = 137179, upload-time = "2025-10-20T16:51:07.809Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/e02a14b0d3ac520849f66391f03c6783b3383fd23a19372d07a2280b815e/pytrec_eval_terrier-0.5.10-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:689ee541d72c27d14ae15cd1f11d2cb86cf9bdc880f5e8af9c5dbbdd47663d4d", size = 304845, upload-time = "2025-10-20T16:54:17.791Z" },
+    { url = "https://files.pythonhosted.org/packages/76/9c/9020b700199b09ebdfc6dbadae81641a49555c4ee21dedbe2aa98af601b5/pytrec_eval_terrier-0.5.10-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3f02118dadd3c09b71462bb26e405e49bd10fe0c60bcc169fcd31454a4256dc2", size = 1327965, upload-time = "2025-10-20T16:54:18.743Z" },
+    { url = "https://files.pythonhosted.org/packages/39/9e/6e7c2b89f52e1cebeef6c3bb47272f5bd69766ddbc6e9e5445da0c876899/pytrec_eval_terrier-0.5.10-cp312-cp312-win_amd64.whl", hash = "sha256:202e48fe24948453fe45dcd73261f9865f99cb2ff4c8a3255ac2ab4c993a64ba", size = 58641, upload-time = "2025-10-20T16:51:26.148Z" },
+    { url = "https://files.pythonhosted.org/packages/93/21/71a0dee7e2cd368237432af6bf6051ffde03370730dc1666cd39494c82a7/pytrec_eval_terrier-0.5.10-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:fcf96c33446c16de8db78e829c5279f7404ceaaf6b502bb5a6a3669b06051601", size = 137186, upload-time = "2025-10-20T16:50:22.941Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/8c/2494edf20d726bdd3ee0a20dc5ed84351c6cc6ccc17b11b474e315808762/pytrec_eval_terrier-0.5.10-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8455485f1faf6759f1be11b12c904d1c749ba5db7e2b6f414aa56e19533ce069", size = 304917, upload-time = "2025-10-20T16:54:20.486Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/51/7611546afb55548e65db35354a63b90d5fd5ea593fc64e5993088bf61415/pytrec_eval_terrier-0.5.10-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e7cc9666305281b0ca1873761dc71cd3f0863e6d759f00a12fd363aa2d558d6f", size = 1327998, upload-time = "2025-10-20T16:54:21.375Z" },
+    { url = "https://files.pythonhosted.org/packages/74/b3/20941b4dbe3b267271ed1ef80aa93b348da674aecb5d6aca8f311c4738b0/pytrec_eval_terrier-0.5.10-cp313-cp313-win_amd64.whl", hash = "sha256:9440bd4a78ee0bc5db6821d7483e962a6c494303fd26598f84f00d54cc64cdd7", size = 58631, upload-time = "2025-10-20T16:51:05.08Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/34/e3d0f75286151d97537309b3f311e1269b0194e3823038fc39054e84c3b4/pytrec_eval_terrier-0.5.10-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:70bc61b8d02e61a37ed97c088282bb0a124b58e7141cc52756512750efabacbb", size = 137320, upload-time = "2025-10-20T16:50:50.92Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/72/2c1f9fd44ed7a5657654a712e5255019d5d23ba2b3d53848da1838bfb8df/pytrec_eval_terrier-0.5.10-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d52d94803c32cadbff7fe5195b0d0d68d27393092f64207fe8250a4485d1f8d7", size = 304917, upload-time = "2025-10-20T16:54:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/66/9d/7e440de7b37dd31cd78eefe2ec1bf3e5f49db42b17b34dc8d6006ee03fc5/pytrec_eval_terrier-0.5.10-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:77950d0ce9bd960af40efede6850e7b6519400e7fda3f9313e0d0d02c247e4e2", size = 1327991, upload-time = "2025-10-20T16:54:23.76Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/94/5639d7c346935a75540c1f1798be277c161b561001f2a91ef303e3d85f10/pytrec_eval_terrier-0.5.10-cp314-cp314-win_amd64.whl", hash = "sha256:c69681fec350fa94af45dd7ef8f53f605e89f752583c814f713d7d2329435cfc", size = 60178, upload-time = "2025-10-20T16:51:50.946Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/a7/9080fe3f971397ea4447e3bda0c350225c944047ede7927c9a1f788af000/pytrec_eval_terrier-0.5.10-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:876740f3d58625058d34aaa1939be31bf253ecacd85d0d8b1089db5dd57ab127", size = 308002, upload-time = "2025-10-20T16:54:24.746Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/c9/5bf9d58cb275559211ba4af905c5a4d95f78c4b973f4186f8b22d8c0b073/pytrec_eval_terrier-0.5.10-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2ca4e624e5f2589ae75c1034ff1f38e9fc81de86314193508ac423e7ca56769c", size = 1330474, upload-time = "2025-10-20T16:54:25.569Z" },
+]
+
+[[package]]
 name = "pytz"
 version = "2025.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3794,6 +3836,7 @@ source = { editable = "." }
 dependencies = [
     { name = "click", marker = "python_full_version < '3.13'" },
     { name = "httpx", marker = "python_full_version < '3.13'" },
+    { name = "ir-measures", marker = "python_full_version < '3.13'" },
     { name = "numpy", marker = "python_full_version < '3.13'" },
     { name = "openai", marker = "python_full_version < '3.13'" },
     { name = "pydantic", marker = "python_full_version < '3.13'" },
@@ -3895,6 +3938,7 @@ requires-dist = [
     { name = "faiss-cpu", marker = "extra == 'dense'", specifier = ">=1.8.0,<2.0" },
     { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.124,<0.125" },
     { name = "httpx", specifier = ">=0.27,<0.28" },
+    { name = "ir-measures", specifier = ">=0.4,<1.0" },
     { name = "langchain-community", marker = "extra == 'loaders'", specifier = ">=0.2,<1.0" },
     { name = "numpy", specifier = ">=2.0,<2.3" },
     { name = "openai", specifier = ">=1.24,<2.0" },


### PR DESCRIPTION
## Summary

This PR upgrades `rag-eval` from ad hoc retrieval scoring to standard IR metrics powered by `ir_measures`, and tightens the eval dataset contract so evaluation is stricter and more predictable.

## What changed

- rewrote `rag-eval` on top of `ir_measures`
- replaced custom `hit_rate`/`mrr` scoring with:
  - `nDCG@k`
  - `MAP@k`
  - `MRR@k`
  - `P@k`
  - `Recall@k`
- updated `EvalResult`, CLI output, JSON output, and docs to reflect the new metrics
- simplified JSON output to expose a single `metrics` object instead of duplicated flat fields
- tightened eval dataset validation:
  - reject duplicate `doc.external_id`
  - reject blank IDs after normalization
  - reject empty `query.relevant_external_ids`
  - reject relevant IDs outside the dataset corpus
  - reject non-integer `schema_version` with an explicit error
- aligned core and app semantics so the valid corpus is defined only by `dataset.docs`
- improved CLI regression UX so it emits a single final result line instead of printing a success-looking line before failing

## Why

The previous eval path mixed product logic with ad hoc metric calculation and tolerated malformed datasets too easily.

This change makes evaluation:
- more standard
- easier to compare across retrieval changes
- safer as a quality gate
- less ambiguous for CI and manual inspection

## Notes

- `rag-eval` still supports `retrieval_mode=sparse` only in this PR
- this PR intentionally does not add backward compatibility for the old JSON result shape
- the default eval dataset format remains JSONL with `meta` / `doc` / `query` records

## Validation

Validated with targeted tests covering:
- core evaluation metrics
- app/core semantic parity
- CLI regression handling and JSON output shape
- strict dataset validation failures

Manual checks also confirmed:
- normal eval still works on the default dataset
- invalid datasets now fail during load with explicit errors
