### PR TITLE
feat(eval): add multi-mode rag-eval and native cross-repo import coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,8 +320,11 @@ rag-status
 
 
 # Offline IR evaluation with standard metrics via `ir_measures`
-# (reproducible gate; default dataset from `datasets/rag_eval_v1.jsonl`)
+# Uses an isolated local eval runtime; does not touch the main doc store or index.
 rag-eval --retrieval-mode sparse
+rag-eval --retrieval-mode dense --candidate-k 20
+rag-eval --retrieval-mode dual --dual-candidate-k 50
+rag-eval --retrieval-mode hybrid --hybrid-alpha 0.5
 ```
 
 > Retrieval mode is selected via `RETRIEVAL_MODE` (there is no `--mode` flag).

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -368,11 +368,19 @@ Evaluación offline reproducible (gate):
 
 ```bash
 rag-eval --retrieval-mode sparse
+rag-eval --retrieval-mode dense --candidate-k 20
+rag-eval --retrieval-mode dual --dual-candidate-k 50
+rag-eval --retrieval-mode hybrid --hybrid-alpha 0.5
 ```
 
 Dataset por defecto: `datasets/rag_eval_v1.jsonl` (o `RAG_EVAL_DATASET_PATH`).
 El comando reporta métricas estándar de IR a `@k` (`nDCG`, `MAP`, `MRR`, `P`, `Recall`).
+La evaluación usa un runtime local aislado y efímero; no reutiliza ni muta el índice principal.
 El dataset se valida de forma estricta: IDs duplicados, relevantes vacíos o relevantes fuera del corpus fallan al cargar.
+Los overrides de modo son explícitos:
+- `--candidate-k` sólo para `dense`
+- `--dual-candidate-k` sólo para `dual`
+- `--hybrid-alpha` sólo para `hybrid`
 
 Reranker opcional (mejora de calidad medible con `rag-eval`):
 

--- a/src/local_rag_backend/cli_commands/eval.py
+++ b/src/local_rag_backend/cli_commands/eval.py
@@ -20,11 +20,29 @@ from local_rag_backend.cli_commands.runtime import get_cli_container
 )
 @click.option(
     "--retrieval-mode",
-    type=click.Choice(["sparse"], case_sensitive=False),
+    type=click.Choice(["sparse", "dense", "dual", "hybrid"], case_sensitive=False),
     default="sparse",
     show_default=True,
 )
 @click.option("--k", type=int, default=3, show_default=True)
+@click.option(
+    "--candidate-k",
+    type=click.IntRange(1),
+    default=None,
+    help="Optional dense candidate count override.",
+)
+@click.option(
+    "--dual-candidate-k",
+    type=click.IntRange(1),
+    default=None,
+    help="Optional sparse candidate pool override for dual retrieval.",
+)
+@click.option(
+    "--hybrid-alpha",
+    type=click.FloatRange(0.0, 1.0),
+    default=None,
+    help="Optional sparse weight override for hybrid retrieval.",
+)
 @click.option("--max-queries", type=int, default=None, help="Evaluate only the first N queries.")
 @click.option("--reranker/--no-reranker", default=False, show_default=True)
 @click.option("--fail-below-ndcg", type=float, default=1.0, show_default=True)
@@ -40,6 +58,9 @@ def eval_cmd(
     dataset: Path | None,
     retrieval_mode: str,
     k: int,
+    candidate_k: int | None,
+    dual_candidate_k: int | None,
+    hybrid_alpha: float | None,
     max_queries: int | None,
     reranker: bool,
     fail_below_ndcg: float,
@@ -65,7 +86,10 @@ def eval_cmd(
             eval_retriever_factory_port=eval_bundle.eval_retriever_factory_port,
             retrieval_mode=retrieval_mode,
             k=k,
+            candidate_k=candidate_k,
             reranker_enabled=bool(reranker),
+            dual_candidate_k=dual_candidate_k,
+            hybrid_alpha=hybrid_alpha,
             reranker_candidate_k=eval_bundle.reranker_candidate_k,
             reranker_strategy=eval_bundle.reranker_strategy,
             max_queries=max_queries,

--- a/src/local_rag_backend/composition/adapters.py
+++ b/src/local_rag_backend/composition/adapters.py
@@ -10,6 +10,8 @@ This module centralizes policy decisions for:
 from __future__ import annotations
 
 import json
+import tempfile
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeVar, cast, overload
@@ -48,6 +50,7 @@ from local_rag_backend.core.ports import (
 )
 from local_rag_backend.core.services.rag_runtime import RagService
 from local_rag_backend.core.services.reranking import RerankingRetriever
+from local_rag_backend.core.services.types import EvalRetrievalConfig
 from local_rag_backend.infrastructure.concurrency.blocking import run_blocking
 from local_rag_backend.infrastructure.ingestion.loaders import (
     ChatGPTLoader,
@@ -86,7 +89,7 @@ from local_rag_backend.infrastructure.search_backends import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable, Mapping, Sequence
+    from collections.abc import Awaitable, Mapping, Sequence
 
     from local_rag_backend.core.domain.entities import Document as DomainDocument
     from local_rag_backend.core.domain.types import DocId
@@ -284,7 +287,9 @@ class _DefaultRagRuntimeFactory(RagRuntimeFactoryPort):
 
 
 class _SqlEvalStoragePort(EvalStoragePort):
-    def __init__(self) -> None:
+    def __init__(self, *, settings_obj: Settings) -> None:
+        self._temp_dir = tempfile.TemporaryDirectory(prefix="rag-eval-")
+        eval_root = Path(self._temp_dir.name)
         engine = create_engine(
             "sqlite:///:memory:",
             connect_args={"check_same_thread": False},
@@ -297,6 +302,16 @@ class _SqlEvalStoragePort(EvalStoragePort):
 
         db_base.ensure_sqlite_schema_compatible(engine_to_use=engine)
         self._doc_repo = SqlDocumentStorage(session_factory=session_local)
+        self._eval_settings = settings_obj.model_copy(
+            update={
+                "persistence_backend": "local_split",
+                "search_backend": "local_split",
+                "data_dir": eval_root,
+                "index_path": str(eval_root / "eval.index"),
+                "id_map_path": str(eval_root / "eval_id_map.json"),
+                "sqlite_url": f"sqlite:///{eval_root / 'eval.db'}",
+            }
+        )
 
     def upsert_dataset_docs(
         self,
@@ -322,32 +337,78 @@ class _SqlEvalStoragePort(EvalStoragePort):
     def get_retriever_storage(self) -> Any:
         return self._doc_repo
 
+    def get_eval_settings(self) -> Any:
+        return self._eval_settings
+
 
 @dataclass(frozen=True)
 class _DefaultEvalRetrieverFactoryPort(EvalRetrieverFactoryPort):
-    def build_sparse_retriever(
+    openai_embedder_factory: Callable[[], EmbedderPort]
+    st_embedder_factory: Callable[[str], EmbedderPort]
+    sparse_retriever_factory: Callable[..., RetrieverPort]
+    dense_retriever_factory: Callable[..., RetrieverPort]
+    hybrid_retriever_factory: Callable[..., RetrieverPort]
+    vector_repo_factory: Callable[..., Any]
+    reranker_factory: Callable[..., Any]
+
+    def build_retriever(
         self,
         *,
         storage: EvalStoragePort,
-        reranker_enabled: bool,
-        candidate_k: int,
-        strategy: str,
+        config: EvalRetrievalConfig,
+        reranker_candidate_k: int,
+        reranker_strategy: str,
     ) -> EvalRetrieverPort:
         docs = storage.list_documents()
-        corpus = [d.content for d in docs]
-        doc_ids = [d.id for d in docs]
         doc_repo = storage.get_retriever_storage()
-        base = SparseBM25Retriever(
-            documents=corpus,
-            doc_ids=doc_ids,
-            doc_repo=doc_repo,
-            preloaded_docs=docs,
+        eval_settings = storage.get_eval_settings().model_copy(
+            update={"retrieval_mode": str(config.retrieval_mode)}
         )
-        if reranker_enabled:
-            return cast(
-                "EvalRetrieverPort",
-                RerankingRetriever(base, candidate_k=candidate_k, strategy=strategy),
-            )
+        captured_embedder: dict[str, EmbedderPort] = {}
+        captured_vector_repo: dict[str, Any] = {}
+
+        def _openai_embedder_factory() -> EmbedderPort:
+            embedder = self.openai_embedder_factory()
+            captured_embedder["value"] = embedder
+            return embedder
+
+        def _st_embedder_factory(model_name: str) -> EmbedderPort:
+            embedder = self.st_embedder_factory(model_name)
+            captured_embedder["value"] = embedder
+            return embedder
+
+        def _vector_repo_factory(**kwargs: Any) -> Any:
+            vector_repo = self.vector_repo_factory(**kwargs)
+            captured_vector_repo["value"] = vector_repo
+            return vector_repo
+
+        base = build_retriever_with_default_embedder_from_settings(
+            settings_obj=eval_settings,
+            retrieval_mode=str(config.retrieval_mode),
+            doc_repo=doc_repo,
+            openai_embedder_factory=_openai_embedder_factory,
+            st_embedder_factory=_st_embedder_factory,
+            preloaded_docs=docs,
+            hybrid_alpha=config.hybrid_alpha,
+            enable_reranker=config.reranker_enabled,
+            reranker_candidate_k=reranker_candidate_k,
+            reranker_strategy=reranker_strategy,
+            sparse_retriever_factory=self.sparse_retriever_factory,
+            dense_retriever_factory=self.dense_retriever_factory,
+            hybrid_retriever_factory=self.hybrid_retriever_factory,
+            vector_repo_factory=_vector_repo_factory,
+            reranker_factory=self.reranker_factory,
+        )
+        if str(config.retrieval_mode) in {"dense", "hybrid"}:
+            vector_repo = captured_vector_repo.get("value")
+            embedder = captured_embedder.get("value")
+            if vector_repo is None or embedder is None:
+                raise RuntimeError(
+                    "Eval runtime failed to initialize vector repo/embedder for dense retrieval."
+                )
+            doc_ids = [doc.id for doc in docs]
+            embeddings = embedder.embed([doc.content for doc in docs])
+            vector_repo.rebuild(doc_ids, embeddings)
         return cast("EvalRetrieverPort", base)
 
 
@@ -494,12 +555,32 @@ def build_rag_runtime_factory(
     )
 
 
-def build_eval_storage_port() -> EvalStoragePort:
-    return _SqlEvalStoragePort()
+def build_eval_storage_port(
+    *,
+    settings_obj: Settings,
+) -> EvalStoragePort:
+    return _SqlEvalStoragePort(settings_obj=settings_obj)
 
 
-def build_eval_retriever_factory_port() -> EvalRetrieverFactoryPort:
-    return _DefaultEvalRetrieverFactoryPort()
+def build_eval_retriever_factory_port(
+    *,
+    openai_embedder_factory: Callable[[], EmbedderPort] | None = None,
+    st_embedder_factory: Callable[[str], EmbedderPort] | None = None,
+    sparse_retriever_factory: Callable[..., RetrieverPort] = SparseBM25Retriever,
+    dense_retriever_factory: Callable[..., RetrieverPort] = DenseVectorRetriever,
+    hybrid_retriever_factory: Callable[..., RetrieverPort] = HybridRetriever,
+    vector_repo_factory: Callable[..., Any] = VectorStorage,
+    reranker_factory: Callable[..., Any] = RerankingRetriever,
+) -> EvalRetrieverFactoryPort:
+    return _DefaultEvalRetrieverFactoryPort(
+        openai_embedder_factory=openai_embedder_factory or _build_default_openai_embedder,
+        st_embedder_factory=st_embedder_factory or _build_default_st_embedder,
+        sparse_retriever_factory=sparse_retriever_factory,
+        dense_retriever_factory=dense_retriever_factory,
+        hybrid_retriever_factory=hybrid_retriever_factory,
+        vector_repo_factory=vector_repo_factory,
+        reranker_factory=reranker_factory,
+    )
 
 
 def build_blocking_executor(

--- a/src/local_rag_backend/composition/container.py
+++ b/src/local_rag_backend/composition/container.py
@@ -379,10 +379,18 @@ class AppContainer:
         )
 
     def build_eval_storage_port(self) -> EvalStoragePort:
-        return build_eval_storage_port()
+        return build_eval_storage_port(settings_obj=self.settings_obj)
 
     def build_eval_retriever_factory_port(self) -> EvalRetrieverFactoryPort:
-        return build_eval_retriever_factory_port()
+        return build_eval_retriever_factory_port(
+            openai_embedder_factory=self.openai_embedder_factory,
+            st_embedder_factory=self.st_embedder_factory,
+            sparse_retriever_factory=self.sparse_retriever_factory,
+            dense_retriever_factory=self.dense_retriever_factory,
+            hybrid_retriever_factory=self.hybrid_retriever_factory,
+            vector_repo_factory=self.vector_repo_factory,
+            reranker_factory=self.reranker_factory,
+        )
 
     def build_eval_execution_bundle(self) -> EvalExecutionBundle:
         return EvalExecutionBundle(

--- a/src/local_rag_backend/core/ports/use_cases.py
+++ b/src/local_rag_backend/core/ports/use_cases.py
@@ -5,7 +5,15 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal, Protocol, TypeVar
+from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeVar, overload
+
+from local_rag_backend.core.services.types import EvalRetrievalConfig
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from local_rag_backend.core.domain.entities import Document
+    from local_rag_backend.core.domain.retrieval import RetrievalRequest, RetrievalResult
 
 BlockingTaskType = Literal["default", "mutation", "network", "eval"]
 T = TypeVar("T")
@@ -122,19 +130,29 @@ class EvalStoragePort(Protocol):
 
     def get_retriever_storage(self) -> Any: ...
 
+    def get_eval_settings(self) -> Any: ...
+
 
 class EvalRetrieverPort(Protocol):
-    def retrieve(self, query: str, k: int = 5) -> tuple[tuple[Any, ...], tuple[float, ...]]: ...
+    @overload
+    def retrieve(self, query: RetrievalRequest) -> RetrievalResult: ...
+
+    @overload
+    def retrieve(self, query: str, k: int = 5) -> tuple[Sequence[Document], Sequence[float]]: ...
+
+    def retrieve(
+        self, query: RetrievalRequest | str, k: int = 5
+    ) -> RetrievalResult | tuple[Sequence[Document], Sequence[float]]: ...
 
 
 class EvalRetrieverFactoryPort(Protocol):
-    def build_sparse_retriever(
+    def build_retriever(
         self,
         *,
         storage: EvalStoragePort,
-        reranker_enabled: bool,
-        candidate_k: int,
-        strategy: str,
+        config: EvalRetrievalConfig,
+        reranker_candidate_k: int,
+        reranker_strategy: str,
     ) -> EvalRetrieverPort: ...
 
 

--- a/src/local_rag_backend/core/services/evaluation.py
+++ b/src/local_rag_backend/core/services/evaluation.py
@@ -156,10 +156,6 @@ def run_retrieval_eval(
     # Backward-compatible kwargs retained for callers migrating from the previous
     # infra-coupled implementation where reranker wiring happened in this layer.
     _ = (reranker_candidate_k, reranker_strategy)
-    if retrieval_mode != "sparse":
-        raise ValueError(
-            "This offline IR evaluation currently supports retrieval_mode=sparse only."
-        )
     if k <= 0:
         raise ValueError("k must be positive")
 
@@ -169,7 +165,7 @@ def run_retrieval_eval(
     if not qs:
         raise ValueError("No queries to evaluate after max_queries.")
     if retrieve_external_ids is None:
-        raise ValueError("retrieve_external_ids callback is required for sparse evaluation.")
+        raise ValueError("retrieve_external_ids callback is required for offline IR evaluation.")
     known_doc_ids = {
         str(doc.external_id).strip() for doc in dataset.docs if str(doc.external_id).strip()
     }

--- a/src/local_rag_backend/core/services/types.py
+++ b/src/local_rag_backend/core/services/types.py
@@ -38,6 +38,16 @@ class EvalDataset:
 
 
 @dataclass(frozen=True)
+class EvalRetrievalConfig:
+    retrieval_mode: str
+    k: int
+    candidate_k: int | None = None
+    dual_candidate_k: int | None = None
+    hybrid_alpha: float | None = None
+    reranker_enabled: bool = False
+
+
+@dataclass(frozen=True)
 class EvalResult:
     dataset_id: str
     retrieval_mode: str

--- a/src/local_rag_backend/core/use_cases/evaluation.py
+++ b/src/local_rag_backend/core/use_cases/evaluation.py
@@ -2,6 +2,13 @@
 
 from __future__ import annotations
 
+from typing import Any
+
+from local_rag_backend.core.domain.retrieval import (
+    RetrievalRequest,
+    RetrievalResult,
+    retrieval_result_from_pairs,
+)
 from local_rag_backend.core.ports import (
     EvalDatasetDocInput,
     EvalRetrieverFactoryPort,
@@ -12,6 +19,51 @@ from local_rag_backend.core.services.evaluation import (
     EvalResult,
     run_retrieval_eval as run_retrieval_eval_core,
 )
+from local_rag_backend.core.services.types import EvalRetrievalConfig
+
+
+def _coerce_retrieval_result(
+    raw_result: Any,
+    *,
+    request: RetrievalRequest,
+) -> RetrievalResult:
+    if isinstance(raw_result, RetrievalResult):
+        return raw_result
+    if (
+        isinstance(raw_result, tuple)
+        and len(raw_result) == 2
+        and isinstance(raw_result[0], (list, tuple))
+        and isinstance(raw_result[1], (list, tuple))
+    ):
+        docs, scores = raw_result
+        return retrieval_result_from_pairs(
+            docs=docs,
+            scores=scores,
+            mode_used=request.mode,
+            backend_used="legacy_eval",
+        )
+    raise RuntimeError(f"Unsupported eval retriever response type: {type(raw_result)!r}")
+
+
+def _validate_eval_options(
+    *,
+    retrieval_mode: str,
+    candidate_k: int | None,
+    dual_candidate_k: int | None,
+    hybrid_alpha: float | None,
+) -> None:
+    if candidate_k is not None and retrieval_mode != "dense":
+        raise ValueError("--candidate-k is supported only with retrieval_mode=dense")
+    if dual_candidate_k is not None and retrieval_mode != "dual":
+        raise ValueError("--dual-candidate-k is supported only with retrieval_mode=dual")
+    if hybrid_alpha is not None and retrieval_mode != "hybrid":
+        raise ValueError("--hybrid-alpha is supported only with retrieval_mode=hybrid")
+    if candidate_k is not None and int(candidate_k) <= 0:
+        raise ValueError("candidate_k must be positive")
+    if dual_candidate_k is not None and int(dual_candidate_k) <= 0:
+        raise ValueError("dual_candidate_k must be positive")
+    if hybrid_alpha is not None and not 0.0 <= float(hybrid_alpha) <= 1.0:
+        raise ValueError("hybrid_alpha must be between 0.0 and 1.0")
 
 
 def run_retrieval_eval(
@@ -21,17 +73,24 @@ def run_retrieval_eval(
     eval_retriever_factory_port: EvalRetrieverFactoryPort,
     retrieval_mode: str = "sparse",
     k: int = 3,
+    candidate_k: int | None = None,
     reranker_enabled: bool = False,
+    dual_candidate_k: int | None = None,
+    hybrid_alpha: float | None = None,
     reranker_candidate_k: int = 20,
     reranker_strategy: str = "overlap_v1",
     max_queries: int | None = None,
 ) -> EvalResult:
-    if retrieval_mode != "sparse":
-        raise ValueError(
-            "This offline IR evaluation currently supports retrieval_mode=sparse only."
-        )
+    if retrieval_mode not in {"sparse", "dense", "dual", "hybrid"}:
+        raise ValueError(f"Unsupported retrieval_mode: {retrieval_mode}")
     if k <= 0:
         raise ValueError("k must be positive")
+    _validate_eval_options(
+        retrieval_mode=str(retrieval_mode),
+        candidate_k=candidate_k,
+        dual_candidate_k=dual_candidate_k,
+        hybrid_alpha=hybrid_alpha,
+    )
 
     eval_storage_port.upsert_dataset_docs(
         dataset_id=dataset.dataset_id,
@@ -46,18 +105,34 @@ def run_retrieval_eval(
         ),
     )
 
-    retriever = eval_retriever_factory_port.build_sparse_retriever(
+    retriever = eval_retriever_factory_port.build_retriever(
         storage=eval_storage_port,
-        reranker_enabled=reranker_enabled,
-        candidate_k=reranker_candidate_k,
-        strategy=reranker_strategy,
+        config=EvalRetrievalConfig(
+            retrieval_mode=str(retrieval_mode),
+            k=int(k),
+            candidate_k=(int(candidate_k) if candidate_k is not None else None),
+            dual_candidate_k=(int(dual_candidate_k) if dual_candidate_k is not None else None),
+            hybrid_alpha=(float(hybrid_alpha) if hybrid_alpha is not None else None),
+            reranker_enabled=bool(reranker_enabled),
+        ),
+        reranker_candidate_k=reranker_candidate_k,
+        reranker_strategy=reranker_strategy,
     )
 
     def _retrieve_external_ids(query: str, top_k: int) -> list[str]:
-        docs, _scores = retriever.retrieve(query, top_k)
+        request = RetrievalRequest(
+            query=query,
+            top_k=top_k,
+            mode=str(retrieval_mode),  # type: ignore[arg-type]
+            candidate_k=(int(candidate_k) if candidate_k is not None else None),
+            dual_candidate_k=(int(dual_candidate_k) if dual_candidate_k is not None else None),
+        )
+        retrieval = _coerce_retrieval_result(retriever.retrieve(request), request=request)
         return [
             str(external_id)
-            for external_id in (getattr(d, "external_id", None) for d in docs)
+            for external_id in (
+                getattr(document, "external_id", None) for document in retrieval.documents
+            )
             if external_id is not None and str(external_id).strip()
         ]
 

--- a/src/local_rag_backend/infrastructure/search_backends/local_split.py
+++ b/src/local_rag_backend/infrastructure/search_backends/local_split.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import math
 from collections.abc import Sequence
-from typing import overload
+from typing import Any, overload
 
 from local_rag_backend.core.domain.entities import Document
 from local_rag_backend.core.domain.retrieval import (
@@ -19,9 +19,18 @@ from local_rag_backend.core.ports import DocumentRepoPort, EmbedderPort, VectorR
 from local_rag_backend.infrastructure.retrieval.sparse_bm25 import SparseBM25Retriever
 
 
-def _doc_field_value(doc: Document, field: str) -> str | None:
+def _normalize_filter_values(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return tuple(str(item) for item in value if item is not None and str(item).strip())
+    rendered = str(value).strip()
+    return (rendered,) if rendered else ()
+
+
+def _doc_field_values(doc: Document, field: str) -> tuple[str, ...]:
     if field == "source_id":
-        return str(doc.source_id) if doc.source_id is not None else None
+        return _normalize_filter_values(doc.source_id)
     metadata = dict(doc.metadata or {})
     metadata_key = metadata_key_for_filter_field(field)
     if metadata_key is None:
@@ -30,17 +39,17 @@ def _doc_field_value(doc: Document, field: str) -> str | None:
         value = metadata
         for part in metadata_key.split("."):
             if not isinstance(value, dict):
-                return None
+                return ()
             value = value.get(part)
-    return str(value) if value is not None else None
+    return _normalize_filter_values(value)
 
 
 def _matches_filters(doc: Document, filters: Sequence[RetrievalFilter]) -> bool:
     if not filters:
         return True
     for filter_item in filters:
-        value = _doc_field_value(doc, filter_item.field)
-        if value is None or value not in filter_item.values:
+        values = _doc_field_values(doc, filter_item.field)
+        if not values or not any(value in filter_item.values for value in values):
             return False
     return True
 

--- a/tests/e2e/test_repogpt_import_flow.py
+++ b/tests/e2e/test_repogpt_import_flow.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from local_rag_backend.cli import cli
+from local_rag_backend.core.domain.retrieval import RetrievalFilter, RetrievalRequest
+from local_rag_backend.infrastructure.persistence.sql import SqlDocumentStorage
+from local_rag_backend.infrastructure.search_backends.local_split import LocalSplitSearchRetriever
+from local_rag_backend.settings import settings
+
+SYNERGY_ROOT = Path(__file__).resolve().parents[3]
+REPOGPT_ROOT = SYNERGY_ROOT / "RepoGPT"
+REPOGPT_SRC = REPOGPT_ROOT / "src"
+pytest.importorskip("structlog")
+if str(REPOGPT_SRC) not in sys.path:
+    sys.path.insert(0, str(REPOGPT_SRC))
+
+
+def _load_repogpt_types() -> tuple[type[object], type[object], type[object], type[object]]:
+    publisher_module = importlib.import_module("repogpt.adapters.publisher.code_units_publisher")
+    models_module = importlib.import_module("repogpt.models")
+    return (
+        publisher_module.CodeUnitsPublisher,
+        models_module.AnalysisConf,
+        models_module.CodeNode,
+        models_module.PipelineResult,
+    )
+
+
+def _write_repogpt_code_units(payload_path: Path) -> dict[str, object]:
+    CodeUnitsPublisher, AnalysisConf, CodeNode, PipelineResult = _load_repogpt_types()
+    sample = payload_path.parent / "sample.py"
+    sample.write_text(
+        "class Demo:\n"
+        "    def method(self, value: int) -> int:\n"
+        "        return value + 1\n"
+        "\n"
+        "def helper(name: str = 'world') -> str:\n"
+        "    return name\n",
+        encoding="utf-8",
+    )
+    method = CodeNode(
+        id="method-1",
+        type="method",
+        name="method",
+        language="py",
+        path="sample.py",
+        start_line=2,
+        end_line=3,
+        parent_id="class-1",
+    )
+    klass = CodeNode(
+        id="class-1",
+        type="class",
+        name="Demo",
+        language="py",
+        path="sample.py",
+        start_line=1,
+        end_line=3,
+        children=[method],
+    )
+    helper = CodeNode(
+        id="function-1",
+        type="function",
+        name="helper",
+        language="py",
+        path="sample.py",
+        start_line=5,
+        end_line=6,
+    )
+    root = CodeNode(
+        id="module-1",
+        type="module",
+        name="sample",
+        language="py",
+        path="sample.py",
+        start_line=1,
+        end_line=6,
+        children=[klass, helper],
+    )
+    CodeUnitsPublisher().publish(
+        [
+            PipelineResult(
+                path=sample,
+                language="py",
+                root=root,
+                file_info={
+                    "relative_path": "sample.py",
+                    "size": sample.stat().st_size,
+                    "sha256": "fixture-sha",
+                },
+                content=sample.read_text(encoding="utf-8"),
+            )
+        ],
+        AnalysisConf(repo_path=payload_path.parent, output=payload_path, emit_kind="code-units"),
+    )
+    return json.loads(payload_path.read_text(encoding="utf-8"))
+
+
+def test_repogpt_emit_code_units_imports_and_retrieves_by_queryable_metadata(
+    in_memory_sqlite, tmp_path, monkeypatch
+):
+    _ = in_memory_sqlite
+    monkeypatch.setattr(settings, "retrieval_mode", "sparse", raising=False)
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    monkeypatch.setattr(settings, "data_dir", data_dir, raising=False)
+
+    payload_path = tmp_path / "repogpt_code_units.json"
+    payload = _write_repogpt_code_units(payload_path)
+
+    assert payload["schema_version"] == "3"
+    assert payload["replace_scope"] is True
+
+    result = CliRunner().invoke(cli, ["import-canonical", "--json", str(payload_path)])
+    assert result.exit_code == 0, result.output
+
+    repo = SqlDocumentStorage()
+    docs = list(repo.get_all_documents())
+    assert docs
+
+    retriever = LocalSplitSearchRetriever(doc_repo=repo)
+    retrieval = retriever.retrieve(
+        RetrievalRequest(
+            query="helper",
+            top_k=1,
+            mode="sparse",
+            filters=(
+                RetrievalFilter(field="path", values=("sample.py",)),
+                RetrievalFilter(field="unit_type", values=("function",)),
+            ),
+        )
+    )
+
+    assert retrieval.items
+    document = retrieval.items[0].document
+    metadata = dict(document.metadata or {})
+    repo_key = str(payload["repo_key"])
+    assert document.external_id == f"repogpt:{repo_key}:sample.py:function:helper"
+    assert metadata["path"] == "sample.py"
+    assert metadata["unit_type"] == "function"
+    assert metadata["repo_key"] == repo_key
+    assert str(metadata["content_hash"]).strip()

--- a/tests/e2e/test_tr3v0r_import_flow.py
+++ b/tests/e2e/test_tr3v0r_import_flow.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from local_rag_backend.cli import cli
+from local_rag_backend.core.domain.retrieval import RetrievalFilter, RetrievalRequest
+from local_rag_backend.infrastructure.persistence.sql import SqlDocumentStorage
+from local_rag_backend.infrastructure.search_backends.local_split import LocalSplitSearchRetriever
+from local_rag_backend.settings import settings
+
+SYNERGY_ROOT = Path(__file__).resolve().parents[3]
+TR3V0R_SRC = SYNERGY_ROOT / "tr3v0r" / "src"
+pytest.importorskip("pyarrow")
+if str(TR3V0R_SRC) not in sys.path:
+    sys.path.insert(0, str(TR3V0R_SRC))
+
+
+def _load_tr3v0r_symbols() -> dict[str, object]:
+    graph_module = importlib.import_module("tr3v0r.builders.graph")
+    canonical_rag_module = importlib.import_module("tr3v0r.canonical_rag")
+    contracts_module = importlib.import_module("tr3v0r.contracts")
+    io_module = importlib.import_module("tr3v0r.io")
+    return {
+        "GroupByMac": graph_module.GroupByMac,
+        "build_net_nodes_with_index_stream": graph_module.build_net_nodes_with_index_stream,
+        "build_canonical_rag_payload": canonical_rag_module.build_canonical_rag_payload,
+        "FeatureWindowV1": contracts_module.FeatureWindowV1,
+        "GraphSnapshotV1": contracts_module.GraphSnapshotV1,
+        "NetEdgeV1": contracts_module.NetEdgeV1,
+        "write_feature_windows": io_module.write_feature_windows,
+        "write_graph_snapshots": io_module.write_graph_snapshots,
+        "write_net_edges": io_module.write_net_edges,
+        "write_net_nodes": io_module.write_net_nodes,
+    }
+
+
+def _feature_window(
+    *,
+    sensor_id: str,
+    window_start_ns: int,
+    window_end_ns: int,
+) -> object:
+    FeatureWindowV1 = _load_tr3v0r_symbols()["FeatureWindowV1"]
+    return FeatureWindowV1(
+        sensor_id=sensor_id,
+        entity_id="aa:bb:cc:dd:ee:ff",
+        phy="wifi",
+        window_start_ns=window_start_ns,
+        window_end_ns=window_end_ns,
+        window_id=f"{sensor_id}:aa:bb:cc:dd:ee:ff:{window_start_ns}",
+        frame_count=12,
+        unique_peer_count=3,
+        mgmt_frame_count=4,
+        data_frame_count=8,
+        mean_rssi_dbm=-48.5,
+        std_rssi_dbm=1.5,
+        mean_interarrival_ns=5000.0,
+        burstiness=0.42,
+        mgmt_to_data_ratio=0.5,
+        ie_entropy=1.25,
+        adv_type_entropy=None,
+        seen_on_bands=1,
+        ssid_fingerprint=101,
+        capability_fingerprint=202,
+        behavior_fingerprint=303,
+    )
+
+
+def _write_tr3v0r_payload(payload_path: Path, built_dir: Path) -> dict[str, object]:
+    symbols = _load_tr3v0r_symbols()
+    GroupByMac = symbols["GroupByMac"]
+    build_net_nodes_with_index_stream = symbols["build_net_nodes_with_index_stream"]
+    NetEdgeV1 = symbols["NetEdgeV1"]
+    GraphSnapshotV1 = symbols["GraphSnapshotV1"]
+    write_feature_windows = symbols["write_feature_windows"]
+    write_net_nodes = symbols["write_net_nodes"]
+    write_net_edges = symbols["write_net_edges"]
+    write_graph_snapshots = symbols["write_graph_snapshots"]
+    build_canonical_rag_payload = symbols["build_canonical_rag_payload"]
+    feature_windows = [
+        _feature_window(
+            sensor_id="sensor_a",
+            window_start_ns=1_000_000_000,
+            window_end_ns=2_000_000_000,
+        ),
+        _feature_window(
+            sensor_id="sensor_b",
+            window_start_ns=2_000_000_000,
+            window_end_ns=3_000_000_000,
+        ),
+    ]
+    nodes, _entity_index = build_net_nodes_with_index_stream(
+        feature_windows,
+        strategy=GroupByMac(),
+    )
+    write_feature_windows(feature_windows, built_dir / "feature_windows.parquet")
+    write_net_nodes(nodes, built_dir / "net_nodes.parquet")
+    write_net_edges(
+        [
+            NetEdgeV1(
+                edge_id="edge-1",
+                sensor_id="sensor_a",
+                src_node_id="node-client-1",
+                dst_node_id="aa:bb:cc:dd:ee:ff",
+                edge_type="wifi_data_flow",
+                window_start_ns=1_000_000_000,
+                window_end_ns=2_000_000_000,
+                window_id="node-client-1:aa:bb:cc:dd:ee:ff:1000000000",
+                frame_count=9,
+                mean_rssi_dbm=-49.0,
+                std_rssi_dbm=1.1,
+                mean_interarrival_ns=6000.0,
+                burstiness=0.12,
+                security_mismatch_flag=False,
+                anomalous_behavior_flag=False,
+            )
+        ],
+        built_dir / "net_edges.parquet",
+    )
+    write_graph_snapshots(
+        [
+            GraphSnapshotV1(
+                snapshot_id="sensor_a:1000000000:2000000000",
+                sensor_id="sensor_a",
+                window_start_ns=1_000_000_000,
+                window_end_ns=2_000_000_000,
+                node_count=2,
+                edge_count=1,
+                mean_degree=1.0,
+                max_degree=1,
+                component_count=1,
+            )
+        ],
+        built_dir / "graph_snapshots.parquet",
+    )
+    payload = build_canonical_rag_payload(
+        input_dir=built_dir,
+        dataset_key="RF Lab Demo",
+        identity_mode="mac_strict",
+    )
+    payload_path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    return payload
+
+
+def test_tr3v0r_canonical_import_preserves_net_node_sensor_ids_and_retrieves_by_membership(
+    in_memory_sqlite, tmp_path, monkeypatch
+):
+    _ = in_memory_sqlite
+    monkeypatch.setattr(settings, "retrieval_mode", "sparse", raising=False)
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    monkeypatch.setattr(settings, "data_dir", data_dir, raising=False)
+
+    built_dir = tmp_path / "built"
+    built_dir.mkdir()
+    payload_path = tmp_path / "tr3v0r_canonical.json"
+    payload = _write_tr3v0r_payload(payload_path, built_dir)
+
+    assert payload["scope"] == "tr3v0r:rf-lab-demo"
+    assert payload["replace_scope"] is True
+
+    result = CliRunner().invoke(cli, ["import-canonical", "--json", str(payload_path)])
+    assert result.exit_code == 0, result.output
+
+    repo = SqlDocumentStorage()
+    docs = list(repo.get_all_documents())
+    assert len(docs) == 6
+
+    retriever = LocalSplitSearchRetriever(doc_repo=repo)
+    retrieval = retriever.retrieve(
+        RetrievalRequest(
+            query="wifi_ap sensor_a sensor_b",
+            top_k=1,
+            mode="sparse",
+            filters=(
+                RetrievalFilter(field="metadata.doc_type", values=("net_node",)),
+                RetrievalFilter(field="metadata.sensor_ids", values=("sensor_a",)),
+            ),
+        )
+    )
+
+    assert retrieval.items
+    document = retrieval.items[0].document
+    metadata = dict(document.metadata or {})
+    assert document.external_id == "tr3v0r:rf-lab-demo:node:aa:bb:cc:dd:ee:ff"
+    assert metadata["doc_type"] == "net_node"
+    assert metadata["sensor_ids"] == ["sensor_a", "sensor_b"]

--- a/tests/unit/application/services/test_app_evaluation_service.py
+++ b/tests/unit/application/services/test_app_evaluation_service.py
@@ -1,23 +1,97 @@
 # tests/unit/app/services/test_evaluation.py
 
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
 from local_rag_backend.composition.adapters import (
     build_eval_retriever_factory_port,
     build_eval_storage_port,
 )
+from local_rag_backend.core.domain.retrieval import (
+    RetrievalRequest,
+    RetrievalResult,
+    retrieval_result_from_pairs,
+)
 from local_rag_backend.core.ports import EvalDatasetDocInput
 from local_rag_backend.core.services.evaluation import (
+    EvalDataset,
+    EvalDoc,
+    EvalQuery,
     load_eval_dataset,
     run_retrieval_eval as run_core_eval,
 )
+from local_rag_backend.core.services.types import EvalRetrievalConfig
 from local_rag_backend.core.use_cases.evaluation import run_retrieval_eval
+from local_rag_backend.settings import settings
+
+
+class DummyEmbedder:
+    dim = 2
+
+    def embed(self, texts):
+        out = []
+        for text in texts:
+            normalized = text.lower()
+            if "auth" in normalized:
+                out.append([1.0, 0.0])
+            elif "sql" in normalized:
+                out.append([0.0, 1.0])
+            else:
+                out.append([0.5, 0.5])
+        return out
+
+
+def _coerce_retrieval_result(raw_result: Any, *, request: RetrievalRequest) -> RetrievalResult:
+    if isinstance(raw_result, RetrievalResult):
+        return raw_result
+    docs, scores = raw_result
+    return retrieval_result_from_pairs(
+        docs=docs,
+        scores=scores,
+        mode_used=request.mode,
+        backend_used="legacy_test",
+    )
+
+
+def _eval_settings():
+    return settings.model_copy(
+        update={
+            "persistence_backend": "local_split",
+            "search_backend": "local_split",
+            "vector_backend": "numpy",
+            "openai_api_key": None,
+        }
+    )
+
+
+def _mode_dataset() -> EvalDataset:
+    return EvalDataset(
+        dataset_id="multi-mode",
+        schema_version=1,
+        docs=(
+            EvalDoc(external_id="doc-auth", content="auth auth guard"),
+            EvalDoc(external_id="doc-sql", content="sql sql helper"),
+        ),
+        queries=(
+            EvalQuery(query="auth", relevant_external_ids=("doc-auth",)),
+            EvalQuery(query="sql", relevant_external_ids=("doc-sql",)),
+        ),
+    )
 
 
 def test_run_retrieval_eval_app_service_passes_on_default_repo_dataset() -> None:
     ds = load_eval_dataset()
+    cfg = _eval_settings()
     res = run_retrieval_eval(
         dataset=ds,
-        eval_storage_port=build_eval_storage_port(),
-        eval_retriever_factory_port=build_eval_retriever_factory_port(),
+        eval_storage_port=build_eval_storage_port(settings_obj=cfg),
+        eval_retriever_factory_port=build_eval_retriever_factory_port(
+            st_embedder_factory=lambda _model_name: DummyEmbedder(),
+        ),
         retrieval_mode="sparse",
         reranker_enabled=True,
         reranker_candidate_k=20,
@@ -33,7 +107,8 @@ def test_run_retrieval_eval_app_service_passes_on_default_repo_dataset() -> None
 
 def test_run_retrieval_eval_app_service_matches_core_semantics() -> None:
     ds = load_eval_dataset()
-    storage = build_eval_storage_port()
+    cfg = _eval_settings()
+    storage = build_eval_storage_port(settings_obj=cfg)
     storage.upsert_dataset_docs(
         dataset_id=ds.dataset_id,
         docs=tuple(
@@ -46,18 +121,27 @@ def test_run_retrieval_eval_app_service_matches_core_semantics() -> None:
             for d in ds.docs
         ),
     )
-    retriever = build_eval_retriever_factory_port().build_sparse_retriever(
+    retriever = build_eval_retriever_factory_port(
+        st_embedder_factory=lambda _model_name: DummyEmbedder(),
+    ).build_retriever(
         storage=storage,
-        reranker_enabled=True,
-        candidate_k=20,
-        strategy="overlap_v1",
+        config=EvalRetrievalConfig(
+            retrieval_mode="sparse",
+            k=3,
+            reranker_enabled=True,
+        ),
+        reranker_candidate_k=20,
+        reranker_strategy="overlap_v1",
     )
 
     def _retrieve_external_ids(query: str, top_k: int) -> list[str]:
-        docs, _scores = retriever.retrieve(query, top_k)
+        request = RetrievalRequest(query=query, top_k=top_k, mode="sparse")
+        retrieval = _coerce_retrieval_result(retriever.retrieve(request), request=request)
         return [
             str(external_id)
-            for external_id in (getattr(d, "external_id", None) for d in docs)
+            for external_id in (
+                getattr(document, "external_id", None) for document in retrieval.documents
+            )
             if external_id is not None and str(external_id).strip()
         ]
 
@@ -70,8 +154,10 @@ def test_run_retrieval_eval_app_service_matches_core_semantics() -> None:
     )
     app_res = run_retrieval_eval(
         dataset=ds,
-        eval_storage_port=build_eval_storage_port(),
-        eval_retriever_factory_port=build_eval_retriever_factory_port(),
+        eval_storage_port=build_eval_storage_port(settings_obj=cfg),
+        eval_retriever_factory_port=build_eval_retriever_factory_port(
+            st_embedder_factory=lambda _model_name: DummyEmbedder(),
+        ),
         retrieval_mode="sparse",
         k=3,
         reranker_enabled=True,
@@ -80,3 +166,60 @@ def test_run_retrieval_eval_app_service_matches_core_semantics() -> None:
     )
 
     assert app_res == core_res
+
+
+def test_build_eval_storage_port_uses_isolated_local_paths(tmp_path: Path) -> None:
+    base = settings.model_copy(
+        update={
+            "data_dir": tmp_path / "main-data",
+            "index_path": str(tmp_path / "main.index"),
+            "id_map_path": str(tmp_path / "main_id_map.json"),
+            "sqlite_url": f"sqlite:///{tmp_path / 'main.db'}",
+            "persistence_backend": "elasticsearch",
+            "search_backend": "elasticsearch",
+        }
+    )
+
+    storage = build_eval_storage_port(settings_obj=base)
+    eval_settings = storage.get_eval_settings()
+
+    assert eval_settings.persistence_backend == "local_split"
+    assert eval_settings.search_backend == "local_split"
+    assert Path(eval_settings.index_path) != Path(base.index_path)
+    assert Path(eval_settings.id_map_path) != Path(base.id_map_path)
+    assert eval_settings.sqlite_url != base.sqlite_url
+
+
+@pytest.mark.parametrize(
+    ("retrieval_mode", "extra_kwargs"),
+    [
+        ("dense", {"candidate_k": 1}),
+        ("dual", {"dual_candidate_k": 2}),
+        ("hybrid", {"hybrid_alpha": 0.5}),
+    ],
+)
+def test_run_retrieval_eval_app_service_supports_multi_mode_runtime(
+    retrieval_mode: str,
+    extra_kwargs: dict[str, Any],
+) -> None:
+    ds = _mode_dataset()
+    cfg = _eval_settings()
+
+    res = run_retrieval_eval(
+        dataset=ds,
+        eval_storage_port=build_eval_storage_port(settings_obj=cfg),
+        eval_retriever_factory_port=build_eval_retriever_factory_port(
+            st_embedder_factory=lambda _model_name: DummyEmbedder(),
+        ),
+        retrieval_mode=retrieval_mode,
+        k=1,
+        reranker_enabled=False,
+        **extra_kwargs,
+    )
+
+    assert res.retrieval_mode == retrieval_mode
+    assert res.ndcg_at_k == pytest.approx(1.0)
+    assert res.map_at_k == pytest.approx(1.0)
+    assert res.mrr_at_k == pytest.approx(1.0)
+    assert res.precision_at_k == pytest.approx(1.0)
+    assert res.recall_at_k == pytest.approx(1.0)

--- a/tests/unit/cli/test_cli_eval.py
+++ b/tests/unit/cli/test_cli_eval.py
@@ -6,6 +6,24 @@ from pathlib import Path
 from click.testing import CliRunner
 
 from local_rag_backend.cli import cli
+from local_rag_backend.composition import factory
+from local_rag_backend.settings import settings
+
+
+class DummyEmbedder:
+    dim = 2
+
+    def embed(self, texts):
+        out = []
+        for text in texts:
+            normalized = text.lower()
+            if "auth" in normalized:
+                out.append([1.0, 0.0])
+            elif "sql" in normalized:
+                out.append([0.0, 1.0])
+            else:
+                out.append([0.5, 0.5])
+        return out
 
 
 def test_rag_eval_fails_below_threshold(tmp_path: Path) -> None:
@@ -93,3 +111,119 @@ def test_rag_eval_json_out_uses_metrics_only_shape(tmp_path: Path) -> None:
         "metrics",
     }
     assert set(payload["metrics"].keys()) == {"nDCG@1", "MAP@1", "MRR@1", "P@1", "Recall@1"}
+
+
+def test_rag_eval_dense_mode_uses_isolated_runtime_and_json_out(
+    tmp_path: Path, monkeypatch
+) -> None:
+    ds = tmp_path / "dense.jsonl"
+    json_out = tmp_path / "dense-result.json"
+    ds.write_text(
+        "\n".join(
+            [
+                '{"type":"meta","dataset_id":"x","schema_version":1}',
+                '{"type":"doc","external_id":"doc-auth","source_id":"eval","content":"auth auth"}',
+                '{"type":"doc","external_id":"doc-sql","source_id":"eval","content":"sql sql"}',
+                '{"type":"query","query":"auth","relevant_external_ids":["doc-auth"]}',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(settings, "openai_api_key", None, raising=False)
+    monkeypatch.setattr(settings, "vector_backend", "numpy", raising=False)
+    monkeypatch.setattr(
+        factory,
+        "SentenceTransformerEmbedder",
+        lambda model_name=None: DummyEmbedder(),
+        raising=True,
+    )
+    factory.reset_app_context()
+
+    r = CliRunner().invoke(
+        cli,
+        [
+            "eval",
+            "--dataset",
+            str(ds),
+            "--retrieval-mode",
+            "dense",
+            "--k",
+            "1",
+            "--candidate-k",
+            "1",
+            "--json-out",
+            str(json_out),
+        ],
+    )
+
+    assert r.exit_code == 0, r.output
+    payload = json.loads(json_out.read_text(encoding="utf-8"))
+    assert payload["retrieval_mode"] == "dense"
+    assert payload["metrics"]["nDCG@1"] == 1.0
+    factory.reset_app_context()
+
+
+def test_rag_eval_dense_mode_reports_missing_embeddings_backend_cleanly(
+    tmp_path: Path, monkeypatch
+) -> None:
+    ds = tmp_path / "dense.jsonl"
+    ds.write_text(
+        "\n".join(
+            [
+                '{"type":"meta","dataset_id":"x","schema_version":1}',
+                '{"type":"doc","external_id":"doc-auth","source_id":"eval","content":"auth auth"}',
+                '{"type":"query","query":"auth","relevant_external_ids":["doc-auth"]}',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    def _st_fail(model_name=None):
+        raise RuntimeError("backend unavailable")
+
+    monkeypatch.setattr(settings, "openai_api_key", None, raising=False)
+    monkeypatch.setattr(factory, "SentenceTransformerEmbedder", _st_fail, raising=True)
+    factory.reset_app_context()
+
+    r = CliRunner().invoke(
+        cli,
+        ["eval", "--dataset", str(ds), "--retrieval-mode", "dense", "--k", "1"],
+    )
+
+    assert r.exit_code == 1
+    assert "Dense/hybrid retrieval requires an embeddings backend" in r.output
+    factory.reset_app_context()
+
+
+def test_rag_eval_rejects_incompatible_mode_specific_flags(tmp_path: Path) -> None:
+    ds = tmp_path / "ds.jsonl"
+    ds.write_text(
+        "\n".join(
+            [
+                '{"type":"meta","dataset_id":"x","schema_version":1}',
+                '{"type":"doc","external_id":"doc:1","source_id":"eval","content":"alpha"}',
+                '{"type":"query","query":"alpha","relevant_external_ids":["doc:1"]}',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    r = CliRunner().invoke(
+        cli,
+        [
+            "eval",
+            "--dataset",
+            str(ds),
+            "--retrieval-mode",
+            "sparse",
+            "--candidate-k",
+            "5",
+        ],
+    )
+
+    assert r.exit_code == 1
+    assert "--candidate-k is supported only with retrieval_mode=dense" in r.output

--- a/tests/unit/core/services/test_evaluation.py
+++ b/tests/unit/core/services/test_evaluation.py
@@ -123,10 +123,17 @@ def test_load_eval_dataset_rejects_blank_ids_after_normalization(tmp_path: Path)
         load_eval_dataset(p)
 
 
-def test_run_retrieval_eval_rejects_non_sparse_mode() -> None:
+def test_run_retrieval_eval_allows_non_sparse_modes_when_callback_is_valid() -> None:
     ds = load_eval_dataset()
-    with pytest.raises(ValueError, match="sparse only"):
-        run_retrieval_eval(dataset=ds, retrieval_mode="dense")
+    result = run_retrieval_eval(
+        dataset=ds,
+        retrieve_external_ids=lambda _query, _top_k: (),
+        retrieval_mode="dense",
+        k=1,
+    )
+
+    assert result.retrieval_mode == "dense"
+    assert result.queries == len(ds.queries)
 
 
 def test_run_retrieval_eval_max_queries_zero_raises() -> None:

--- a/tests/unit/core/use_cases/test_characterization.py
+++ b/tests/unit/core/use_cases/test_characterization.py
@@ -74,12 +74,12 @@ def test_rag_query_list_history_entries_sync_delegates_to_crud() -> None:
 def test_evaluation_run_retrieval_eval_validates_inputs() -> None:
     dataset = SimpleNamespace(docs=[], dataset_id="d", queries=[])
 
-    with pytest.raises(ValueError, match="retrieval_mode=sparse only"):
+    with pytest.raises(ValueError, match="Unsupported retrieval_mode"):
         evaluation.run_retrieval_eval(
             dataset=dataset,
             eval_storage_port=SimpleNamespace(),
             eval_retriever_factory_port=SimpleNamespace(),
-            retrieval_mode="dense",
+            retrieval_mode="invalid",
         )
 
     with pytest.raises(ValueError, match="k must be positive"):
@@ -89,4 +89,13 @@ def test_evaluation_run_retrieval_eval_validates_inputs() -> None:
             eval_retriever_factory_port=SimpleNamespace(),
             retrieval_mode="sparse",
             k=0,
+        )
+
+    with pytest.raises(ValueError, match="candidate-k is supported only"):
+        evaluation.run_retrieval_eval(
+            dataset=dataset,
+            eval_storage_port=SimpleNamespace(),
+            eval_retriever_factory_port=SimpleNamespace(),
+            retrieval_mode="sparse",
+            candidate_k=2,
         )

--- a/tests/unit/infrastructure/search_backends/test_local_split_search.py
+++ b/tests/unit/infrastructure/search_backends/test_local_split_search.py
@@ -188,6 +188,41 @@ def test_sparse_supports_metadata_prefixed_filters():
     assert [item.document.id for item in result.items] == ["doc-node"]
 
 
+def test_sparse_supports_membership_filters_for_metadata_sequences():
+    docs = [
+        Document(
+            id="doc-node",
+            content="AP node seen by sensors alpha and beta",
+            source_id="tr3v0r:dataset:artifact:net_nodes",
+            metadata={
+                "doc_type": "net_node",
+                "sensor_ids": ["sensor-alpha", "sensor-beta"],
+            },
+        ),
+        Document(
+            id="doc-edge",
+            content="Edge observed by sensor gamma",
+            source_id="tr3v0r:dataset:artifact:net_edges",
+            metadata={"doc_type": "net_edge", "sensor_ids": ["sensor-gamma"]},
+        ),
+    ]
+    retriever = LocalSplitSearchRetriever(doc_repo=DummyDocRepo(docs), preloaded_docs=docs)
+
+    result = retriever.retrieve(
+        RetrievalRequest(
+            query="sensor",
+            top_k=2,
+            mode="sparse",
+            filters=(
+                RetrievalFilter(field="metadata.doc_type", values=("net_node",)),
+                RetrievalFilter(field="metadata.sensor_ids", values=("sensor-beta",)),
+            ),
+        )
+    )
+
+    assert [item.document.id for item in result.items] == ["doc-node"]
+
+
 def test_dense_requires_embedder_and_vector_repo():
     retriever = LocalSplitSearchRetriever(doc_repo=DummyDocRepo([]), preloaded_docs=[])
 


### PR DESCRIPTION
## Summary

This PR turns `rag-eval` into a multi-mode retrieval evaluator and adds maintained end-to-end coverage for the native `RepoGPT -> rag-prototype` and `tr3v0r -> rag-prototype` import flows.

## What changed

### Multi-mode `rag-eval`

- added support for:
  - `sparse`
  - `dense`
  - `dual`
  - `hybrid`
- reused the production retrieval composition path instead of a separate eval-only retriever stack
- introduced an isolated local eval runtime with ephemeral storage and index paths
- kept metric computation on top of `ir_measures`
- added mode-specific eval config and CLI support:
  - `--candidate-k`
  - `--dual-candidate-k`
  - `--hybrid-alpha`

### Eval hardening and UX

- validated mode-specific flags and error paths
- kept eval isolated from the main document store and vector index
- documented the official multi-mode usage in:
  - `README.md`
  - `docs/USAGE.md`

### Search semantics and native import coverage

- extended local metadata filtering so exact filters also work for sequence-valued metadata
- added maintained e2e coverage for:
  - `RepoGPT` canonical code-units import
  - `tr3v0r` canonical RF import
- verified retrieval by queryable metadata after native import

## Why

Before this change, `rag-eval` only covered the sparse path and did not exercise the same retrieval construction path used by the application.

This PR makes evaluation more representative of real retrieval behavior, while keeping it reproducible and safe by running in an isolated local runtime.

It also turns the native cross-repo ingestion paths into maintained test coverage instead of ad hoc smoke scripts.

## Notes

- eval still targets retrieval quality only; it does not evaluate generation
- the eval runtime is intentionally isolated and does not reuse the main storage or index
- backend-specific remote evaluation is out of scope for this PR

## Validation

Verified with:
- targeted unit tests for core/app/CLI eval flows
- search backend tests for metadata membership filtering
- maintained e2e tests for:
  - `RepoGPT -> rag-prototype`
  - `tr3v0r -> rag-prototype`
- lint and type checks:
  - `ruff`
  - `mypy` with project dev/server dependencies

## Commit structure

- `feat(eval): add isolated multi-mode rag-eval runtime`
- `test(search): cover metadata membership and cross-repo import flows`
- `test(eval): harden multi-mode validation and document official usage`
