### PR TITLE
feat(config): migrate runtime configuration to YAML-only

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,8 @@ repos:
     hooks:
       - id: mypy
         name: "Type check Python code (MyPy)"
-        additional_dependencies: [types-requests, types-setuptools, pydantic, pydantic-settings]
+        additional_dependencies:
+          [types-requests, types-setuptools, types-PyYAML, pydantic, pydantic-settings]
         exclude: "^tests/"
 
   # Essential File Quality Checks

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ rag-server
 ```
 
 > `rag-server` does not accept CLI flags (`--host`, `--port`, etc.). Host and port are controlled
-> exclusively via `APP_HOST` / `APP_PORT` environment variables (or `.env`).
+> exclusively via `config.yaml` (`app_host`, `app_port`).
 
 > Alternative startup (without `rag-server` wrapper):
 > `uvicorn local_rag_backend.http.main:app --reload`.
@@ -102,113 +102,16 @@ rag-server
 
 ## Configuration
 
-Default `src/local_rag_backend/settings.py` (Pydantic Settings). Overridden with environment variables or a `.env` file (case-insensitive).
+Runtime configuration lives in the repository-root `config.yaml`.
+It is the only runtime source of truth; the process fails fast if the file is missing or invalid.
+See [`config.example.yaml`](./config.example.yaml) for the canonical template.
 
-> **Security note:** when exposing this service behind a reverse proxy, keep `API_KEY` enabled and ensure the proxy sanitizes forwarding headers.
-Runtime auth guards evaluate client origin using `X-Forwarded-For` and RFC 7239 `Forwarded`; untrusted/unsanitized header chains can weaken source attribution. When `API_KEY` is unset and `PUBLIC_BIND_REQUIRES_API_KEY=true`, ambiguous forwarding chains (e.g. empty/unknown-only proxy headers) are rejected fail-closed.
-
-> `DEBUG` also tolerates common external build-style values such as `release`/`prod` and `debug`/`dev`, to avoid import-time failures when those variables leak into the shell environment.
-
-
-Key variables (non-exhaustive):
-
-| Variable                         | Default                   | Scope        | Description                                            |
-| -------------------------------- | ------------------------- | ------------ | ------------------------------------------------------ |
-| `APP_HOST`                       | `127.0.0.1`               | server       | Service host                                           |
-| `APP_PORT`                       | `8000`                    | server       | Service port                                           |
-| `DEBUG`                          | `false`                   | server       | Reload/detailed logging                                |
-| `LOG_LEVEL`                      | `INFO`                    | server       | Logging level                                          |
-| `API_KEY`                        | —                         | security     | If set, require `X-API-Key: <API_KEY>` for `/api/*` and `/metrics` |
-| `PUBLIC_BIND_REQUIRES_API_KEY`   | `true`                    | security     | Refuse unsafe public startup and reject non-local `/api/*` + `/metrics` requests when `API_KEY` is unset |
-| `CORS_ALLOW_ORIGINS`             | `[]`                      | security     | Allowed CORS origins when `DEBUG=false` (JSON list or comma-separated) |
-| `RETRIEVAL_MODE`                 | `sparse`                  | retrieval    | `sparse` \| `dense` \| `dual` \| `hybrid`              |
-| `PERSISTENCE_BACKEND`            | `local_split`             | storage      | `local_split` \| `elasticsearch`                       |
-| `SEARCH_BACKEND`                 | `local_split`             | retrieval    | `local_split` \| `elasticsearch` \| `opensearch` \| `solr` — controls query execution backend independently of persistence |
-| `DATA_DIR`                       | `data`                    | storage      | Base data directory (SQLite parent, vector index paths) |
-| `SQLITE_URL`                     | `sqlite:///./data/app.db` | storage      | SQLite URL                                             |
-| `FAQ_CSV`                        | `data/faq.csv`            | ingestion    | Bootstrap CSV path (must exist; no fallback)          |
-| `CSV_HAS_HEADER`                 | `true`                    | ingestion    | CSV has header                                         |
-| `INGEST_CHUNK_STRATEGY`          | `chars_v1`                | ingestion    | Chunking strategy identifier (deterministic)           |
-| `INGEST_CHUNKER_VERSION`         | `chars_v1`                | ingestion    | Version token included in chunk dedup hashes           |
-| `INGEST_CHUNK_CHARS`             | `1200`                    | ingestion    | Chunk size in characters (`200..8000`)                 |
-| `INGEST_CHUNK_OVERLAP`           | `200`                     | ingestion    | Chunk overlap in characters (`0..4000`, `< CHUNK_CHARS`) |
-| `INGEST_BATCH_SIZE`              | `64`                      | ingestion    | File-plans per ingestion batch (`1..512`)              |
-| `INGEST_CLEAN_LOWERCASE`         | `true`                    | ingestion    | Lowercase during ingestion preprocessing               |
-| `INGEST_CLEAN_REMOVE_HTML`       | `true`                    | ingestion    | Remove HTML tags during ingestion preprocessing        |
-| `INGEST_CLEAN_COLLAPSE_WHITESPACE` | `true`                 | ingestion    | Collapse consecutive whitespace                         |
-| `INGEST_CLEAN_STRIP`             | `true`                    | ingestion    | Strip leading/trailing whitespace                       |
-| `ST_EMBEDDING_MODEL`             | `all-MiniLM-L6-v2`        | dense/hybrid | SentenceTransformers model                             |
-| `OPENAI_EMBEDDING_MODEL`         | `text-embedding-3-small`  | OpenAI       | Embeddings model                                       |
-| `RAG_EMBEDDING_CACHE_DB`         | `DATA_DIR/embedding_cache.sqlite3` | dense/hybrid | Optional persistent embedding-cache SQLite path        |
-| `RAG_DISABLE_EMBEDDING_CACHE`    | `false`                   | dense/hybrid | Disable the content-addressed embedding cache wrapper  |
-| `VECTOR_BACKEND`                 | `auto`                    | local_split  | Vector backend selector: `auto` \| `faiss` \| `numpy` |
-| `STORAGE_PROFILE`                | _(auto)_                  | consistency  | Optional explicit storage profile (`sql_only_local`, `sql_faiss_local`, `sql_numpy_local`, `es_unified_dense`, `es_unified_hybrid`) |
-| `WRITE_LOCK_TIMEOUT_S`           | `30.0`                    | consistency  | Timeout (seconds) for multi-store write lock           |
-| `WRITE_LOCK_POLL_S`              | `0.05`                    | consistency  | Poll interval (seconds) while waiting for lock         |
-| `MUTATION_BATCH_MAX_SIZE`        | `32`                      | consistency  | Max queued mutation requests coalesced per batch cycle (`1..512`) |
-| `MUTATION_BATCH_MAX_WAIT_MS`     | `50`                      | consistency  | Coalescing wait time before draining a mutation batch (`0..5000`) |
-| `MUTATION_RECOVERY_ENABLED`      | `true`                    | consistency  | Enable startup/background replay of incomplete mutations |
-| `MUTATION_RECOVERY_INTERVAL_S`   | `30.0`                    | consistency  | Background recovery interval (seconds)                 |
-| `INDEX_PATH`                     | `data/index.faiss`        | dense/hybrid | FAISS file                                             |
-| `ID_MAP_PATH`                    | `data/id_map.json`        | dense/hybrid | FAISS ID map (JSON)                                    |
-| (derived) `index_manifest.json`  | `data/index_manifest.json`| dense/hybrid | Index manifest (model/dim/chunker) for drift detection |
-| `ES_BASE_URL`                    | —                         | elasticsearch| Elasticsearch base URL                                 |
-| `ES_API_KEY`                     | —                         | elasticsearch| Elasticsearch API key                                  |
-| `ES_USERNAME`                    | —                         | elasticsearch| Elasticsearch username                                 |
-| `ES_PASSWORD`                    | —                         | elasticsearch| Elasticsearch password                                 |
-| `ES_VERIFY_TLS`                  | `true`                    | elasticsearch| Verify TLS certificates                                |
-| `ES_REQUEST_TIMEOUT_S`           | `30.0`                    | elasticsearch| HTTP timeout for Elasticsearch                          |
-| `ES_DOCS_INDEX`                  | `rag-docs`                | elasticsearch| Documents index                                         |
-| `ES_HISTORY_INDEX`               | `rag-history`             | elasticsearch| History index                                           |
-| `ES_SYSTEM_INDEX`                | `rag-system`              | elasticsearch| System state / cache invalidation index                |
-| `ES_TOMBSTONES_INDEX`            | `rag-tombstones`          | elasticsearch| Tombstones index                                        |
-| `ES_CONTENT_FIELD`               | `content`                 | elasticsearch| Text field used for lexical retrieval                   |
-| `ES_EMBEDDING_FIELD`             | `embedding`               | elasticsearch| Dense vector field                                      |
-| `ES_HYBRID_LEXICAL_K`            | `50`                      | elasticsearch| Lexical candidate pool for hybrid                       |
-| `ES_HYBRID_VECTOR_K`             | `50`                      | elasticsearch| Vector candidate pool for hybrid                        |
-| `ENABLE_RERANKER`                | `false`                   | retrieval    | Wrap selected retriever with reranking layer           |
-| `RERANKER_CANDIDATE_K`           | `20`                      | retrieval    | Candidate set size fetched before reranking (`3..200`) |
-| `RERANKER_STRATEGY`              | `overlap_v1`              | retrieval    | Reranker strategy identifier                            |
-| `ENABLE_MONITORING`              | `false`                   | monitoring   | Enable metrics middleware and `/metrics` endpoint      |
-| `OPENAI_TOP_P`                   | `1.0`                     | OpenAI       | top-p parameter                                        |
-| `OPENROUTER_ENABLED`             | `false`                  | OpenRouter   | Enable OpenRouter proxy                                |
-| `OPENROUTER_API_KEY`             | —                        | OpenRouter   | API key                                                |
-| `OPENROUTER_BASE_URL`            | `https://openrouter.ai/api/v1` | OpenRouter | Base URL                                          |
-| `OPENROUTER_MODEL`               | `openai/gpt-4o-mini`     | OpenRouter   | Default model                                         |
-| `OPENROUTER_SITE_URL`            | —                        | OpenRouter   | Optional Referer header                                |
-| `OPENROUTER_APP_TITLE`           | —                        | OpenRouter   | Optional X-Title header                                |
-| `HYBRID_RETRIEVAL_ALPHA`         | `0.5`                     | hybrid       | Weight of the **sparse** component (0=dense, 1=sparse) |
-| `DUAL_CANDIDATE_K`               | `50`                      | dual         | Sparse candidate count fetched before dense rerank in `dual` mode (`1..1000`) |
-| `OS_BASE_URL`                    | —                         | opensearch   | OpenSearch base URL (required when `SEARCH_BACKEND=opensearch`) |
-| `OS_API_KEY`                     | —                         | opensearch   | OpenSearch API key |
-| `OS_USERNAME`                    | —                         | opensearch   | OpenSearch username |
-| `OS_PASSWORD`                    | —                         | opensearch   | OpenSearch password |
-| `OS_VERIFY_TLS`                  | `true`                    | opensearch   | Verify TLS certificates |
-| `OS_REQUEST_TIMEOUT_S`           | `30.0`                    | opensearch   | HTTP timeout (seconds) |
-| `OS_DOCS_INDEX`                  | `rag-docs`                | opensearch   | Documents index |
-| `OS_CONTENT_FIELD`               | `content`                 | opensearch   | Lexical retrieval field |
-| `OS_EMBEDDING_FIELD`             | `embedding`               | opensearch   | Dense vector field |
-| `OS_DENSE_CANDIDATE_K`           | `50`                      | opensearch   | Vector candidate pool for dense retrieval (`1..1000`) |
-| `SOLR_BASE_URL`                  | —                         | solr         | Solr base URL (required when `SEARCH_BACKEND=solr`) |
-| `SOLR_CORE`                      | `rag-docs`                | solr         | Solr core/collection for documents |
-| `SOLR_CONTENT_FIELD`             | `content`                 | solr         | Content field name |
-| `SOLR_REQUEST_TIMEOUT_S`         | `30.0`                    | solr         | HTTP timeout (seconds). Only `sparse` retrieval is supported in v1 |
-| `OPENAI_API_KEY`                 | —                         | OpenAI       | API key                                                |
-| `OPENAI_MODEL`                   | `gpt-4o-mini`             | OpenAI       | Chat model                                             |
-| `OPENAI_REQUEST_TIMEOUT`         | `60`                      | OpenAI       | Timeout (s) for OpenAI-compatible HTTP requests        |
-| `OPENAI_TEMPERATURE`             | `0.2`                     | OpenAI       | Temperature                                            |
-| `OPENAI_MAX_TOKENS`              | `256`                     | OpenAI       | Max tokens                                             |
-| `OPENAI_PROMPT_TEMPLATE`         | _(builtin template)_      | prompting    | Prompt template for OpenAI/OpenRouter generators       |
-| `OLLAMA_ENABLED`                 | `false`                   | Ollama       | Enable Ollama                                          |
-| `OLLAMA_MODEL`                   | `lfm2.5-thinking`               | Ollama       | Model served by Ollama                                 |
-| `OLLAMA_BASE_URL`                | `http://localhost:11434`  | Ollama       | Server URL                                             |
-| `OLLAMA_REQUEST_TIMEOUT`         | `180`                     | Ollama       | Timeout (s)                                            |
-| `OLLAMA_PROMPT_TEMPLATE`         | _(builtin template)_      | prompting    | Prompt template for Ollama generator                   |
+All runtime keys are shown in `snake_case` and map 1:1 to the fields in `config.yaml`.
 
 
 ### Backend matrix
 
-| `PERSISTENCE_BACKEND` | `SEARCH_BACKEND` | Retrieval modes | Canonical write model | Notes |
+| `persistence_backend` | `search_backend` | `retrieval_mode` | Canonical write model | Notes |
 | --- | --- | --- | --- | --- |
 | `local_split` | `local_split` (default) | `sparse`, `dense`, `dual`, `hybrid` | `DURABLE_SAGA` | Default standalone topology. Sparse/dual are SQLite-backed; dense/hybrid add local vector state. |
 | `local_split` | `elasticsearch` | `sparse`, `dense`, `dual` | `DURABLE_SAGA` | Remote Elasticsearch query execution over local SQL persistence. `hybrid` is rejected. |
@@ -217,13 +120,13 @@ Key variables (non-exhaustive):
 | `elasticsearch` | `elasticsearch` | `sparse`, `dense`, `dual`, `hybrid` | `ATOMIC` | Unified docs/history/vectors/system-state/tombstones in Elasticsearch. |
 | `elasticsearch` | `local_split` | `dense`, `dual`, `hybrid` | `ATOMIC` | ES-backed persistence with local_split query orchestration. Sparse is rejected. |
 | `elasticsearch` | `opensearch` | `dense`, `dual` | `ATOMIC` | ES-backed persistence with OpenSearch query execution. Sparse/hybrid are rejected. |
-| `elasticsearch` | `solr` | none | `ATOMIC` | Rejected at startup. Solr is sparse-only, but sparse is disallowed with ES persistence unless `SEARCH_BACKEND=elasticsearch`. |
+| `elasticsearch` | `solr` | none | `ATOMIC` | Rejected at startup. Solr is sparse-only, but sparse is disallowed with ES persistence unless `search_backend=elasticsearch`. |
 
 The selector in `Settings` plus `composition/adapters.py` enforce this matrix at startup.
 
 ### Index manifest (`local_split` dense/hybrid only)
 
-When `PERSISTENCE_BACKEND=local_split` and `RETRIEVAL_MODE=dense|hybrid`, the system writes an `index_manifest.json` next to `INDEX_PATH`.
+When `persistence_backend=local_split` and `retrieval_mode=dense|hybrid`, the system writes an `index_manifest.json` next to `index_path`.
 It records stable identifiers for the index build (embedding backend/model, dimension, chunker strategy/version).
 
 If you change any of these settings, `/readyz` and `rag-status` will report drift and instruct you to rebuild:
@@ -251,7 +154,7 @@ The backend matrix above is authoritative. The common runtime routes are:
   `LocalSplitSearchRetriever`-style orchestration over ES-backed persistence for `dense`/`dual`/`hybrid`.
 * `elasticsearch` + `opensearch`:
   `ElasticLikeSearchRetriever` for `dense`/`dual`.
-* If `ENABLE_RERANKER=true`, the selected retriever is wrapped as:
+* If `enable_reranker: true`, the selected retriever is wrapped as:
   `RerankingRetriever(base=<selected>)`
 
 This boundary is enforced in `composition/adapters.py` and consumed by `AppContainer`.
@@ -272,8 +175,8 @@ The ingestion process is orchestrated by `IngestionPipeline`:
 * **Sparse**: stores directly in SQLite (no embeddings required).
 * **Dense / Hybrid on `local_split`**:
   1. Save chunks in SQLite
-  2. Generate embeddings with OpenAI (if `OPENAI_API_KEY`) or SentenceTransformers (`ST_EMBEDDING_MODEL`)
-  3. Upsert into the vector index (`INDEX_PATH`, `ID_MAP_PATH`)
+  2. Generate embeddings with OpenAI (if `openai_api_key`) or SentenceTransformers (`st_embedding_model`)
+  3. Upsert into the vector index (`index_path`, `id_map_path`)
 * **Dense / Hybrid on `elasticsearch`**:
   1. Generate embeddings for changed chunks
   2. Upsert documents and embeddings atomically by `external_id`
@@ -352,7 +255,7 @@ bash ../synergy/scripts/repogpt_eval_smoke.sh
 bash ../synergy/scripts/repogpt_ingest_demo.sh --profile local_split
 ```
 
-> Retrieval mode is selected via `RETRIEVAL_MODE` (there is no `--mode` flag).
+> Retrieval mode is selected via `retrieval_mode` in `config.yaml` (there is no `--mode` flag).
 
 RepoGPT integration pack:
 
@@ -383,8 +286,7 @@ Optional: Prometheus metrics (`/metrics`) and structured-ish domain metrics:
 
 ```bash
 uv sync --frozen --extra monitoring
-# then:
-export ENABLE_MONITORING=true
+# then set `enable_monitoring: true` in config.yaml
 rag-server
 ```
 
@@ -400,8 +302,9 @@ These extras are included in `all` but are **not required** for sparse or dense 
 Optional: reranker (retrieval quality knob, measurable via `rag-eval`):
 
 ```bash
-export ENABLE_RERANKER=true
-export RERANKER_CANDIDATE_K=20
+# set these in config.yaml:
+# enable_reranker: true
+# reranker_candidate_k: 20
 ```
 
 
@@ -422,9 +325,9 @@ curl http://localhost:8000/healthz/ollama
 
 Notes:
 - Backend listens on `8000`, Ollama on `11434`.
-- Configure providers via `.env` or environment variables (see `.env.example`).
-- In `docker-compose.yml`, `OLLAMA_ENABLED=true` and `OLLAMA_BASE_URL=http://ollama:11434` are set.
-- `docker-compose.yml` defaults to `PERSISTENCE_BACKEND=local_split` and `RETRIEVAL_MODE=sparse` for a lightweight image.
+- Configure providers via `config.yaml`.
+- In `docker-compose.yml`, `ollama_enabled: true` and `ollama_base_url: http://ollama:11434` are set.
+- `docker-compose.yml` defaults to `persistence_backend: local_split` and `retrieval_mode: sparse` for a lightweight image.
 - For `local_split` dense/hybrid in compose, build backend with extras, for example:
 
 ```bash
@@ -504,7 +407,7 @@ Notes:
 * `/readyz` is stricter than `/healthz`: it returns `503` when no LLM provider is configured, even if the HTTP app and database are otherwise healthy.
 * In `local_split` dense/dual/hybrid mode, `/readyz` is intentionally strict and returns `503` when it detects missing/corrupt index files or drift between SQLite documents and the vector index.
 * In `elasticsearch` mode, `/readyz` validates backend connectivity, index existence, mapping dimensions, and embedded-document counts.
-* For public/proxy deployments, use `API_KEY` and sanitize `X-Forwarded-For` / `Forwarded` at the edge proxy.
+* For public/proxy deployments, set `api_key` in `config.yaml` and sanitize `X-Forwarded-For` / `Forwarded` at the edge proxy.
 
 Example:
 
@@ -616,15 +519,15 @@ sequenceDiagram
 
 * Synchronous LLM clients (httpx/OpenAI SDK); migration to async is straightforward but not included.
 * Minimal UI without front-end tests.
-* Minimal API-key auth is available (`API_KEY`), but there is no user/role authZ or rate limiting.
+* Minimal API-key auth is available via `api_key` in `config.yaml`, but there is no user/role authZ or rate limiting.
 * When using the FAISS backend, the index type is `IndexFlatL2` (simple). For large volumes, consider IVF/HNSW or other backends.
 
 ## Runtime considerations
 
 * **Singleton per process**: `RagService` is initialized as a singleton in `composition/factory`. With `uvicorn --workers N`, each process loads its own instance (and its retrieval/index adapters). Align deployment and warm-up as needed.
 * **Cross-process coordination files**: multi-store write lock and RAG reload token are stored in a shared coordination directory (`Settings.get_coordination_dir()`), preferring explicit `DATA_DIR`; when `DATA_DIR` is default and `SQLITE_URL` is absolute, it uses the DB parent directory to keep workers/CLI aligned.
-* **Metrics**: if `ENABLE_MONITORING=true` and `prometheus-client` is installed, `/metrics` provides Prometheus format.
-* **Dense/Hybrid**: must use the same embedding model for indexing and querying (`ST_EMBEDDING_MODEL`).
+* **Metrics**: if `enable_monitoring: true` and `prometheus-client` is installed, `/metrics` provides Prometheus format.
+* **Dense/Hybrid**: must use the same embedding model for indexing and querying (`st_embedding_model`).
 
 ## Tests
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,0 +1,143 @@
+# Canonical example runtime configuration for rag-prototype.
+# Copy this file to `config.yaml` and edit the values for your deployment.
+# Paths below are resolved relative to this file at startup.
+
+# --- Core ---
+persistence_backend: local_split
+app_host: 127.0.0.1
+app_port: 8000
+debug: false
+log_level: INFO
+enable_monitoring: false
+enable_reranker: false
+
+# --- Security / HTTP ---
+api_key: null
+public_bind_requires_api_key: true
+cors_allow_origins: []
+
+# --- Retrieval ---
+search_backend: local_split
+retrieval_mode: sparse
+vector_backend: auto
+hybrid_retrieval_alpha: 0.5
+dual_candidate_k: 50
+st_embedding_model: all-MiniLM-L6-v2
+
+# --- LLM Providers ---
+openai_api_key: null
+openai_model: gpt-4o-mini
+openai_embedding_model: text-embedding-3-small
+openai_request_timeout: 60
+openai_temperature: 0.2
+openai_top_p: 1.0
+openai_max_tokens: 256
+openrouter_enabled: false
+openrouter_api_key: null
+openrouter_base_url: https://openrouter.ai/api/v1
+openrouter_site_url: null
+openrouter_app_title: null
+ollama_enabled: false
+ollama_model: lfm2.5-thinking
+ollama_base_url: http://localhost:11434
+ollama_request_timeout: 180
+
+# --- File Paths ---
+data_dir: data
+index_path: data/index.faiss
+id_map_path: data/id_map.json
+sqlite_url: sqlite:///./data/app.db
+faq_csv: data/faq.csv
+storage_profile: ""
+eval_dataset_path: datasets/rag_eval_v1.jsonl
+embedding_cache_db_path: data/embedding_cache.sqlite3
+disable_embedding_cache: false
+synthetic_embeddings: false
+synthetic_embedding_fail_rate: 0.0
+synthetic_embedding_jitter_min_ms: 0.0
+synthetic_embedding_jitter_max_ms: 0.0
+synthetic_embedding_dim: 384
+perf_metrics_out_path: null
+lock_metrics_path: null
+blocking_workers: 8
+blocking_workers_mutation: 2
+blocking_workers_network: 4
+blocking_workers_eval: 2
+blocking_queue_default: 64
+blocking_queue_mutation: 32
+blocking_queue_network: 64
+blocking_queue_eval: 32
+write_lock_timeout_s: 30.0
+write_lock_poll_s: 0.05
+mutation_batch_max_size: 32
+mutation_batch_max_wait_ms: 50
+mutation_recovery_enabled: true
+mutation_recovery_interval_s: 30.0
+
+# --- Elasticsearch ---
+es_base_url: null
+es_api_key: null
+es_username: null
+es_password: null
+es_verify_tls: true
+es_request_timeout_s: 30.0
+es_docs_index: rag-docs
+es_history_index: rag-history
+es_system_index: rag-system
+es_tombstones_index: rag-tombstones
+es_content_field: content
+es_embedding_field: embedding
+es_hybrid_lexical_k: 50
+es_hybrid_vector_k: 50
+
+# --- OpenSearch ---
+os_base_url: null
+os_api_key: null
+os_username: null
+os_password: null
+os_verify_tls: true
+os_request_timeout_s: 30.0
+os_docs_index: rag-docs
+os_content_field: content
+os_embedding_field: embedding
+os_dense_candidate_k: 50
+
+# --- Solr ---
+solr_base_url: null
+solr_core: rag-docs
+solr_content_field: content
+solr_request_timeout_s: 30.0
+
+# --- Ingestion ---
+ingest_chunk_strategy: chars_v1
+ingest_chunker_version: chars_v1
+ingest_chunk_chars: 1200
+ingest_chunk_overlap: 200
+csv_has_header: true
+ingest_batch_size: 64
+ingest_clean_lowercase: true
+ingest_clean_remove_html: true
+ingest_clean_collapse_whitespace: true
+ingest_clean_strip: true
+
+# --- Retrieval quality ---
+reranker_strategy: overlap_v1
+reranker_candidate_k: 20
+
+# --- Prompt templates ---
+openai_prompt_template: |
+  Answer using ONLY the context provided.
+
+  CONTEXT:
+  {context}
+
+  QUESTION: {question}
+ollama_prompt_template: |
+  Based on the context, answer the question.
+  If the context is not enough, say so.
+
+  CONTEXT:
+  {context}
+
+  QUESTION:
+  {question}

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,142 @@
+# Canonical runtime configuration for rag-prototype.
+# Paths below are resolved relative to this file at startup.
+
+# --- Core ---
+persistence_backend: local_split
+app_host: 127.0.0.1
+app_port: 8000
+debug: false
+log_level: INFO
+enable_monitoring: false
+enable_reranker: false
+
+# --- Security / HTTP ---
+api_key: null
+public_bind_requires_api_key: true
+cors_allow_origins: []
+
+# --- Retrieval ---
+search_backend: local_split
+retrieval_mode: sparse
+vector_backend: auto
+hybrid_retrieval_alpha: 0.5
+dual_candidate_k: 50
+st_embedding_model: all-MiniLM-L6-v2
+
+# --- LLM Providers ---
+openai_api_key: null
+openai_model: gpt-4o-mini
+openai_embedding_model: text-embedding-3-small
+openai_request_timeout: 60
+openai_temperature: 0.2
+openai_top_p: 1.0
+openai_max_tokens: 256
+openrouter_enabled: false
+openrouter_api_key: null
+openrouter_base_url: https://openrouter.ai/api/v1
+openrouter_site_url: null
+openrouter_app_title: null
+ollama_enabled: false
+ollama_model: lfm2.5-thinking
+ollama_base_url: http://localhost:11434
+ollama_request_timeout: 180
+
+# --- File Paths ---
+data_dir: data
+index_path: data/index.faiss
+id_map_path: data/id_map.json
+sqlite_url: sqlite:///./data/app.db
+faq_csv: data/faq.csv
+storage_profile: ""
+eval_dataset_path: datasets/rag_eval_v1.jsonl
+embedding_cache_db_path: data/embedding_cache.sqlite3
+disable_embedding_cache: false
+synthetic_embeddings: false
+synthetic_embedding_fail_rate: 0.0
+synthetic_embedding_jitter_min_ms: 0.0
+synthetic_embedding_jitter_max_ms: 0.0
+synthetic_embedding_dim: 384
+perf_metrics_out_path: null
+lock_metrics_path: null
+blocking_workers: 8
+blocking_workers_mutation: 2
+blocking_workers_network: 4
+blocking_workers_eval: 2
+blocking_queue_default: 64
+blocking_queue_mutation: 32
+blocking_queue_network: 64
+blocking_queue_eval: 32
+write_lock_timeout_s: 30.0
+write_lock_poll_s: 0.05
+mutation_batch_max_size: 32
+mutation_batch_max_wait_ms: 50
+mutation_recovery_enabled: true
+mutation_recovery_interval_s: 30.0
+
+# --- Elasticsearch ---
+es_base_url: null
+es_api_key: null
+es_username: null
+es_password: null
+es_verify_tls: true
+es_request_timeout_s: 30.0
+es_docs_index: rag-docs
+es_history_index: rag-history
+es_system_index: rag-system
+es_tombstones_index: rag-tombstones
+es_content_field: content
+es_embedding_field: embedding
+es_hybrid_lexical_k: 50
+es_hybrid_vector_k: 50
+
+# --- OpenSearch ---
+os_base_url: null
+os_api_key: null
+os_username: null
+os_password: null
+os_verify_tls: true
+os_request_timeout_s: 30.0
+os_docs_index: rag-docs
+os_content_field: content
+os_embedding_field: embedding
+os_dense_candidate_k: 50
+
+# --- Solr ---
+solr_base_url: null
+solr_core: rag-docs
+solr_content_field: content
+solr_request_timeout_s: 30.0
+
+# --- Ingestion ---
+ingest_chunk_strategy: chars_v1
+ingest_chunker_version: chars_v1
+ingest_chunk_chars: 1200
+ingest_chunk_overlap: 200
+csv_has_header: true
+ingest_batch_size: 64
+ingest_clean_lowercase: true
+ingest_clean_remove_html: true
+ingest_clean_collapse_whitespace: true
+ingest_clean_strip: true
+
+# --- Retrieval quality ---
+reranker_strategy: overlap_v1
+reranker_candidate_k: 20
+
+# --- Prompt templates ---
+openai_prompt_template: |
+  Answer using ONLY the context provided.
+
+  CONTEXT:
+  {context}
+
+  QUESTION: {question}
+ollama_prompt_template: |
+  Based on the context, answer the question.
+  If the context is not enough, say so.
+
+  CONTEXT:
+  {context}
+
+  QUESTION:
+  {question}

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -29,42 +29,43 @@ Este documento describe cómo utilizar `rag-prototype` como una librería de Pyt
 
 ## Paso 1: Configuración del Entorno
 
-La librería se configura mediante variables de entorno o un archivo `.env`. Para este caso de uso, crea un archivo `.env` en la raíz de tu proyecto con la siguiente configuración:
+La librería se configura mediante un único archivo `config.yaml` en la raíz del proyecto.
+Las rutas se resuelven relativas a ese archivo, no al directorio actual.
+Toma como base `config.example.yaml` y copia el archivo a `config.yaml` antes de editarlo.
 
-```dotenv
-# .env
+```yaml
+# config.yaml
+persistence_backend: local_split
+app_host: 127.0.0.1
+app_port: 8000
+debug: false
+log_level: INFO
+enable_monitoring: false
+enable_reranker: false
 
-# Habilitar el generador de Ollama
-OLLAMA_ENABLED=True
-OLLAMA_MODEL="lfm2.5-thinking" # O el modelo que prefieras
+api_key: null
+public_bind_requires_api_key: true
+cors_allow_origins: []
 
-# Configurar el modo de recuperación (sparse, dense, dual, o hybrid)
-# Para empezar, 'sparse' es el más sencillo ya que no requiere embeddings.
-RETRIEVAL_MODE="sparse"
+search_backend: local_split
+retrieval_mode: sparse
+vector_backend: auto
+hybrid_retrieval_alpha: 0.5
+dual_candidate_k: 50
+st_embedding_model: all-MiniLM-L6-v2
 
-# Topología de persistencia:
-# - local_split: SQLite (+ soporte local para dense/dual/hybrid)
-# - elasticsearch: backend unificado; soporta sparse/dense/dual/hybrid
-PERSISTENCE_BACKEND="local_split"
-
-# Ruta de la base de datos para almacenar los documentos
-SQLITE_URL="sqlite:///./data/custom_app.db"
-
-# Si usas PERSISTENCE_BACKEND=elasticsearch:
-# ES_BASE_URL="http://localhost:9200"
-# ES_DOCS_INDEX="rag-docs"
-# ES_HISTORY_INDEX="rag-history"
-# ES_SYSTEM_INDEX="rag-system"
-# ES_TOMBSTONES_INDEX="rag-tombstones"
-
-# Opcional: ajusta los parámetros de logging
-LOG_LEVEL="INFO"
+openai_api_key: null
+ollama_enabled: true
+ollama_model: lfm2.5-thinking
+sqlite_url: sqlite:///./data/custom_app.db
+data_dir: data
+faq_csv: data/faq.csv
+eval_dataset_path: datasets/rag_eval_v1.jsonl
 ```
 
-Nota de topología: `SEARCH_BACKEND` controla el motor de consulta independientemente de `PERSISTENCE_BACKEND`.
-Los combos soportados hoy son `local_split/local_split`, `elasticsearch/elasticsearch`,
-`local_split/opensearch` y `local_split/solr`; consulta la matriz del README si necesitas
-validar `dense`, `dual` o `hybrid` antes de cambiar variables.
+Nota de topología: `search_backend` controla el motor de consulta independientemente de
+`persistence_backend`. Consulta la matriz del README para validar `dense`, `dual` o `hybrid`
+antes de cambiar valores.
 
 ## Paso 2: Implementación de un `Loader` Personalizado
 
@@ -302,8 +303,8 @@ curl -s http://localhost:8000/readyz
 ```
 
 `/healthz` solo valida disponibilidad básica del servicio. `/readyz` es más estricto y puede devolver
-`503` si no hay proveedor LLM configurado (`OPENAI_API_KEY`, `OLLAMA_ENABLED=true` u OpenRouter), aunque
-la app y SQLite estén sanos.
+`503` si no hay proveedor LLM configurado (`openai_api_key`, `ollama_enabled: true` u OpenRouter),
+aunque la app y SQLite estén sanos.
 
 ```bash
 curl -X POST "http://localhost:8000/api/docs/mutate" \
@@ -325,7 +326,7 @@ curl -X POST "http://localhost:8000/api/docs/query" \
 curl -X POST "http://localhost:8000/api/index/rebuild"
 ```
 
-Si has configurado `API_KEY`, añade `-H "X-API-Key: <API_KEY>"`. Además, por defecto las peticiones no-locales requieren API key.
+Si has configurado `api_key` en `config.yaml`, añade `-H "X-API-Key: <api_key>"`. Además, por defecto las peticiones no-locales requieren API key.
 
 ### 3) Como librería (flujo programático recomendado)
 
@@ -372,12 +373,12 @@ Monitoring mínimo (Prometheus):
 
 ```bash
 uv sync --frozen --extra server --extra monitoring
-export ENABLE_MONITORING=true
+# set `enable_monitoring: true` in config.yaml
 rag-server
 curl -s http://localhost:8000/metrics | head
 ```
 
-Si tienes `API_KEY`, añade `-H "X-API-Key: <API_KEY>"` al `curl`.
+Si tienes `api_key` en `config.yaml`, añade `-H "X-API-Key: <api_key>"` al `curl`.
 
 Evaluación offline reproducible (gate):
 
@@ -396,7 +397,7 @@ bash ../synergy/scripts/repogpt_eval_smoke.sh
 bash ../synergy/scripts/repogpt_ingest_demo.sh --profile local_split
 ```
 
-Dataset por defecto: `datasets/rag_eval_v1.jsonl` (o `RAG_EVAL_DATASET_PATH`).
+Dataset por defecto: `datasets/rag_eval_v1.jsonl` (o `eval_dataset_path` en `config.yaml`).
 El comando reporta métricas estándar de IR a `@k` (`nDCG`, `MAP`, `MRR`, `P`, `Recall`).
 La evaluación usa un runtime local aislado y efímero; no reutiliza ni muta el índice principal.
 El dataset se valida de forma estricta: IDs duplicados, relevantes vacíos o relevantes fuera del corpus fallan al cargar.
@@ -512,6 +513,7 @@ bash scripts/test_rag_eval_compare_e2e.sh
 Reranker opcional (mejora de calidad medible con `rag-eval`):
 
 ```bash
-export ENABLE_RERANKER=true
-export RERANKER_CANDIDATE_K=20
+# set these in config.yaml:
+# enable_reranker: true
+# reranker_candidate_k: 20
 ```

--- a/docs/app.md
+++ b/docs/app.md
@@ -129,4 +129,4 @@ La mutación write-enabled se hace solo por la superficie unificada (`/api/docs/
 
 ## Artefactos de evaluación
 
-El dataset de evaluación por defecto vive en `datasets/rag_eval_v1.jsonl` (raíz del repositorio), no dentro de `src/`. Puede sobreescribirse con `RAG_EVAL_DATASET_PATH`.
+El dataset de evaluación por defecto vive en `datasets/rag_eval_v1.jsonl` (raíz del repositorio), no dentro de `src/`. Puede sobreescribirse con `eval_dataset_path` en `config.yaml`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,7 +7,7 @@
 
 ## 0) TL;DR (90 seconds)
 
-- **What:** `rag-prototype` is a local-first RAG system (library + CLI + optional FastAPI transport) built as a modular monolith with hexagonal boundaries. Today it supports split-store persistence (`local_split`: SQLite + local vector index), unified persistence (`elasticsearch`), and external search adapters (`opensearch`, `solr`) controlled via `SEARCH_BACKEND`, while keeping application contracts backend-agnostic.
+- **What:** `rag-prototype` is a local-first RAG system (library + CLI + optional FastAPI transport) built as a modular monolith with hexagonal boundaries. Today it supports split-store persistence (`local_split`: SQLite + local vector index), unified persistence (`elasticsearch`), and external search adapters (`opensearch`, `solr`) controlled via `search_backend` in `config.yaml`, while keeping application contracts backend-agnostic.
 - **Why:** The immediate priority is architectural stabilization and decoupling (not feature expansion). We will accept breaking changes to eliminate structural debt now and freeze a clean first deliverable.
 - **How:**
   - Domain + ports in `core/`, adapters in `infrastructure/`, composition in `composition/`, transports in `http/` and `cli_commands/`.
@@ -49,7 +49,7 @@
 - Legal / regulatory: no special regulated-domain requirement declared for D1.
 - Budget / latency / throughput: local-first single-node operation, optional Docker; avoid infra-heavy dependencies by default.
 - Team: small maintainer set; changes must be reviewable in small increments.
-- Tech (languages, runtime, hosting): Python 3.11/3.12, `uv`, FastAPI optional extra (`server`). Current supported persistence backends are `local_split` (SQLite + local vector index) and `elasticsearch`. Active search adapters: `local_split`, `elasticsearch`, `opensearch`, `solr` (controlled via `SEARCH_BACKEND`). Architecture keeps room for future unified engines (pgvector, Qdrant) through ports.
+- Tech (languages, runtime, hosting): Python 3.11/3.12, `uv`, FastAPI optional extra (`server`). Current supported persistence backends are `local_split` (SQLite + local vector index) and `elasticsearch`. Active search adapters: `local_split`, `elasticsearch`, `opensearch`, `solr` (controlled via `search_backend` in `config.yaml`). Architecture keeps room for future unified engines (pgvector, Qdrant) through ports.
 - Product constraint: breaking changes explicitly allowed for this deliverable.
 
 ### 1.4 Quality attributes
@@ -88,7 +88,7 @@
 - **MutationRecord:** Durable journal state for multi-store writes.
 - **StorageProfile:** Capability profile (`ATOMIC`, `DURABLE_SAGA`, `READ_ONLY`) for allowed operations.
 - **Retriever mode:** `sparse`, `dense`, `dual`, `hybrid` retrieval strategy.
-- **Search backend:** `SEARCH_BACKEND` setting decouples query execution engine from persistence topology (`local_split`, `elasticsearch`, `opensearch`, `solr`).
+- **Search backend:** `search_backend` setting decouples query execution engine from persistence topology (`local_split`, `elasticsearch`, `opensearch`, `solr`).
 
 ### 2.2 Bounded contexts
 
@@ -144,9 +144,9 @@
 - Current supported backends:
   - `local_split`: relational persistence via SQLite + SQLAlchemy plus vector index via FAISS/numpy adapters on local disk.
   - `elasticsearch`: unified document/vector/history/system-state/tombstone persistence via HTTP adapter.
-  - `opensearch` (`SEARCH_BACKEND=opensearch`): OpenSearch adapter for query execution; persistence still handled by `local_split` SQL layer.
-  - `solr` (`SEARCH_BACKEND=solr`): Solr adapter for sparse (lexical) retrieval; only `RETRIEVAL_MODE=sparse` is supported in v1.
-- `SEARCH_BACKEND` decouples the query-execution engine from `PERSISTENCE_BACKEND`. When both are set to the same system (e.g. `elasticsearch`/`elasticsearch`), writes and reads are colocated; mixed configurations (e.g. `local_split` + `opensearch`) split SQL writes from remote retrieval.
+  - `opensearch` (`search_backend=opensearch`): OpenSearch adapter for query execution; persistence still handled by `local_split` SQL layer.
+  - `solr` (`search_backend=solr`): Solr adapter for sparse (lexical) retrieval; only `retrieval_mode=sparse` is supported in v1.
+- `search_backend` decouples the query-execution engine from `persistence_backend`. When both are set to the same system (e.g. `elasticsearch`/`elasticsearch`), writes and reads are colocated; mixed configurations (e.g. `local_split` + `opensearch`) split SQL writes from remote retrieval.
 - Target abstraction:
   - application uses persistence ports and capability profile, not concrete store topology;
   - supported topologies:
@@ -155,7 +155,7 @@
 - Cache: in-process runtime cache (`RagService` cache versioned via `system_state`, stored in SQLite or Elasticsearch depending on backend).
 - Files / blobs: local filesystem (`data/`, index artifacts, mutation journal).
 - Concurrency locks: OS-level file/write lock adapters in `infrastructure/concurrency/locks/{file_lock.py,write_lock.py}`.
-- Evaluation fixtures: repository-level datasets under `datasets/` (for example `datasets/rag_eval_v1.jsonl`), optionally overridden by `RAG_EVAL_DATASET_PATH`.
+- Evaluation fixtures: repository-level datasets under `datasets/` (for example `datasets/rag_eval_v1.jsonl`), optionally overridden by `eval_dataset_path` in `config.yaml`.
 
 ### 3.2 Schemas
 - SQL models: `src/local_rag_backend/infrastructure/persistence/sql/models.py`
@@ -358,7 +358,7 @@ Fase B closure (2026-03-01):
 
 ### 7.1 Public API
 - Protocol: REST + CLI + Python library usage.
-- Auth: `X-API-Key` is optional for localhost-only setups; with `PUBLIC_BIND_REQUIRES_API_KEY=true` (default), non-local requests are rejected when `API_KEY` is unset, and public bind startup without key is refused fail-closed.
+- Auth: `X-API-Key` is optional for localhost-only setups; with `public_bind_requires_api_key=true` (default), non-local requests are rejected when `api_key` is unset in `config.yaml`, and public bind startup without key is refused fail-closed.
 - Rate limiting: no explicit built-in limiter currently (must be handled by deployment edge if needed).
 - HTTP endpoints (current):
   - `/api/ask`, `/api/ask_eval`, `/api/history`
@@ -380,7 +380,7 @@ Fase B closure (2026-03-01):
 ## 8) Security, privacy, compliance
 
 - Threat model: accidental public exposure of costly/mutating endpoints.
-- Secrets management: environment variables (`.env` for local dev), never hardcoded.
+- Secrets management: `config.yaml` for runtime config, never hardcoded.
 - PII handling: avoid raw question logging; logs use hashed question fingerprint (`q_sha256`, `q_len`).
 - Log redaction: structured logs avoid full payloads by default.
 - Supply-chain:
@@ -454,7 +454,7 @@ Key mutation/UoW characterization tests:
 ## 12) Deployment & environments
 
 - Environments: local dev, CI, containerized runtime.
-- Config strategy: 12-factor with `pydantic-settings` + env vars.
+- Config strategy: single-file `config.yaml` loaded at startup, validated by Pydantic, and used as the sole runtime source of truth.
 - Migrations/compatibility:
   - SQLite compatibility ensured at startup/CLI bootstrap.
   - D1 allows breaking schema/contracts if required for decoupling.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,7 @@ dependencies = [
   "sqlalchemy>=2.0,<3.0",
   # Configuration & Validation
   "pydantic>=2.0,<3.0",
-  "pydantic-settings>=2.2,<3.0",
-  "python-dotenv>=1.0,<2.0",
+  "PyYAML>=6.0,<7.0",
   # CLI & Utilities
   "click>=8.0,<9.0",
   "rich>=13.0,<14.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ test = [
 lint = [
   "ruff>=0.4,<1.0",
   "mypy>=1.10,<2.0",
+  "types-PyYAML>=6.0.12",
   "import-linter>=2.0,<3.0",
   "pre-commit>=4.2.0,<5.0",
 ]

--- a/src/local_rag_backend/cli_commands/eval.py
+++ b/src/local_rag_backend/cli_commands/eval.py
@@ -8,6 +8,7 @@ import click
 
 from local_rag_backend.cli_commands.runtime import get_cli_container
 from local_rag_backend.core.services.types import EvalRetrievalMode
+from local_rag_backend.settings import settings
 
 
 def _is_contract_error(exc: Exception) -> bool:
@@ -63,7 +64,7 @@ def _parse_retrieval_mode_field(value: object, *, field_name: str) -> EvalRetrie
     default=None,
     help=(
         "Path to a JSONL eval dataset. If omitted, uses datasets/rag_eval_v1.jsonl "
-        "(or RAG_EVAL_DATASET_PATH)."
+        "(or eval_dataset_path in config.yaml)."
     ),
 )
 @click.option(
@@ -134,7 +135,7 @@ def eval_cmd(
 
         container = get_cli_container()
         eval_bundle = container.build_eval_execution_bundle()
-        ds = load_eval_dataset(dataset)
+        ds = load_eval_dataset(dataset if dataset is not None else settings.eval_dataset_path)
         res = run_retrieval_eval(
             dataset=ds,
             eval_storage_port=eval_bundle.eval_storage_port,
@@ -182,7 +183,7 @@ def eval_cmd(
     default=None,
     help=(
         "Path to a JSONL eval dataset. If omitted, uses datasets/rag_eval_v1.jsonl "
-        "(or RAG_EVAL_DATASET_PATH)."
+        "(or eval_dataset_path in config.yaml)."
     ),
 )
 @click.option(
@@ -249,7 +250,7 @@ def eval_batch_cmd(
 
         container = get_cli_container()
         eval_bundle = container.build_eval_execution_bundle()
-        ds = load_eval_dataset(dataset)
+        ds = load_eval_dataset(dataset if dataset is not None else settings.eval_dataset_path)
         results = run_retrieval_eval_batch(
             dataset=ds,
             eval_storage_port=eval_bundle.eval_storage_port,
@@ -283,7 +284,7 @@ def eval_batch_cmd(
     default=None,
     help=(
         "Path to a JSONL eval dataset. If omitted, uses datasets/rag_eval_v1.jsonl "
-        "(or RAG_EVAL_DATASET_PATH)."
+        "(or eval_dataset_path in config.yaml)."
     ),
 )
 @click.option("--k", type=int, default=3, show_default=True)
@@ -359,7 +360,7 @@ def eval_compare_cmd(
 
         container = get_cli_container()
         eval_bundle = container.build_eval_execution_bundle()
-        ds = load_eval_dataset(dataset)
+        ds = load_eval_dataset(dataset if dataset is not None else settings.eval_dataset_path)
         result = compare_retrieval_eval(
             dataset=ds,
             eval_storage_port=eval_bundle.eval_storage_port,

--- a/src/local_rag_backend/cli_commands/index.py
+++ b/src/local_rag_backend/cli_commands/index.py
@@ -21,7 +21,7 @@ def rebuild_index_cmd() -> None:
 
         container = get_cli_container()
         if container.settings_obj.retrieval_mode not in ("dense", "dual", "hybrid"):
-            raise RuntimeError("rebuild-index requires RETRIEVAL_MODE=dense|dual|hybrid")
+            raise RuntimeError("rebuild-index requires retrieval_mode=dense|dual|hybrid")
         ports = container.index_mutation_ports(
             build_embedder=build_dense_embedder,
         )

--- a/src/local_rag_backend/composition/adapters.py
+++ b/src/local_rag_backend/composition/adapters.py
@@ -116,7 +116,7 @@ T = TypeVar("T")
 
 DEFAULT_DENSE_BACKEND_MESSAGE = (
     "Dense/hybrid retrieval requires an embeddings backend. "
-    "Either set OPENAI_API_KEY to use OpenAI embeddings, or install the "
+    "Configure openai_api_key in config.yaml to use OpenAI embeddings, or install the "
     "'dense-st' extra for SentenceTransformers (e.g. `uv sync --extra dense-st`)."
 )
 
@@ -820,8 +820,10 @@ def build_dense_embedder_from_settings(
     return ContentAddressedCachingEmbedder(
         base=base,
         cache_db_path=resolve_embedding_cache_db_path(
-            data_dir=Path(getattr(settings_obj, "data_dir", "data"))
+            data_dir=Path(getattr(settings_obj, "data_dir", "data")),
+            configured_path=getattr(settings_obj, "embedding_cache_db_path", None),
         ),
+        disabled=bool(getattr(settings_obj, "disable_embedding_cache", False)),
     )
 
 
@@ -880,8 +882,8 @@ def resolve_preferred_llm_provider(*, settings_obj: Settings) -> str:
     ):
         return "openrouter"
     raise LLMConfigurationError(
-        "No LLM configured. Set OPENAI_API_KEY, enable OLLAMA_ENABLED, "
-        "or set OPENROUTER_ENABLED=true with OPENROUTER_API_KEY."
+        "No LLM configured. Set openai_api_key in config.yaml, enable ollama_enabled, "
+        "or enable openrouter_enabled with openrouter_api_key."
     )
 
 
@@ -913,14 +915,14 @@ def build_retriever_from_settings(
         and search_backend != "elasticsearch"
     ):
         raise ValueError(
-            "PERSISTENCE_BACKEND=elasticsearch supports retrieval_mode=sparse only when "
-            "SEARCH_BACKEND=elasticsearch"
+            "persistence_backend=elasticsearch supports retrieval_mode=sparse only when "
+            "search_backend=elasticsearch"
         )
     if search_backend == "solr" and mode in {"dense", "dual"}:
-        raise ValueError("SEARCH_BACKEND=solr supports only retrieval_mode=sparse in v1")
+        raise ValueError("search_backend=solr supports only retrieval_mode=sparse in v1")
     if mode == "hybrid" and search_backend not in {"local_split", "elasticsearch"}:
         raise ValueError(
-            "retrieval_mode=hybrid is supported only with SEARCH_BACKEND=local_split|elasticsearch"
+            "retrieval_mode=hybrid is supported only with search_backend=local_split|elasticsearch"
         )
     if (
         mode == "hybrid"
@@ -928,8 +930,8 @@ def build_retriever_from_settings(
         and persistence_backend != "elasticsearch"
     ):
         raise ValueError(
-            "retrieval_mode=hybrid with SEARCH_BACKEND=elasticsearch requires "
-            "PERSISTENCE_BACKEND=elasticsearch"
+            "retrieval_mode=hybrid with search_backend=elasticsearch requires "
+            "persistence_backend=elasticsearch"
         )
 
     retriever: RetrieverPort

--- a/src/local_rag_backend/composition/container.py
+++ b/src/local_rag_backend/composition/container.py
@@ -270,13 +270,13 @@ class AppContainer:
             "dense",
             "dual",
         }:
-            errors.append("SEARCH_BACKEND=solr supports only retrieval_mode=sparse in v1")
+            errors.append("search_backend=solr supports only retrieval_mode=sparse in v1")
         if config.retrieval_mode == "hybrid" and self.settings_obj.search_backend not in {
             "local_split",
             "elasticsearch",
         }:
             errors.append(
-                "retrieval_mode=hybrid is supported only with SEARCH_BACKEND=local_split|elasticsearch"
+                "retrieval_mode=hybrid is supported only with search_backend=local_split|elasticsearch"
             )
         if (
             config.retrieval_mode == "hybrid"
@@ -284,8 +284,8 @@ class AppContainer:
             and self.settings_obj.persistence_backend != "elasticsearch"
         ):
             errors.append(
-                "retrieval_mode=hybrid with SEARCH_BACKEND=elasticsearch requires "
-                "PERSISTENCE_BACKEND=elasticsearch"
+                "retrieval_mode=hybrid with search_backend=elasticsearch requires "
+                "persistence_backend=elasticsearch"
             )
         if config.prompt_template is not None:
             try:

--- a/src/local_rag_backend/core/services/evaluation.py
+++ b/src/local_rag_backend/core/services/evaluation.py
@@ -7,7 +7,6 @@ Focus: reproducible retrieval metrics without requiring an LLM provider.
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -29,13 +28,8 @@ from local_rag_backend.core.services.types import (
     EvalRetrievalMode,
 )
 
-_EVAL_DATASET_ENV = "RAG_EVAL_DATASET_PATH"
-
 
 def _default_eval_dataset_path() -> Path:
-    env = str(os.getenv(_EVAL_DATASET_ENV, "")).strip()
-    if env:
-        return Path(env)
     # src/local_rag_backend/core/services/evaluation.py -> repo root
     return Path(__file__).resolve().parents[4] / "datasets" / "rag_eval_v1.jsonl"
 
@@ -55,7 +49,8 @@ def load_eval_dataset(path: str | Path | None = None) -> EvalDataset:
         p = _default_eval_dataset_path()
         if not p.is_file():
             raise FileNotFoundError(
-                f"Default eval dataset not found: {p}. Set RAG_EVAL_DATASET_PATH or pass --dataset."
+                f"Default eval dataset not found: {p}. Pass --dataset or configure "
+                "eval_dataset_path in config.yaml."
             )
         content = p.read_text(encoding="utf-8")
     else:

--- a/src/local_rag_backend/http/routers/openrouter.py
+++ b/src/local_rag_backend/http/routers/openrouter.py
@@ -50,7 +50,7 @@ async def openrouter_generate(
         and getattr(settings_obj, "openrouter_api_key", None)
     ):
         raise BadRequestError(
-            detail="OpenRouter is not configured (set OPENROUTER_ENABLED and OPENROUTER_API_KEY)",
+            detail="OpenRouter is not configured (set openrouter_enabled and openrouter_api_key in config.yaml)",
         )
 
     service_payload = OpenRouterServiceRequest(

--- a/src/local_rag_backend/infrastructure/concurrency/blocking.py
+++ b/src/local_rag_backend/infrastructure/concurrency/blocking.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import asyncio
 import atexit
 import functools
-import os
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -19,6 +18,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast
 
 from local_rag_backend.infrastructure.observability.telemetry import get_telemetry
+from local_rag_backend.settings import settings
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -57,26 +57,21 @@ def _parse_positive_int(raw: str | None, *, fallback: int) -> int:
 
 def _default_workers() -> int:
     # Keep conservative by default; these tasks can involve network I/O and CPU.
-    return _parse_positive_int(
-        os.getenv("RAG_BLOCKING_WORKERS"), fallback=_DEFAULT_WORKERS_BY_TASK["default"]
-    )
+    return _parse_positive_int(str(getattr(settings, "blocking_workers", "")), fallback=_DEFAULT_WORKERS_BY_TASK["default"])
 
 
 def _workers_for_task(task_type: BlockingTaskType) -> int:
-    env_name = f"RAG_BLOCKING_WORKERS_{task_type.upper()}"
-    raw = os.getenv(env_name)
-    if raw is not None:
-        return _parse_positive_int(raw, fallback=_DEFAULT_WORKERS_BY_TASK[task_type])
     if task_type == "default":
         return _default_workers()
+    configured = getattr(settings, f"blocking_workers_{task_type}", None)
+    if configured is not None:
+        return _parse_positive_int(str(configured), fallback=_DEFAULT_WORKERS_BY_TASK[task_type])
     return _DEFAULT_WORKERS_BY_TASK[task_type]
 
 
 def _queue_limit_for_task(task_type: BlockingTaskType) -> int:
-    env_name = f"RAG_BLOCKING_QUEUE_{task_type.upper()}"
-    return _parse_positive_int(
-        os.getenv(env_name), fallback=_DEFAULT_QUEUE_LIMIT_BY_TASK[task_type]
-    )
+    configured = getattr(settings, f"blocking_queue_{task_type}", None)
+    return _parse_positive_int(str(configured), fallback=_DEFAULT_QUEUE_LIMIT_BY_TASK[task_type])
 
 
 def _parse_task_type(task_type: str) -> BlockingTaskType:

--- a/src/local_rag_backend/infrastructure/concurrency/blocking.py
+++ b/src/local_rag_backend/infrastructure/concurrency/blocking.py
@@ -57,7 +57,9 @@ def _parse_positive_int(raw: str | None, *, fallback: int) -> int:
 
 def _default_workers() -> int:
     # Keep conservative by default; these tasks can involve network I/O and CPU.
-    return _parse_positive_int(str(getattr(settings, "blocking_workers", "")), fallback=_DEFAULT_WORKERS_BY_TASK["default"])
+    return _parse_positive_int(
+        str(getattr(settings, "blocking_workers", "")), fallback=_DEFAULT_WORKERS_BY_TASK["default"]
+    )
 
 
 def _workers_for_task(task_type: BlockingTaskType) -> int:

--- a/src/local_rag_backend/infrastructure/concurrency/locks/write_lock.py
+++ b/src/local_rag_backend/infrastructure/concurrency/locks/write_lock.py
@@ -24,7 +24,6 @@ if TYPE_CHECKING:
 
 _LOCAL_WRITE_LOCK = threading.RLock()
 _THREAD_STATE = threading.local()
-_LOCK_METRICS_PATH_ENV = "RAG_LOCK_METRICS_PATH"
 
 
 def _exclusive_file_lock(
@@ -48,7 +47,7 @@ def _record_lock_event(
     wait_s: float | None = None,
     hold_s: float | None = None,
 ) -> None:
-    metrics_path = str(os.getenv(_LOCK_METRICS_PATH_ENV, "")).strip()
+    metrics_path = str(getattr(settings, "lock_metrics_path", "") or "").strip()
     if not metrics_path:
         return
     payload: dict[str, float | int | str] = {

--- a/src/local_rag_backend/infrastructure/embeddings/cached.py
+++ b/src/local_rag_backend/infrastructure/embeddings/cached.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
 import sqlite3
 import time
 from collections.abc import Mapping, Sequence
@@ -30,10 +29,11 @@ def resolve_embedding_model_key(embedder: EmbedderPort) -> str:
     return f"{backend}:{model}:{int(embedder.dim)}"
 
 
-def resolve_embedding_cache_db_path(*, data_dir: Path) -> Path:
-    override = str(os.getenv("RAG_EMBEDDING_CACHE_DB", "")).strip()
-    if override:
-        return Path(override)
+def resolve_embedding_cache_db_path(
+    *, data_dir: Path, configured_path: str | Path | None = None
+) -> Path:
+    if configured_path is not None and str(configured_path).strip():
+        return Path(configured_path)
     return data_dir / "embedding_cache.sqlite3"
 
 
@@ -99,15 +99,16 @@ class ContentAddressedCachingEmbedder(EmbedderPort):
 
     dim: int
 
-    def __init__(self, *, base: EmbedderPort, cache_db_path: Path) -> None:
+    def __init__(
+        self,
+        *,
+        base: EmbedderPort,
+        cache_db_path: Path,
+        disabled: bool = False,
+    ) -> None:
         self._base = base
         self._cache = _SqliteEmbeddingCache(cache_db_path)
-        self._disabled = str(os.getenv("RAG_DISABLE_EMBEDDING_CACHE", "")).strip().lower() in {
-            "1",
-            "true",
-            "yes",
-            "on",
-        }
+        self._disabled = bool(disabled)
         self.dim = base.dim
         self.model_key = resolve_embedding_model_key(base)
 

--- a/src/local_rag_backend/infrastructure/embeddings/cached.py
+++ b/src/local_rag_backend/infrastructure/embeddings/cached.py
@@ -74,7 +74,9 @@ class _SqliteEmbeddingCache:
                 """,
                 [model_key, json.dumps(hashes)],
             ).fetchall()
-        return {str(content_sha): list(json.loads(vector_json)) for content_sha, vector_json in rows}
+        return {
+            str(content_sha): list(json.loads(vector_json)) for content_sha, vector_json in rows
+        }
 
     def put_many(self, *, model_key: str, vectors_by_hash: Mapping[str, Sequence[float]]) -> None:
         rows = [
@@ -159,7 +161,10 @@ class ContentAddressedCachingEmbedder(EmbedderPort):
                 )
                 cached.update(miss_vectors)
 
-            return cast("Sequence[Embedding]", [list(cached[content_sha]) for content_sha in hashes_in_order])
+            return cast(
+                "Sequence[Embedding]",
+                [list(cached[content_sha]) for content_sha in hashes_in_order],
+            )
         except Exception:
             record_embedding_cache_error()
             return self._base.embed(texts_list)

--- a/src/local_rag_backend/infrastructure/embeddings/sentence_transformers.py
+++ b/src/local_rag_backend/infrastructure/embeddings/sentence_transformers.py
@@ -6,7 +6,6 @@ SentenceTransformer embedder (CPU-friendly).
 from __future__ import annotations
 
 import hashlib
-import os
 import random
 import time
 from collections.abc import Sequence
@@ -14,6 +13,7 @@ from typing import cast
 
 from local_rag_backend.core.errors import LLMResponseError, LLMTimeoutError
 from local_rag_backend.core.ports import EmbedderPort
+from local_rag_backend.settings import settings
 
 Embedding = Sequence[float]
 
@@ -23,25 +23,16 @@ class SentenceTransformerEmbedder(EmbedderPort):
 
     def __init__(self, model_name: str = "all-MiniLM-L6-v2"):
         self.model_name = model_name
-        self._synthetic = str(os.getenv("RAG_SYNTHETIC_EMBEDDINGS", "")).strip().lower() in {
-            "1",
-            "true",
-            "yes",
-            "on",
-        }
+        self._synthetic = bool(settings.synthetic_embeddings)
         # nosec S311: intentional non-cryptographic RNG for synthetic stress-mode jitter/failures.
         self._rng = random.Random()  # noqa: S311
-        self._fail_rate = max(
-            0.0, min(1.0, float(os.getenv("RAG_SYNTHETIC_EMBEDDING_FAIL_RATE", "0.0")))
-        )
-        self._jitter_min_ms = max(
-            0.0, float(os.getenv("RAG_SYNTHETIC_EMBEDDING_JITTER_MIN_MS", "0.0"))
-        )
+        self._fail_rate = max(0.0, min(1.0, float(settings.synthetic_embedding_fail_rate)))
+        self._jitter_min_ms = max(0.0, float(settings.synthetic_embedding_jitter_min_ms))
         self._jitter_max_ms = max(
             self._jitter_min_ms,
-            float(os.getenv("RAG_SYNTHETIC_EMBEDDING_JITTER_MAX_MS", str(self._jitter_min_ms))),
+            float(settings.synthetic_embedding_jitter_max_ms),
         )
-        self.dim = int(os.getenv("RAG_SYNTHETIC_EMBEDDING_DIM", "384"))
+        self.dim = int(settings.synthetic_embedding_dim)
         self.model = None
 
         if self._synthetic:
@@ -52,7 +43,7 @@ class SentenceTransformerEmbedder(EmbedderPort):
         except ImportError as e:  # pragma: no cover
             raise RuntimeError(
                 "sentence-transformers is not installed. Install the 'dense-st' extra "
-                "(e.g. `uv sync --extra dense-st`) or switch RETRIEVAL_MODE=sparse."
+                "(e.g. `uv sync --extra dense-st`) or switch retrieval_mode=sparse."
             ) from e
 
         self.model = SentenceTransformer(model_name)

--- a/src/local_rag_backend/infrastructure/observability/perf.py
+++ b/src/local_rag_backend/infrastructure/observability/perf.py
@@ -82,10 +82,14 @@ def snapshot_perf_metrics() -> dict[str, Any]:
     embed_seconds = float(cache["embed_seconds"])
     cache["hit_rate"] = round((hits / lookups), 6) if lookups else 0.0
     cache["avg_embed_seconds"] = round((embed_seconds / embedded), 6) if embedded else 0.0
-    cache["estimated_saved_embed_seconds"] = round(
-        (embed_seconds / embedded) * hits,
-        6,
-    ) if embedded and hits else 0.0
+    cache["estimated_saved_embed_seconds"] = (
+        round(
+            (embed_seconds / embedded) * hits,
+            6,
+        )
+        if embedded and hits
+        else 0.0
+    )
     return payload
 
 

--- a/src/local_rag_backend/infrastructure/observability/perf.py
+++ b/src/local_rag_backend/infrastructure/observability/perf.py
@@ -11,6 +11,8 @@ from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
+from local_rag_backend.settings import settings
+
 _LOCK = threading.Lock()
 _STATE: dict[str, Any] = {
     "embedding_cache": {
@@ -139,7 +141,7 @@ def _merge_process_metrics(path: Path, payload: dict[str, Any]) -> None:
 
 
 def dump_perf_metrics_if_configured() -> None:
-    output = str(os.getenv("RAG_PERF_METRICS_OUT", "")).strip()
+    output = str(getattr(settings, "perf_metrics_out_path", "") or "").strip()
     if not output:
         return
     payload = {

--- a/src/local_rag_backend/infrastructure/search_backends/solr.py
+++ b/src/local_rag_backend/infrastructure/search_backends/solr.py
@@ -72,7 +72,7 @@ class SolrSearchRetriever:
 
     def retrieve(self, request: RetrievalRequest) -> RetrievalResult:
         if request.mode != "sparse":
-            raise ValueError("SEARCH_BACKEND=solr supports only retrieval_mode=sparse in v1")
+            raise ValueError("search_backend=solr supports only retrieval_mode=sparse in v1")
         params: list[tuple[str, str | int | float | bool | None]] = [
             ("q", request.query),
             ("df", self._content_field),

--- a/src/local_rag_backend/settings.py
+++ b/src/local_rag_backend/settings.py
@@ -2,14 +2,9 @@
 """
 Configuration management for Intrinsical RAG Prototype.
 
-This module provides centralized configuration using Pydantic Settings with
-environment variable support and validation. All settings can be overridden
-via environment variables or .env file.
-
-Example:
-    export OPENAI_API_KEY=\"your-key-here\"
-    export RETRIEVAL_MODE=\"hybrid\"
-    python -m local_rag_backend.http.main
+This module provides centralized configuration using a YAML file as the single
+runtime source of truth. The YAML payload is loaded at startup and validated
+through a Pydantic model.
 """
 
 from __future__ import annotations
@@ -19,11 +14,68 @@ from contextlib import suppress
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import Field, ValidationInfo, field_validator, model_validator
-from pydantic_settings import BaseSettings, SettingsConfigDict
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator, model_validator
+
+DEFAULT_CONFIG_PATH = Path("config.yaml")
 
 
-class Settings(BaseSettings):
+def _resolve_relative_path_value(value: Any, *, base_dir: Path) -> str | None:
+    if value is None:
+        return None
+    path = Path(value).expanduser()
+    path = (base_dir / path).resolve() if not path.is_absolute() else path.resolve()
+    return str(path)
+
+
+def _resolve_sqlite_url_value(value: Any, *, base_dir: Path) -> str | None:
+    if value is None:
+        return None
+    rendered = str(value).strip()
+    prefix = "sqlite:///"
+    if not rendered.startswith(prefix):
+        return rendered
+    raw_path = rendered[len(prefix) :]
+    if not raw_path:
+        return rendered
+    path = Path(raw_path).expanduser()
+    if path.is_absolute():
+        return f"{prefix}{path}"
+    resolved = (base_dir / path).resolve()
+    return f"{prefix}{resolved}"
+
+
+def load_settings_from_yaml(config_path: str | Path = DEFAULT_CONFIG_PATH) -> Settings:
+    path = Path(config_path)
+    if not path.is_file():
+        raise FileNotFoundError(f"Configuration file not found: {path}")
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if raw is None:
+        data: dict[str, Any] = {}
+    elif isinstance(raw, dict):
+        data = dict(raw)
+    else:
+        raise ValueError("Configuration file must contain a YAML mapping at the top level.")
+
+    base_dir = path.resolve().parent
+    for key in (
+        "data_dir",
+        "index_path",
+        "id_map_path",
+        "faq_csv",
+        "embedding_cache_db_path",
+        "eval_dataset_path",
+        "perf_metrics_out_path",
+        "lock_metrics_path",
+    ):
+        if key in data:
+            data[key] = _resolve_relative_path_value(data.get(key), base_dir=base_dir)
+    if "sqlite_url" in data:
+        data["sqlite_url"] = _resolve_sqlite_url_value(data.get("sqlite_url"), base_dir=base_dir)
+    return Settings(**data)
+
+
+class Settings(BaseModel):
     """Centralized application configuration.
 
     All fields have default values, so the class can be instantiated without arguments.
@@ -159,6 +211,91 @@ class Settings(BaseSettings):
             "and vector backend."
         ),
     )
+    eval_dataset_path: str = Field(
+        "datasets/rag_eval_v1.jsonl",
+        description="Default JSONL dataset path for offline retrieval evaluation.",
+    )
+    embedding_cache_db_path: str = Field(
+        "data/embedding_cache.sqlite3",
+        description="Persistent embedding cache DB path.",
+    )
+    disable_embedding_cache: bool = Field(
+        False,
+        description="Disable the content-addressed embedding cache wrapper.",
+    )
+    synthetic_embeddings: bool = Field(
+        False,
+        description="Enable synthetic SentenceTransformer embeddings for local stress testing.",
+    )
+    synthetic_embedding_fail_rate: float = Field(
+        0.0,
+        ge=0.0,
+        le=1.0,
+        description="Probability of synthetic embedding failure when synthetic_embeddings=true.",
+    )
+    synthetic_embedding_jitter_min_ms: float = Field(
+        0.0,
+        ge=0.0,
+        description="Minimum synthetic embedding jitter in milliseconds.",
+    )
+    synthetic_embedding_jitter_max_ms: float = Field(
+        0.0,
+        ge=0.0,
+        description="Maximum synthetic embedding jitter in milliseconds.",
+    )
+    synthetic_embedding_dim: int = Field(
+        384,
+        ge=1,
+        description="Embedding dimensionality used when synthetic embeddings are enabled.",
+    )
+    perf_metrics_out_path: str | None = Field(
+        None,
+        description="Optional JSON output file for process-local perf metrics.",
+    )
+    lock_metrics_path: str | None = Field(
+        None,
+        description="Optional NDJSON output file for write-lock metrics.",
+    )
+    blocking_workers: int = Field(
+        8,
+        ge=1,
+        description="Default worker count for blocking tasks.",
+    )
+    blocking_workers_mutation: int = Field(
+        2,
+        ge=1,
+        description="Worker count for blocking mutation tasks.",
+    )
+    blocking_workers_network: int = Field(
+        4,
+        ge=1,
+        description="Worker count for blocking network tasks.",
+    )
+    blocking_workers_eval: int = Field(
+        2,
+        ge=1,
+        description="Worker count for blocking eval tasks.",
+    )
+    blocking_queue_default: int = Field(
+        64,
+        ge=1,
+        description="Queue depth for default blocking tasks beyond worker count.",
+    )
+    blocking_queue_mutation: int = Field(
+        32,
+        ge=1,
+        description="Queue depth for mutation blocking tasks beyond worker count.",
+    )
+    blocking_queue_network: int = Field(
+        64,
+        ge=1,
+        description="Queue depth for network blocking tasks beyond worker count.",
+    )
+    blocking_queue_eval: int = Field(
+        32,
+        ge=1,
+        description="Queue depth for eval blocking tasks beyond worker count.",
+    )
     write_lock_timeout_s: float = Field(
         30.0,
         ge=0.1,
@@ -287,14 +424,7 @@ class Settings(BaseSettings):
         "Based on the context, answer the question.\nIf the context is not enough, say so.\n\nCONTEXT:\n{context}\n\nQUESTION:\n{question}"
     )
 
-    model_config = SettingsConfigDict(
-        env_file=".env",
-        env_file_encoding="utf-8",
-        case_sensitive=False,
-        extra="ignore",
-        # Allow non-JSON env vars for complex fields (e.g., comma-separated CORS origins).
-        enable_decoding=False,
-    )
+    model_config = ConfigDict(extra="forbid")
 
     @field_validator("debug", mode="before")
     @classmethod
@@ -310,7 +440,7 @@ class Settings(BaseSettings):
     @field_validator("log_level", mode="before")
     @classmethod
     def _normalize_log_level(cls, v: Any) -> Any:
-        # Make env/config more forgiving while keeping a strict Literal type.
+        # Keep the YAML config forgiving while retaining a strict Literal type.
         if isinstance(v, str):
             return v.upper()
         return v
@@ -319,8 +449,8 @@ class Settings(BaseSettings):
     @classmethod
     def _parse_cors_allow_origins(cls, v: Any) -> Any:
         """
-        Allow `CORS_ALLOW_ORIGINS` to be set as:
-        - JSON list (recommended): ["http://localhost:5173", ...]
+        Allow `cors_allow_origins` to be set as:
+        - YAML list (recommended): ["http://localhost:5173", ...]
         - Comma-separated string: http://localhost:5173,http://127.0.0.1:5173
         - Empty string: (disable CORS)
         """
@@ -330,7 +460,7 @@ class Settings(BaseSettings):
             s = v.strip()
             if not s:
                 return []
-            # JSON list string (common in docker-compose env)
+            # JSON list string (useful when the YAML loader gets a quoted scalar).
             if s.startswith("["):
                 try:
                     parsed = json.loads(s)
@@ -400,29 +530,29 @@ class Settings(BaseSettings):
         if self.persistence_backend == "elasticsearch":
             if self.retrieval_mode == "sparse" and self.search_backend != "elasticsearch":
                 raise ValueError(
-                    "PERSISTENCE_BACKEND=elasticsearch supports retrieval_mode=sparse only when "
-                    "SEARCH_BACKEND=elasticsearch"
+                    "persistence_backend=elasticsearch supports retrieval_mode=sparse only when "
+                    "search_backend=elasticsearch"
                 )
             if not self.es_base_url:
-                raise ValueError("ES_BASE_URL is required when PERSISTENCE_BACKEND=elasticsearch")
+                raise ValueError("es_base_url is required when persistence_backend=elasticsearch")
         else:
             if not self.sqlite_url.startswith("sqlite:///"):
                 raise ValueError("SQLite URL must start with 'sqlite:///'")
 
         if self.search_backend == "elasticsearch" and not self.es_base_url:
-            raise ValueError("ES_BASE_URL is required when SEARCH_BACKEND=elasticsearch")
+            raise ValueError("es_base_url is required when search_backend=elasticsearch")
         if self.search_backend == "opensearch" and not self.os_base_url:
-            raise ValueError("OS_BASE_URL is required when SEARCH_BACKEND=opensearch")
+            raise ValueError("os_base_url is required when search_backend=opensearch")
         if self.search_backend == "solr" and not self.solr_base_url:
-            raise ValueError("SOLR_BASE_URL is required when SEARCH_BACKEND=solr")
+            raise ValueError("solr_base_url is required when search_backend=solr")
         if self.search_backend == "solr" and self.retrieval_mode in {"dense", "dual"}:
-            raise ValueError("SEARCH_BACKEND=solr supports only retrieval_mode=sparse in v1")
+            raise ValueError("search_backend=solr supports only retrieval_mode=sparse in v1")
         if self.retrieval_mode == "hybrid" and self.search_backend not in {
             "local_split",
             "elasticsearch",
         }:
             raise ValueError(
-                "retrieval_mode=hybrid is supported only with SEARCH_BACKEND=local_split|elasticsearch"
+                "retrieval_mode=hybrid is supported only with search_backend=local_split|elasticsearch"
             )
         if (
             self.retrieval_mode == "hybrid"
@@ -430,8 +560,8 @@ class Settings(BaseSettings):
             and self.persistence_backend != "elasticsearch"
         ):
             raise ValueError(
-                "retrieval_mode=hybrid with SEARCH_BACKEND=elasticsearch requires "
-                "PERSISTENCE_BACKEND=elasticsearch"
+                "retrieval_mode=hybrid with search_backend=elasticsearch requires "
+                "persistence_backend=elasticsearch"
             )
         return self
 
@@ -467,4 +597,4 @@ class Settings(BaseSettings):
 
 
 # Global settings instance
-settings: Settings = Settings()
+settings: Settings = load_settings_from_yaml()

--- a/tests/unit/cli/test_cli_rebuild_index.py
+++ b/tests/unit/cli/test_cli_rebuild_index.py
@@ -64,4 +64,4 @@ def test_rebuild_index_cli_rejects_non_dense_modes(monkeypatch) -> None:
     result = CliRunner().invoke(index_cmd_module.rebuild_index_cmd)
 
     assert result.exit_code == 1
-    assert "RETRIEVAL_MODE=dense|dual|hybrid" in result.output
+    assert "retrieval_mode=dense|dual|hybrid" in result.output

--- a/tests/unit/composition/test_composition.py
+++ b/tests/unit/composition/test_composition.py
@@ -358,7 +358,9 @@ def test_build_retriever_hybrid_uses_elasticsearch_lexical_path_for_local_split_
 
     def _hybrid_retriever_factory(**kwargs):
         seen["hybrid_kwargs"] = kwargs
-        sparse_result = kwargs["sparse"].retrieve(RetrievalRequest(query="hello", top_k=2, mode="sparse"))
+        sparse_result = kwargs["sparse"].retrieve(
+            RetrievalRequest(query="hello", top_k=2, mode="sparse")
+        )
         seen["sparse_result"] = sparse_result
         return "hybrid-retriever"
 
@@ -387,7 +389,10 @@ def test_build_retriever_hybrid_uses_elasticsearch_lexical_path_for_local_split_
     }
     assert seen["lexical_k"] == 2
     assert seen["sparse_result"].backend_used == "elastic_lexical"
-    assert tuple(doc.id for doc in seen["sparse_result"].documents) == (DocId("doc-1"), DocId("doc-2"))
+    assert tuple(doc.id for doc in seen["sparse_result"].documents) == (
+        DocId("doc-1"),
+        DocId("doc-2"),
+    )
     assert seen["dense_kwargs"]["doc_repo"] is not None
     assert seen["hybrid_kwargs"]["alpha"] == 0.4
 

--- a/tests/unit/core/services/test_write_lock.py
+++ b/tests/unit/core/services/test_write_lock.py
@@ -64,11 +64,10 @@ def test_multi_store_write_lock_records_wait_and_hold_metrics(tmp_path, monkeypa
         yield
 
     mono = iter([10.0, 10.2, 10.2, 10.7])
-    monkeypatch.setenv("RAG_LOCK_METRICS_PATH", str(metrics_path))
     monkeypatch.setattr(
         write_lock,
         "settings",
-        SimpleNamespace(get_coordination_dir=lambda: tmp_path),
+        SimpleNamespace(get_coordination_dir=lambda: tmp_path, lock_metrics_path=str(metrics_path)),
         raising=True,
     )
     monkeypatch.setattr(write_lock, "_exclusive_file_lock", _fake_lock, raising=True)
@@ -93,11 +92,10 @@ def test_multi_store_write_lock_records_released_and_failed_on_exception(tmp_pat
         yield
 
     mono = iter([1.0, 1.1, 1.1, 1.6, 1.8])
-    monkeypatch.setenv("RAG_LOCK_METRICS_PATH", str(metrics_path))
     monkeypatch.setattr(
         write_lock,
         "settings",
-        SimpleNamespace(get_coordination_dir=lambda: tmp_path),
+        SimpleNamespace(get_coordination_dir=lambda: tmp_path, lock_metrics_path=str(metrics_path)),
         raising=True,
     )
     monkeypatch.setattr(write_lock, "_exclusive_file_lock", _fake_lock, raising=True)

--- a/tests/unit/http/test_blocking.py
+++ b/tests/unit/http/test_blocking.py
@@ -16,30 +16,30 @@ def _reset_blocking_state() -> None:
     blocking._EXECUTOR_STATES.clear()
 
 
-def test_default_workers_uses_valid_positive_env(monkeypatch):
-    monkeypatch.setenv("RAG_BLOCKING_WORKERS", "12")
+def test_default_workers_uses_valid_positive_config(monkeypatch):
+    monkeypatch.setattr(blocking.settings, "blocking_workers", 12, raising=False)
     assert blocking._default_workers() == 12
 
 
-def test_default_workers_falls_back_on_invalid_or_non_positive_env(monkeypatch):
-    monkeypatch.setenv("RAG_BLOCKING_WORKERS", "abc")
+def test_default_workers_falls_back_on_invalid_or_non_positive_config(monkeypatch):
+    monkeypatch.setattr(blocking.settings, "blocking_workers", "abc", raising=False)
     assert blocking._default_workers() == 8
 
-    monkeypatch.setenv("RAG_BLOCKING_WORKERS", "0")
+    monkeypatch.setattr(blocking.settings, "blocking_workers", "0", raising=False)
     assert blocking._default_workers() == 8
 
-    monkeypatch.setenv("RAG_BLOCKING_WORKERS", "-3")
+    monkeypatch.setattr(blocking.settings, "blocking_workers", "-3", raising=False)
     assert blocking._default_workers() == 8
 
 
-def test_workers_for_task_prefers_task_specific_env(monkeypatch):
-    monkeypatch.setenv("RAG_BLOCKING_WORKERS_MUTATION", "5")
+def test_workers_for_task_prefers_task_specific_config(monkeypatch):
+    monkeypatch.setattr(blocking.settings, "blocking_workers_mutation", 5, raising=False)
     assert blocking._workers_for_task("mutation") == 5
 
 
 def test_executor_state_uses_workers_and_queue_limits(monkeypatch):
-    monkeypatch.setenv("RAG_BLOCKING_WORKERS_MUTATION", "3")
-    monkeypatch.setenv("RAG_BLOCKING_QUEUE_MUTATION", "9")
+    monkeypatch.setattr(blocking.settings, "blocking_workers_mutation", 3, raising=False)
+    monkeypatch.setattr(blocking.settings, "blocking_queue_mutation", 9, raising=False)
 
     state = blocking._get_executor_state("mutation")
     assert state.max_pending == 12

--- a/tests/unit/http/test_docs_upsert_endpoint.py
+++ b/tests/unit/http/test_docs_upsert_endpoint.py
@@ -55,7 +55,7 @@ async def test_mutate_upsert_rejects_duplicate_external_ids(
 
 
 async def test_mutate_upsert_dense_updates_only_changed_content(
-    asgi_client, in_memory_sqlite, monkeypatch
+    asgi_client, in_memory_sqlite, monkeypatch, tmp_path
 ):
     class DummyEmbedder:
         dim = 4
@@ -81,6 +81,12 @@ async def test_mutate_upsert_dense_updates_only_changed_content(
 
     monkeypatch.setattr(settings, "retrieval_mode", "dense", raising=False)
     monkeypatch.setattr(settings, "openai_api_key", "DUMMY", raising=False)
+    monkeypatch.setattr(
+        settings,
+        "embedding_cache_db_path",
+        str(tmp_path / "embedding-cache.sqlite3"),
+        raising=False,
+    )
 
     dummy_embedder = DummyEmbedder()
     dummy_vec = DummyVec()

--- a/tests/unit/infrastructure/embeddings/test_content_addressed_cache.py
+++ b/tests/unit/infrastructure/embeddings/test_content_addressed_cache.py
@@ -13,6 +13,7 @@ from local_rag_backend.infrastructure.observability.perf import (
     reset_perf_metrics,
     snapshot_perf_metrics,
 )
+from local_rag_backend.settings import settings
 
 
 class _Embedder:
@@ -54,7 +55,7 @@ def test_perf_metrics_dump_aggregates_process_payloads(monkeypatch, tmp_path: Pa
     cached.embed(["alpha", "alpha"])
 
     out = tmp_path / "perf.json"
-    monkeypatch.setenv("RAG_PERF_METRICS_OUT", str(out))
+    monkeypatch.setattr(settings, "perf_metrics_out_path", str(out), raising=False)
     dump_perf_metrics_if_configured()
 
     payload = json.loads(out.read_text(encoding="utf-8"))
@@ -76,7 +77,12 @@ def test_resolve_embedding_model_key_detects_openai_like_embedder() -> None:
     assert resolve_embedding_model_key(_OpenAIEmbedder()) == "openai:text-embedding-3-small:3"
 
 
-def test_resolve_embedding_cache_db_path_honors_override(monkeypatch, tmp_path: Path) -> None:
+def test_resolve_embedding_cache_db_path_honors_override(tmp_path: Path) -> None:
     override = tmp_path / "custom-cache.sqlite3"
-    monkeypatch.setenv("RAG_EMBEDDING_CACHE_DB", str(override))
-    assert resolve_embedding_cache_db_path(data_dir=tmp_path / "data") == override
+    assert (
+        resolve_embedding_cache_db_path(
+            data_dir=tmp_path / "data",
+            configured_path=override,
+        )
+        == override
+    )

--- a/tests/unit/infrastructure/retrievers/test_scoring.py
+++ b/tests/unit/infrastructure/retrievers/test_scoring.py
@@ -28,4 +28,3 @@ def test_validate_normalized_scores_rejects_invalid_values(bad_score: float) -> 
 
 def test_validate_normalized_scores_accepts_valid_values() -> None:
     validate_normalized_scores([0.0, 0.25, 1.0], source="test")
-

--- a/tests/unit/settings/test_settings_validators.py
+++ b/tests/unit/settings/test_settings_validators.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from local_rag_backend.settings import Settings
+from local_rag_backend.settings import Settings, load_settings_from_yaml
 
 
 def test_sqlite_url_validator():
@@ -12,7 +12,7 @@ def test_sqlite_url_validator():
 
 
 def test_elasticsearch_backend_requires_es_base_url():
-    with pytest.raises(ValueError, match="ES_BASE_URL is required"):
+    with pytest.raises(ValueError, match="es_base_url is required"):
         Settings(
             persistence_backend="elasticsearch",
             retrieval_mode="dense",
@@ -40,7 +40,7 @@ def test_elasticsearch_backend_accepts_sparse_with_elasticsearch_search_backend(
 
 
 def test_opensearch_search_backend_requires_url():
-    with pytest.raises(ValueError, match="OS_BASE_URL is required"):
+    with pytest.raises(ValueError, match="os_base_url is required"):
         Settings(search_backend="opensearch", retrieval_mode="dense")
 
 
@@ -99,15 +99,13 @@ def test_log_level_is_normalized_to_uppercase():
     assert s.log_level == "DEBUG"
 
 
-def test_debug_accepts_release_alias_from_env(monkeypatch):
-    monkeypatch.setenv("DEBUG", "release")
-    s = Settings()
+def test_debug_accepts_release_alias_from_string():
+    s = Settings(debug="release")
     assert s.debug is False
 
 
-def test_debug_accepts_development_alias_from_env(monkeypatch):
-    monkeypatch.setenv("DEBUG", "development")
-    s = Settings()
+def test_debug_accepts_development_alias_from_string():
+    s = Settings(debug="development")
     assert s.debug is True
 
 
@@ -151,3 +149,44 @@ def test_coordination_dir_uses_absolute_sqlite_parent_when_data_dir_is_relative(
 def test_coordination_dir_uses_absolute_sqlite_parent_when_data_dir_is_default(tmp_path):
     s = Settings(data_dir=Path("data"), sqlite_url=f"sqlite:///{tmp_path / 'app.db'}")
     assert s.get_coordination_dir() == tmp_path.resolve()
+
+
+def test_load_settings_from_yaml_resolves_relative_paths(tmp_path):
+    config_dir = tmp_path / "config-root"
+    config_dir.mkdir()
+    config_file = config_dir / "config.yaml"
+    config_file.write_text(
+        "\n".join(
+            [
+                "data_dir: data",
+                "index_path: data/index.faiss",
+                "id_map_path: data/id_map.json",
+                "sqlite_url: sqlite:///./data/app.db",
+                "faq_csv: data/faq.csv",
+                "eval_dataset_path: datasets/rag_eval_v1.jsonl",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    settings = load_settings_from_yaml(config_file)
+
+    assert settings.data_dir == (config_dir / "data").resolve()
+    assert settings.index_path == str((config_dir / "data/index.faiss").resolve())
+    assert settings.id_map_path == str((config_dir / "data/id_map.json").resolve())
+    assert settings.sqlite_url == f"sqlite:///{(config_dir / 'data/app.db').resolve()}"
+    assert settings.faq_csv == str((config_dir / "data/faq.csv").resolve())
+    assert settings.eval_dataset_path == str((config_dir / "datasets/rag_eval_v1.jsonl").resolve())
+
+
+def test_load_settings_from_yaml_rejects_missing_file(tmp_path):
+    with pytest.raises(FileNotFoundError, match="Configuration file not found"):
+        load_settings_from_yaml(tmp_path / "missing.yaml")
+
+
+def test_load_settings_from_yaml_rejects_non_mapping(tmp_path):
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("- not-a-mapping\n- still-not-a-mapping\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="top level"):
+        load_settings_from_yaml(config_file)

--- a/uv.lock
+++ b/uv.lock
@@ -1110,6 +1110,7 @@ wheels = [
 name = "griffelib"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/06/eccbd311c9e2b3ca45dbc063b93134c57a1ccc7607c5e545264ad092c4a9/griffelib-2.0.0.tar.gz", hash = "sha256:e504d637a089f5cab9b5daf18f7645970509bf4f53eda8d79ed71cce8bd97934", size = 166312, upload-time = "2026-03-23T21:06:55.954Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/51/c936033e16d12b627ea334aaaaf42229c37620d0f15593456ab69ab48161/griffelib-2.0.0-py3-none-any.whl", hash = "sha256:01284878c966508b6d6f1dbff9b6fa607bc062d8261c5c7253cb285b06422a7f", size = 142004, upload-time = "2026-02-09T19:09:40.561Z" },
 ]
@@ -3840,8 +3841,7 @@ dependencies = [
     { name = "numpy", marker = "python_full_version < '3.13'" },
     { name = "openai", marker = "python_full_version < '3.13'" },
     { name = "pydantic", marker = "python_full_version < '3.13'" },
-    { name = "pydantic-settings", marker = "python_full_version < '3.13'" },
-    { name = "python-dotenv", marker = "python_full_version < '3.13'" },
+    { name = "pyyaml", marker = "python_full_version < '3.13'" },
     { name = "rank-bm25", marker = "python_full_version < '3.13'" },
     { name = "rich", marker = "python_full_version < '3.13'" },
     { name = "sqlalchemy", marker = "python_full_version < '3.13'" },
@@ -3946,10 +3946,9 @@ requires-dist = [
     { name = "orjson", marker = "extra == 'performance-cpu'", specifier = ">=3.10,<4.0" },
     { name = "prometheus-client", marker = "extra == 'monitoring'", specifier = ">=0.19,<1.0" },
     { name = "pydantic", specifier = ">=2.0,<3.0" },
-    { name = "pydantic-settings", specifier = ">=2.2,<3.0" },
-    { name = "python-dotenv", specifier = ">=1.0,<2.0" },
     { name = "python-magic", marker = "extra == 'magic'", specifier = ">=0.4,<1.0" },
     { name = "python-multipart", marker = "extra == 'server'", specifier = ">=0.0.9,<1.0" },
+    { name = "pyyaml", specifier = ">=6.0,<7.0" },
     { name = "rag-prototype", extras = ["server", "dense", "dense-st", "loaders", "magic", "performance", "monitoring"], marker = "extra == 'all'" },
     { name = "rank-bm25", specifier = ">=0.2,<1.0" },
     { name = "rich", specifier = ">=13.0,<14.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -3907,6 +3907,7 @@ dev = [
     { name = "pytest-cov", marker = "python_full_version < '3.13'" },
     { name = "pytest-xdist", marker = "python_full_version < '3.13'" },
     { name = "ruff", marker = "python_full_version < '3.13'" },
+    { name = "types-pyyaml", marker = "python_full_version < '3.13'" },
 ]
 docs = [
     { name = "mkdocs", marker = "python_full_version < '3.13'" },
@@ -3920,6 +3921,7 @@ lint = [
     { name = "mypy", marker = "python_full_version < '3.13'" },
     { name = "pre-commit", marker = "python_full_version < '3.13'" },
     { name = "ruff", marker = "python_full_version < '3.13'" },
+    { name = "types-pyyaml", marker = "python_full_version < '3.13'" },
 ]
 sec = [
     { name = "bandit", marker = "python_full_version < '3.13'" },
@@ -3975,6 +3977,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=6.1.1,<7.0" },
     { name = "pytest-xdist", specifier = ">=3.5,<4.0" },
     { name = "ruff", specifier = ">=0.4,<1.0" },
+    { name = "types-pyyaml", specifier = ">=6.0.12" },
 ]
 docs = [
     { name = "mkdocs", specifier = ">=1.5,<2.0" },
@@ -3988,6 +3991,7 @@ lint = [
     { name = "mypy", specifier = ">=1.10,<2.0" },
     { name = "pre-commit", specifier = ">=4.2.0,<5.0" },
     { name = "ruff", specifier = ">=0.4,<1.0" },
+    { name = "types-pyyaml", specifier = ">=6.0.12" },
 ]
 sec = [
     { name = "bandit", extras = ["toml"], specifier = ">=1.7,<2.0" },
@@ -5042,6 +5046,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20250915"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/69/3c51b36d04da19b92f9e815be12753125bd8bc247ba0470a982e6979e71c/types_pyyaml-6.0.12.20250915.tar.gz", hash = "sha256:0f8b54a528c303f0e6f7165687dd33fafa81c807fcac23f632b63aa624ced1d3", size = 17522, upload-time = "2025-09-15T03:01:00.728Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/e0/1eed384f02555dde685fff1a1ac805c1c7dcb6dd019c916fe659b1c1f9ec/types_pyyaml-6.0.12.20250915-py3-none-any.whl", hash = "sha256:e7d4d9e064e89a3b3cae120b4990cd370874d2bf12fa5f46c97018dd5d3c9ab6", size = 20338, upload-time = "2025-09-15T03:00:59.218Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
This PR replaces env-based runtime configuration with a single `config.yaml` source of truth.

`Settings` remains as a Pydantic validation layer, but it no longer reads from environment variables or `.env` files. The app now loads configuration from YAML at startup, resolves relative paths against the YAML file location, and shares the same config model across HTTP, CLI, and bootstrap flows.

## What changed
- Added `config.yaml` as the canonical runtime config.
- Added `config.example.yaml` as the documented template.
- Reworked `Settings` to validate YAML input instead of reading env vars.
- Removed runtime env-based config reads across:
  - embedder/cache wiring
  - blocking worker/queue settings
  - metrics and lock paths
  - eval dataset config
  - OpenRouter and retrieval-related validation messages
- Updated docs to point to `config.yaml` and `config.example.yaml`.
- Updated tests to cover loader behavior, path resolution, and runtime wiring.

## Validation
- `uv run ruff check src/local_rag_backend tests`
- `uv run pytest -q -o addopts=''`
- Result: `679 passed, 4 skipped`

## Notes
- This is an operational breaking change: runtime config must now live in `config.yaml`.
- No env/.env back-compat is retained by design.
- Relative paths in config are resolved relative to the YAML file, not the current working directory.
