### PR TITLE
refactor: clean up evaluation surface

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > Scope: prioritized delivery roadmap derived from the current technical-debt register and the current codebase
 >
-> Status: current as of 2026-04-08
+> Status: current as of 2026-04-26
 
 This roadmap is execution-oriented and intentionally atomic. Each item should be implementable and reviewable on its own, without bundling large architectural rewrites into one change.
 
@@ -11,9 +11,9 @@ This roadmap is execution-oriented and intentionally atomic. Each item should be
 - `transport`: align canonical import semantics between CLI and HTTP
   - unify `replace_scope` defaults
   - cover the behavior explicitly in transport tests
-- `eval`: preserve retriever scores in offline evaluation
+- [x] `eval`: preserve retriever scores in offline evaluation
   - change the eval callback contract from `Sequence[str]` to `(external_id, score)` pairs
-- `eval`: stop silently filtering unknown retrieved IDs
+- [x] `eval`: stop silently filtering unknown retrieved IDs
   - either keep them as non-relevant results or emit explicit evaluator anomalies
 - `ux/dx`: unify CLI payload validation with DTOs / use cases for:
   - `rag-mutate-docs`
@@ -25,9 +25,9 @@ This roadmap is execution-oriented and intentionally atomic. Each item should be
 - `mutation`: extract a typed mutation runtime/config object from `Settings`
 - `mutation`: remove duplicated profile resolution and strategy branching from `MutationCoordinator`
 - `mutation`: split `_mutation_saga_executor.py` into explicit phases without changing behavior
-- `eval`: emit per-query outputs for compare mode
+- [x] `eval`: emit per-query outputs for compare mode
   - this is the prerequisite for stronger statistical comparison later
-- `ux/dx`: reduce `rag-eval-compare` complexity with profiles or spec-file support
+- [x] `ux/dx`: reduce `rag-eval-compare` complexity with spec-file support
 
 ## P2
 
@@ -40,7 +40,7 @@ This roadmap is execution-oriented and intentionally atomic. Each item should be
 
 ## P3
 
-- `eval`: extend dataset schema to support optional graded relevance
+- [x] `eval`: extend dataset schema to support optional graded relevance
 - `eval`: add paired significance testing for compare mode once per-query outputs exist
 - `canonical import`: decide whether scope replacement belongs inside canonical mutation or a dedicated use case
 - `ux/dx`: review evaluation help texts and flag naming for consistency and scanability

--- a/docs/ROADMAP_UX_DX.md
+++ b/docs/ROADMAP_UX_DX.md
@@ -18,9 +18,9 @@ This roadmap isolates the UX / DX work so it can move independently from mutatio
 
 ## P1
 
-- Reduce `rag-eval-compare` complexity:
-  - support compare profiles or spec files, not only expanded flag matrices
-  - make common compare flows easier than bespoke flag composition
+- [x] Reduce `rag-eval-compare` complexity:
+  - use a canonical `--spec` file with baseline, candidate, and thresholds
+  - remove expanded baseline/candidate flag matrices
 - Homogenize CLI exit codes and success/error output:
   - consistent distinction between contract errors, runtime errors, and failed evaluation gates
   - consistent success summaries across commands

--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -55,7 +55,7 @@ Interpretation:
 | Mutation saga | One module still owns profile validation, journal lifecycle, before-image, SQL apply, vector apply, rollback, recovery, and reconcile | [`src/local_rag_backend/core/use_cases/_mutation_saga_executor.py`](../src/local_rag_backend/core/use_cases/_mutation_saga_executor.py) | High blast radius for write-path changes | High |
 | Mutation coordinator | Strategy selection, profile resolution, batching, and settings-derived behavior remain concentrated in one coordinator | [`src/local_rag_backend/core/use_cases/docs_mutation.py`](../src/local_rag_backend/core/use_cases/docs_mutation.py) | Coordination logic still spreads across layers | High |
 | Canonical import path | Scope-sync still relies on dynamic repo capabilities outside the coordinator; transport validation is now shared, but the write semantics still depend on repo-specific delete hooks | [`src/local_rag_backend/core/use_cases/docs_import_canonical.py`](../src/local_rag_backend/core/use_cases/docs_import_canonical.py), [`src/local_rag_backend/cli_commands/docs/docs_import_canonical.py`](../src/local_rag_backend/cli_commands/docs/docs_import_canonical.py) | Same business action can still depend on repo capabilities outside the core coordinator | High |
-| Evaluation methodology | Unknown retrieved IDs are silently filtered; original retriever scores are discarded; compare gate uses aggregate deltas only | [`src/local_rag_backend/core/services/evaluation.py`](../src/local_rag_backend/core/services/evaluation.py), [`src/local_rag_backend/core/use_cases/evaluation.py`](../src/local_rag_backend/core/use_cases/evaluation.py) | Retrieval defects can be masked; candidate quality can be overstated | High |
+| Evaluation methodology | Score/unknown-ID handling is fixed; compare gate still needs statistical testing beyond aggregate deltas | [`src/local_rag_backend/core/services/evaluation.py`](../src/local_rag_backend/core/services/evaluation.py), [`src/local_rag_backend/core/use_cases/evaluation.py`](../src/local_rag_backend/core/use_cases/evaluation.py) | Candidate quality can still be overstated without paired significance tests | Medium |
 | CLI / DX contract consistency | Evaluation flags are still powerful and cognitively expensive; some command surfaces remain manually shaped rather than spec-driven | [`src/local_rag_backend/cli_commands/docs/docs_mutate.py`](../src/local_rag_backend/cli_commands/docs/docs_mutate.py), [`src/local_rag_backend/cli_commands/eval.py`](../src/local_rag_backend/cli_commands/eval.py) | Users still have to learn a wide CLI surface | Medium |
 | Maintenance | Two multi-store delete flows are still near-mirror implementations | [`src/local_rag_backend/core/services/maintenance.py`](../src/local_rag_backend/core/services/maintenance.py) | Partial fixes and telemetry drift | Medium |
 | Ingestion planner | Planning, stale detection, batching, mutation execution, and terminal output still live in one module; `items` remains `Any` | [`src/local_rag_backend/cli_commands/docs/_ingestion_planner.py`](../src/local_rag_backend/cli_commands/docs/_ingestion_planner.py) | Reuse is limited; contracts remain implicit | Medium |
@@ -107,15 +107,14 @@ Validated points:
 
 - Dataset parsing and aggregate metric calculation are correctly centralized in [`load_eval_dataset`](../src/local_rag_backend/core/services/evaluation.py) and `ir_measures`.
 - The evaluation workspace is isolated through [`prepare_eval_workspace`](../src/local_rag_backend/core/use_cases/evaluation.py), so this is not a simple "production index accidentally reused" story.
-- The core evaluator still filters retrieved IDs not present in the dataset corpus:
-  `normalized_external_id not in known_doc_ids` in [`run_retrieval_eval`](../src/local_rag_backend/core/services/evaluation.py).
-- The evaluator also discards original retrieval scores because the callback contract is `Sequence[str]`, then invents rank-based scores via `k - rank + 1`.
-- [`compare_eval_results`](../src/local_rag_backend/core/services/evaluation.py) still gates on aggregate deltas only, with no per-query distribution or significance testing.
+- The core evaluator now keeps retrieved IDs not present in the dataset corpus as non-relevant results and emits explicit anomalies.
+- The evaluator now accepts ranked `(external_id, score)` style results while keeping backward compatibility for ID-only callbacks.
+- [`compare_eval_results`](../src/local_rag_backend/core/services/evaluation.py) still gates on aggregate deltas; detailed reports now expose per-query deltas, but significance testing remains future work.
 
 Why this matters:
 
-- Filtering unknown IDs can hide retrieval-state defects or corpus leakage instead of surfacing them as degraded precision.
-- Rank-only callback contracts make the evaluator lossy and block better future analysis.
+- Unknown retrieved IDs now degrade metrics and are visible in report/anomaly outputs.
+- Score-preserving callback contracts unblock better future analysis.
 - Aggregate-only gates are acceptable as operational guardrails, but not as evidence of statistical superiority.
 
 Nuance:
@@ -125,10 +124,8 @@ Nuance:
 
 Recommended direction:
 
-- Change the retrieval callback contract to return `(external_id, score)` pairs.
-- Stop silently filtering unknown IDs; either keep them as non-relevant results or surface them as explicit evaluator anomalies.
-- Extend the dataset format to support optional graded relevance.
-- Add per-query outputs and, later, paired significance testing for compare mode.
+- Add paired significance testing for compare mode.
+- Expand external benchmark adapters on top of the internal `EvalDataset`/`EvalRun`/`EvalReport` model.
 
 ### 4. CLI / DX contract consistency is now first-order debt
 
@@ -136,8 +133,8 @@ Validated points:
 
 - CLI mutation and canonical-import commands still parse JSON manually instead of reusing shared typed validation.
 - `replace_scope` semantics are aligned and the typed validation path is now shared across CLI, HTTP, and MCP.
-- `rag-eval`, `rag-eval-batch`, and `rag-eval-compare` expose powerful workflows, but the option surface is large and uneven:
-  flags such as `--candidate-candidate-k`, `--baseline-dual-candidate-k`, and JSON batch specs create a high cognitive load.
+- `rag-eval-compare` now uses a canonical `--spec` file instead of expanded baseline/candidate flag matrices.
+  `rag-eval` and `rag-eval-batch` still need continued payload-validation cleanup.
 - `_ingestion_planner.py` still emits terminal output directly, which keeps planning logic coupled to CLI behavior.
 
 Why this matters:
@@ -150,7 +147,7 @@ Recommended direction:
 
 - Reuse DTOs / use-case input models for CLI payload validation.
 - Align visible defaults across CLI and HTTP.
-- Simplify evaluation entrypoints with profiles or spec-driven compare flows, not only flag expansion.
+- Continue simplifying evaluation entrypoints by reusing the shared eval config validation path.
 - Standardize exit codes and success/error output shape across commands.
 
 ### 5. Maintenance still has cheap-to-fix duplication
@@ -230,8 +227,8 @@ Interpretation:
 - Extract a typed mutation runtime/config object from `Settings`.
 - Split mutation saga internals by phase without changing external behavior.
 - Remove duplicate profile resolution and strategy branching where possible from `MutationCoordinator`.
-- Add per-query outputs to evaluation compare mode.
-- Reduce `eval-compare` flag complexity with profiles or spec-file support.
+- [x] Add per-query outputs to evaluation compare mode.
+- [x] Reduce `eval-compare` flag complexity with spec-file support.
 - Homogenize CLI exit codes and success/error output shape.
 
 ### P2

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -396,12 +396,16 @@ rag-eval --retrieval-mode sparse
 rag-eval --retrieval-mode dense --candidate-k 20
 rag-eval --retrieval-mode dual --dual-candidate-k 50
 rag-eval --retrieval-mode hybrid --hybrid-alpha 0.5
-rag-eval-compare --candidate-mode dual --candidate-dual-candidate-k 50
+rag-eval --retrieval-mode sparse --run-out /tmp/run.jsonl --report-out /tmp/report.json
+rag-eval-compare --spec /tmp/rag-eval-compare-spec.json
 rag-eval-batch --specs /tmp/rag-eval-batch-specs.json
 ```
 
 Dataset por defecto: `datasets/rag_eval_v1.jsonl` (o `eval_dataset_path` en `config.yaml`).
 El comando reporta métricas estándar de IR a `@k` (`nDCG`, `MAP`, `MRR`, `P`, `Recall`).
+El evaluador conserva los scores del retriever cuando están disponibles. Los IDs recuperados
+fuera del corpus ya no se filtran silenciosamente: cuentan como no relevantes y aparecen como
+anomalías en `--report-out` / `--anomalies-out`.
 La evaluación usa un runtime local aislado bajo `<data_dir>/_eval_workspaces/`; no reutiliza ni muta el índice principal.
 Ese runtime sí puede reutilizar un índice denso de evaluación ya persistido cuando coinciden:
 
@@ -412,6 +416,12 @@ Ese runtime sí puede reutilizar un índice denso de evaluación ya persistido c
 Si cambias el modelo de embeddings, el backend vectorial o cualquier input del manifest denso, la evaluación invalida ese workspace y reconstruye el índice aislado.
 El rebuild denso se hace en batches acotados para reducir picos de memoria en corpora grandes, pero sigue siendo un rebuild completo del workspace de evaluación cuando hay drift.
 El dataset se valida de forma estricta: IDs duplicados, relevantes vacíos o relevantes fuera del corpus fallan al cargar.
+El schema v1 (`relevant_external_ids`) se mantiene. El schema v2 añade qrels graduados:
+
+```json
+{"type":"query","query":"alpha","qrels":[{"external_id":"doc:1","relevance":3}]}
+```
+
 Los overrides de modo son explícitos:
 - `--candidate-k` sólo para `dense`
 - `--dual-candidate-k` sólo para `dual`
@@ -428,20 +438,30 @@ Ese env var sobrescribe `perf_metrics_out_path` en tiempo de carga de settings s
 Comparación baseline-vs-candidate (“Detector de Placebo RAG”):
 
 ```bash
+cat > /tmp/rag-eval-compare-spec.json <<'JSON'
+{
+  "k": 3,
+  "baseline": {"retrieval_mode": "sparse"},
+  "candidate": {"retrieval_mode": "dual", "dual_candidate_k": 50},
+  "thresholds": {
+    "min_delta_ndcg": 0.02,
+    "min_delta_map": 0.02,
+    "min_delta_mrr": 0.02,
+    "max_regression_precision": 0.01,
+    "max_regression_recall": 0.01
+  }
+}
+JSON
+
 rag-eval-compare \
-  --candidate-mode dual \
-  --candidate-dual-candidate-k 50 \
-  --min-delta-ndcg 0.02 \
-  --min-delta-map 0.02 \
-  --min-delta-mrr 0.02 \
-  --max-regression-precision 0.01 \
-  --max-regression-recall 0.01 \
-  --json-out /tmp/rag-eval-compare.json
+  --spec /tmp/rag-eval-compare-spec.json \
+  --json-out /tmp/rag-eval-compare.json \
+  --report-out /tmp/rag-eval-compare-report.json
 ```
 
 Comportamiento:
-- baseline por defecto: `sparse` sin reranker
-- candidate: la configuración que quieras validar
+- `baseline` y `candidate` se declaran en `--spec`
+- `thresholds` contiene los umbrales del gate; si se omite un valor, su default es `0.0`
 - exit code `0`: pasa el gate
 - exit code `1`: la candidate no mejora lo suficiente o degrada métricas críticas
 - exit code `2`: error de configuración, dependencia o entorno
@@ -450,6 +470,9 @@ El JSON de salida incluye:
 - `baseline`
 - `candidate`
 - `delta`
+
+El report detallado añade métricas por query y contadores de anomalías, pensado para auditoría,
+pooling y futuros adapters RAGAS/BEIR/MTEB/LLM judge.
 
 Smoke e2e reproducible:
 

--- a/scripts/test_rag_eval_compare_e2e.sh
+++ b/scripts/test_rag_eval_compare_e2e.sh
@@ -8,6 +8,8 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 DATASET_PATH="$TMP_DIR/rag_eval_compare.jsonl"
 PASS_JSON="$TMP_DIR/pass.json"
 FAIL_JSON="$TMP_DIR/fail.json"
+PASS_SPEC="$TMP_DIR/pass-spec.json"
+FAIL_SPEC="$TMP_DIR/fail-spec.json"
 
 cat >"$DATASET_PATH" <<'EOF'
 {"type":"meta","dataset_id":"rag_eval_compare_smoke","schema_version":1}
@@ -15,18 +17,38 @@ cat >"$DATASET_PATH" <<'EOF'
 {"type":"query","query":"alpha","relevant_external_ids":["doc:alpha"]}
 EOF
 
+cat >"$PASS_SPEC" <<'EOF'
+{
+  "k": 1,
+  "baseline": {"retrieval_mode": "sparse"},
+  "candidate": {"retrieval_mode": "sparse"},
+  "thresholds": {
+    "min_delta_ndcg": 0.0,
+    "min_delta_map": 0.0,
+    "min_delta_mrr": 0.0,
+    "max_regression_precision": 0.0,
+    "max_regression_recall": 0.0
+  }
+}
+EOF
+
+cat >"$FAIL_SPEC" <<'EOF'
+{
+  "k": 1,
+  "baseline": {"retrieval_mode": "sparse"},
+  "candidate": {"retrieval_mode": "sparse"},
+  "thresholds": {
+    "min_delta_ndcg": 0.1
+  }
+}
+EOF
+
 cd "$ROOT_DIR"
 
 echo "[1/2] Expect PASS with identical sparse baseline/candidate and zero delta thresholds"
 env DEBUG=false UV_CACHE_DIR="${UV_CACHE_DIR:-.uv_cache}" uv run rag-eval-compare \
   --dataset "$DATASET_PATH" \
-  --k 1 \
-  --candidate-mode sparse \
-  --min-delta-ndcg 0.0 \
-  --min-delta-map 0.0 \
-  --min-delta-mrr 0.0 \
-  --max-regression-precision 0.0 \
-  --max-regression-recall 0.0 \
+  --spec "$PASS_SPEC" \
   --json-out "$PASS_JSON"
 
 python - <<'PY' "$PASS_JSON"
@@ -44,9 +66,7 @@ echo "[2/2] Expect FAIL when requiring an impossible positive delta from an iden
 set +e
 env DEBUG=false UV_CACHE_DIR="${UV_CACHE_DIR:-.uv_cache}" uv run rag-eval-compare \
   --dataset "$DATASET_PATH" \
-  --k 1 \
-  --candidate-mode sparse \
-  --min-delta-ndcg 0.1 \
+  --spec "$FAIL_SPEC" \
   --json-out "$FAIL_JSON"
 rc=$?
 set -e

--- a/src/local_rag_backend/cli_commands/eval.py
+++ b/src/local_rag_backend/cli_commands/eval.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import cast
 
 import click
 
 from local_rag_backend.cli_commands.runtime import get_cli_container
-from local_rag_backend.core.services.types import EvalResult, EvalRetrievalMode
+from local_rag_backend.core.services.evaluation_models import EvalResult
 from local_rag_backend.settings import settings
 
 
@@ -21,7 +20,15 @@ def _resolve_eval_dataset_path(dataset: Path | None) -> Path | str:
 
 def _write_json_output(path: Path | None, payload: object) -> None:
     if path is not None:
+        path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _write_text_output(path: Path | None, payload: str) -> None:
+    if path is not None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        suffix = "\n" if payload and not payload.endswith("\n") else ""
+        path.write_text(payload + suffix, encoding="utf-8")
 
 
 def _raise_cli_error(*, prefix: str, exc: Exception, exit_code: int) -> None:
@@ -36,50 +43,8 @@ def _load_batch_specs(path: Path) -> tuple[dict[str, object], ...]:
     return tuple(payload)
 
 
-def _validate_required_batch_fields(raw_specs: tuple[dict[str, object], ...]) -> None:
-    required_fields = ("name", "retrieval_mode", "k")
-    for index, item in enumerate(raw_specs):
-        for field_name in required_fields:
-            if field_name not in item:
-                raise click.BadParameter(
-                    f"Spec at index {index} is missing required field {field_name!r}.",
-                    param_hint="--specs",
-                )
-
-
-def _parse_int_field(value: object, *, field_name: str) -> int:
-    if isinstance(value, bool):
-        raise ValueError(f"{field_name} must be an integer, got boolean.")
-    if isinstance(value, int):
-        return value
-    if isinstance(value, str):
-        return int(value.strip())
-    raise ValueError(f"{field_name} must be an integer.")
-
-
-def _parse_optional_int_field(value: object, *, field_name: str) -> int | None:
-    if value is None:
-        return None
-    return _parse_int_field(value, field_name=field_name)
-
-
-def _parse_optional_float_field(value: object, *, field_name: str) -> float | None:
-    if value is None:
-        return None
-    if isinstance(value, bool):
-        raise ValueError(f"{field_name} must be numeric, got boolean.")
-    if isinstance(value, int | float):
-        return float(value)
-    if isinstance(value, str):
-        return float(value.strip())
-    raise ValueError(f"{field_name} must be numeric.")
-
-
-def _parse_retrieval_mode_field(value: object, *, field_name: str) -> EvalRetrievalMode:
-    normalized = str(value).strip().lower()
-    if normalized not in {"sparse", "dense", "dual", "hybrid"}:
-        raise ValueError(f"{field_name} must be one of sparse, dense, dual, hybrid.")
-    return cast("EvalRetrievalMode", normalized)
+def _load_compare_spec(path: Path) -> object:
+    return json.loads(path.read_text(encoding="utf-8"))
 
 
 def _collect_eval_threshold_failures(
@@ -152,6 +117,18 @@ def _collect_eval_threshold_failures(
     default=None,
     help="Optional path to write the ranked run as JSONL (one line per query). Used for multi-run pooling.",
 )
+@click.option(
+    "--report-out",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help="Optional path to write a detailed eval report JSON.",
+)
+@click.option(
+    "--anomalies-out",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help="Optional path to write eval anomalies as JSONL.",
+)
 def eval_cmd(
     dataset: Path | None,
     retrieval_mode: str,
@@ -166,10 +143,14 @@ def eval_cmd(
     fail_below_mrr: float,
     json_out: Path | None,
     run_out: Path | None,
+    report_out: Path | None,
+    anomalies_out: Path | None,
 ) -> None:
     """Offline IR evaluation with standard retrieval metrics."""
     try:
         from local_rag_backend.core.services.evaluation import (
+            eval_anomalies_to_jsonl,
+            eval_result_report_to_json,
             eval_result_to_json,
             format_eval_result,
             load_eval_dataset,
@@ -195,6 +176,22 @@ def eval_cmd(
             run_out=run_out,
         )
         _write_json_output(json_out, eval_result_to_json(res))
+        _write_json_output(
+            report_out,
+            eval_result_report_to_json(
+                res,
+                config={
+                    "retrieval_mode": retrieval_mode,
+                    "k": k,
+                    "candidate_k": candidate_k,
+                    "dual_candidate_k": dual_candidate_k,
+                    "hybrid_alpha": hybrid_alpha,
+                    "reranker_enabled": bool(reranker),
+                    "max_queries": max_queries,
+                },
+            ),
+        )
+        _write_text_output(anomalies_out, eval_anomalies_to_jsonl(res))
 
         failures = _collect_eval_threshold_failures(
             result=res,
@@ -248,38 +245,18 @@ def eval_batch_cmd(
     """Offline IR evaluation for multiple specs over the same dataset."""
     try:
         from local_rag_backend.core.services.evaluation import (
+            eval_anomalies_to_jsonl,
+            eval_result_report_to_json,
             eval_result_to_json,
             format_eval_result,
             load_eval_dataset,
+            parse_eval_batch_spec,
         )
-        from local_rag_backend.core.services.types import EvalBatchSpec
         from local_rag_backend.core.use_cases.evaluation import run_retrieval_eval_batch
 
         raw_specs = _load_batch_specs(specs)
-        _validate_required_batch_fields(raw_specs)
         batch_specs = tuple(
-            EvalBatchSpec(
-                name=str(item["name"]),
-                retrieval_mode=_parse_retrieval_mode_field(
-                    item["retrieval_mode"], field_name="retrieval_mode"
-                ),
-                k=_parse_int_field(item["k"], field_name="k"),
-                candidate_k=_parse_optional_int_field(
-                    item.get("candidate_k"), field_name="candidate_k"
-                ),
-                dual_candidate_k=_parse_optional_int_field(
-                    item.get("dual_candidate_k"), field_name="dual_candidate_k"
-                ),
-                hybrid_alpha=_parse_optional_float_field(
-                    item.get("hybrid_alpha"), field_name="hybrid_alpha"
-                ),
-                reranker_enabled=bool(item.get("reranker_enabled", False)),
-                json_out=(
-                    str(item["json_out"]).strip() if item.get("json_out") is not None else None
-                ),
-                run_out=(str(item["run_out"]).strip() if item.get("run_out") is not None else None),
-            )
-            for item in raw_specs
+            parse_eval_batch_spec(item, index=index) for index, item in enumerate(raw_specs)
         )
 
         container = get_cli_container()
@@ -298,8 +275,17 @@ def eval_batch_cmd(
         for batch_result in results:
             if batch_result.json_out is not None:
                 json_out = Path(batch_result.json_out)
-                json_out.parent.mkdir(parents=True, exist_ok=True)
                 _write_json_output(json_out, eval_result_to_json(batch_result.result))
+            if batch_result.report_out is not None:
+                _write_json_output(
+                    Path(batch_result.report_out),
+                    eval_result_report_to_json(batch_result.result),
+                )
+            if batch_result.anomalies_out is not None:
+                _write_text_output(
+                    Path(batch_result.anomalies_out),
+                    eval_anomalies_to_jsonl(batch_result.result),
+                )
             click.echo(f"{batch_result.name}: {format_eval_result(batch_result.result)}")
     except SystemExit:
         raise
@@ -317,77 +303,42 @@ def eval_batch_cmd(
         "(or eval_dataset_path in config.yaml)."
     ),
 )
-@click.option("--k", type=int, default=3, show_default=True)
 @click.option(
-    "--baseline-mode",
-    type=click.Choice(["sparse", "dense", "dual", "hybrid"], case_sensitive=False),
-    default="sparse",
-    show_default=True,
-)
-@click.option("--baseline-candidate-k", type=click.IntRange(1), default=None)
-@click.option("--baseline-dual-candidate-k", type=click.IntRange(1), default=None)
-@click.option("--baseline-hybrid-alpha", type=click.FloatRange(0.0, 1.0), default=None)
-@click.option(
-    "--baseline-reranker/--no-baseline-reranker",
-    default=False,
-    show_default=True,
-)
-@click.option(
-    "--candidate-mode",
-    type=click.Choice(["sparse", "dense", "dual", "hybrid"], case_sensitive=False),
+    "--spec",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
     required=True,
+    help="Path to a JSON compare spec with baseline, candidate, and thresholds.",
 )
-@click.option("--candidate-candidate-k", type=click.IntRange(1), default=None)
-@click.option("--candidate-dual-candidate-k", type=click.IntRange(1), default=None)
-@click.option("--candidate-hybrid-alpha", type=click.FloatRange(0.0, 1.0), default=None)
-@click.option(
-    "--candidate-reranker/--no-candidate-reranker",
-    default=False,
-    show_default=True,
-)
-@click.option("--max-queries", type=int, default=None, help="Evaluate only the first N queries.")
-@click.option("--min-delta-ndcg", type=float, default=0.0, show_default=True)
-@click.option("--min-delta-map", type=float, default=0.0, show_default=True)
-@click.option("--min-delta-mrr", type=float, default=0.0, show_default=True)
-@click.option("--max-regression-precision", type=float, default=0.0, show_default=True)
-@click.option("--max-regression-recall", type=float, default=0.0, show_default=True)
 @click.option(
     "--json-out",
     type=click.Path(dir_okay=False, path_type=Path),
     default=None,
     help="Optional path to write compare results as JSON.",
 )
+@click.option(
+    "--report-out",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help="Optional path to write a detailed compare report JSON.",
+)
 def eval_compare_cmd(
     dataset: Path | None,
-    k: int,
-    baseline_mode: str,
-    baseline_candidate_k: int | None,
-    baseline_dual_candidate_k: int | None,
-    baseline_hybrid_alpha: float | None,
-    baseline_reranker: bool,
-    candidate_mode: str,
-    candidate_candidate_k: int | None,
-    candidate_dual_candidate_k: int | None,
-    candidate_hybrid_alpha: float | None,
-    candidate_reranker: bool,
-    max_queries: int | None,
-    min_delta_ndcg: float,
-    min_delta_map: float,
-    min_delta_mrr: float,
-    max_regression_precision: float,
-    max_regression_recall: float,
+    spec: Path,
     json_out: Path | None,
+    report_out: Path | None,
 ) -> None:
-    """Compare baseline and candidate retrieval configs and fail on placebo improvements."""
+    """Compare baseline and candidate retrieval configs from a spec file."""
     try:
         from local_rag_backend.core.services.evaluation import (
+            eval_compare_report_to_json,
             eval_compare_result_to_json,
             format_eval_compare_result,
             load_eval_dataset,
+            parse_eval_compare_spec,
         )
-        from local_rag_backend.core.services.types import EvalCompareConfig
         from local_rag_backend.core.use_cases.evaluation import compare_retrieval_eval
 
+        compare_spec = parse_eval_compare_spec(_load_compare_spec(spec))
         container = get_cli_container()
         eval_bundle = container.build_eval_execution_bundle()
         ds = load_eval_dataset(_resolve_eval_dataset_path(dataset))
@@ -395,35 +346,20 @@ def eval_compare_cmd(
             dataset=ds,
             eval_storage_port=eval_bundle.eval_storage_port,
             eval_retriever_factory_port=eval_bundle.eval_retriever_factory_port,
-            baseline=EvalCompareConfig(
-                retrieval_mode=_parse_retrieval_mode_field(
-                    baseline_mode, field_name="baseline-mode"
-                ),
-                candidate_k=baseline_candidate_k,
-                dual_candidate_k=baseline_dual_candidate_k,
-                hybrid_alpha=baseline_hybrid_alpha,
-                reranker_enabled=bool(baseline_reranker),
-            ),
-            candidate=EvalCompareConfig(
-                retrieval_mode=_parse_retrieval_mode_field(
-                    candidate_mode, field_name="candidate-mode"
-                ),
-                candidate_k=candidate_candidate_k,
-                dual_candidate_k=candidate_dual_candidate_k,
-                hybrid_alpha=candidate_hybrid_alpha,
-                reranker_enabled=bool(candidate_reranker),
-            ),
-            k=k,
+            baseline=compare_spec.baseline,
+            candidate=compare_spec.candidate,
+            k=compare_spec.k,
             reranker_candidate_k=eval_bundle.reranker_candidate_k,
             reranker_strategy=eval_bundle.reranker_strategy,
-            max_queries=max_queries,
-            min_delta_ndcg=min_delta_ndcg,
-            min_delta_map=min_delta_map,
-            min_delta_mrr=min_delta_mrr,
-            max_regression_precision=max_regression_precision,
-            max_regression_recall=max_regression_recall,
+            max_queries=compare_spec.max_queries,
+            min_delta_ndcg=compare_spec.thresholds.min_delta_ndcg,
+            min_delta_map=compare_spec.thresholds.min_delta_map,
+            min_delta_mrr=compare_spec.thresholds.min_delta_mrr,
+            max_regression_precision=compare_spec.thresholds.max_regression_precision,
+            max_regression_recall=compare_spec.thresholds.max_regression_recall,
         )
         _write_json_output(json_out, eval_compare_result_to_json(result))
+        _write_json_output(report_out, eval_compare_report_to_json(result))
 
         baseline_line, candidate_line, delta_line, gate_line = format_eval_compare_result(result)
         click.echo(baseline_line)

--- a/src/local_rag_backend/composition/adapters.py
+++ b/src/local_rag_backend/composition/adapters.py
@@ -9,7 +9,6 @@ This module centralizes policy decisions for:
 
 from __future__ import annotations
 
-import hashlib
 import json
 import logging
 from collections.abc import Callable
@@ -18,10 +17,17 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from openai import OpenAI
-from sqlalchemy import create_engine, text
-from sqlalchemy.orm import sessionmaker
-from sqlalchemy.pool import StaticPool
+from sqlalchemy import text
 
+from local_rag_backend.composition.embeddings import (
+    DEFAULT_DENSE_BACKEND_MESSAGE as DEFAULT_DENSE_BACKEND_MESSAGE,
+    _settings_cfg_version,
+    build_dense_embedder_from_settings,
+)
+from local_rag_backend.composition.evaluation import (
+    build_eval_retriever_factory_port as build_eval_retriever_factory_port,
+    build_eval_storage_port as build_eval_storage_port,
+)
 from local_rag_backend.core.domain.retrieval import (
     RetrievalFilter,
     RetrievalRequest,
@@ -29,17 +35,13 @@ from local_rag_backend.core.domain.retrieval import (
     document_matches_filters,
     retrieval_result_from_pairs,
 )
-from local_rag_backend.core.errors import EmbeddingsBackendUnavailableError, LLMConfigurationError
+from local_rag_backend.core.errors import LLMConfigurationError
 from local_rag_backend.core.ports import (
     BlockingExecutorPort,
     BlockingTaskType,
     DocsImportLoaderPort,
     DocsReadPort,
     EmbedderPort,
-    EvalDatasetDocInput,
-    EvalRetrieverFactoryPort,
-    EvalRetrieverPort,
-    EvalStoragePort,
     HealthDiagnosticsPort,
     HistoryEntry,
     HistoryReadPort,
@@ -54,12 +56,7 @@ from local_rag_backend.core.ports import (
 )
 from local_rag_backend.core.services.rag_runtime import RagService
 from local_rag_backend.core.services.reranking import RerankingRetriever
-from local_rag_backend.core.services.types import EvalRetrievalConfig
 from local_rag_backend.infrastructure.concurrency.blocking import run_blocking
-from local_rag_backend.infrastructure.embeddings.cached import (
-    ContentAddressedCachingEmbedder,
-    resolve_embedding_cache_db_path,
-)
 from local_rag_backend.infrastructure.ingestion.loaders import (
     ChatGPTLoader,
     GeminiLoader,
@@ -88,10 +85,7 @@ from local_rag_backend.infrastructure.persistence.vector.manifest import (
 )
 from local_rag_backend.infrastructure.persistence.vector.storage import VectorStorage
 from local_rag_backend.infrastructure.retrieval.dense_vector import DenseVectorRetriever
-from local_rag_backend.infrastructure.retrieval.hybrid import (
-    HybridRetriever,
-    combine_hybrid_results,
-)
+from local_rag_backend.infrastructure.retrieval.hybrid import HybridRetriever
 from local_rag_backend.infrastructure.retrieval.sparse_bm25 import SparseBM25Retriever
 from local_rag_backend.infrastructure.search_backends import (
     ElasticLikeSearchRetriever,
@@ -114,16 +108,6 @@ if TYPE_CHECKING:
     from local_rag_backend.settings import Settings
 T = TypeVar("T")
 logger = logging.getLogger(__name__)
-
-
-DEFAULT_DENSE_BACKEND_MESSAGE = (
-    "Dense/hybrid retrieval requires an embeddings backend. "
-    "Configure openai_api_key in config.yaml to use OpenAI embeddings, or install the "
-    "'dense-st' extra for SentenceTransformers (e.g. `uv sync --extra dense-st`)."
-)
-# Keep eval rebuild batches bounded so large offline datasets do not materialize every
-# document embedding in memory at once.
-EVAL_DENSE_REBUILD_BATCH_SIZE = 64
 
 
 @dataclass(frozen=True)
@@ -319,424 +303,6 @@ class _DefaultRagRuntimeFactory(RagRuntimeFactoryPort):
         )
 
 
-class _SqlEvalStoragePort(EvalStoragePort):
-    """Evaluation storage adapter for offline/e2e workflows.
-
-    The port isolates evaluation from production persistence by creating a dedicated
-    local SQLite-backed workspace per dataset signature.
-    """
-
-    def __init__(self, *, settings_obj: Settings) -> None:
-        self._base_settings = settings_obj
-        self._workspace_root = Path(settings_obj.data_dir).resolve() / "_eval_workspaces"
-        self._active_dataset_signature: str | None = None
-        self._active_dataset_id: str | None = None
-        self._active_external_ids: tuple[str, ...] = ()
-        self._eval_settings = self._settings_for_eval_root(self._workspace_root / "_pending")
-        self._doc_repo: SqlDocumentStorage | None = None
-
-    def _get_doc_repo(self) -> SqlDocumentStorage:
-        """Return the active dataset repository, initializing it when first used."""
-        if self._doc_repo is None:
-            self._doc_repo = self._new_doc_repo()
-        return self._doc_repo
-
-    def _new_doc_repo(self) -> SqlDocumentStorage:
-        engine = create_engine(
-            "sqlite:///:memory:",
-            connect_args={"check_same_thread": False},
-            poolclass=StaticPool,
-        )
-        session_local = sessionmaker(bind=engine, autocommit=False, autoflush=False)
-
-        # Side-effect import: registers SQLAlchemy model metadata with db_base.
-        from local_rag_backend.infrastructure.persistence.sql import models as _models  # noqa: F401
-
-        db_base.ensure_sqlite_schema_compatible(engine_to_use=engine)
-        return SqlDocumentStorage(session_factory=session_local)
-
-    def _settings_for_eval_root(self, eval_root: Path) -> Settings:
-        return self._base_settings.model_copy(
-            update={
-                "persistence_backend": "local_split",
-                "search_backend": "local_split",
-                "data_dir": eval_root,
-                "index_path": str(eval_root / "eval.index"),
-                "id_map_path": str(eval_root / "eval_id_map.json"),
-                "sqlite_url": f"sqlite:///{eval_root / 'eval.db'}",
-            }
-        )
-
-    def _dataset_signature(
-        self,
-        *,
-        dataset_id: str,
-        docs: tuple[EvalDatasetDocInput, ...],
-    ) -> str:
-        digest = hashlib.sha256()
-        digest.update(str(dataset_id).encode("utf-8"))
-        for doc in docs:
-            digest.update(b"\0")
-            digest.update(str(doc.external_id).encode("utf-8"))
-            digest.update(b"\0")
-            digest.update(str(doc.source_id or "").encode("utf-8"))
-            digest.update(b"\0")
-            digest.update(
-                hashlib.sha256(str(doc.content).encode("utf-8")).hexdigest().encode("ascii")
-            )
-        return digest.hexdigest()
-
-    def _workspace_slug(self, dataset_id: str) -> str:
-        collapsed = "".join(ch if ch.isalnum() else "-" for ch in str(dataset_id).strip().lower())
-        normalized = "-".join(part for part in collapsed.split("-") if part)
-        return normalized[:48] or "dataset"
-
-    def _workspace_root_for_dataset(self, *, dataset_id: str, signature: str) -> Path:
-        slug = self._workspace_slug(dataset_id)
-        return self._workspace_root / f"{slug}-{signature[:16]}"
-
-    def get_dataset_signature(self) -> str | None:
-        return self._active_dataset_signature
-
-    def upsert_dataset_docs(
-        self,
-        *,
-        dataset_id: str,
-        docs: tuple[EvalDatasetDocInput, ...],
-    ) -> tuple[str, ...]:
-        signature = self._dataset_signature(dataset_id=dataset_id, docs=docs)
-        external_ids = tuple(str(doc.external_id) for doc in docs)
-        if (
-            self._active_dataset_id == str(dataset_id)
-            and self._active_dataset_signature == signature
-            and self._active_external_ids == external_ids
-        ):
-            return external_ids
-
-        eval_root = self._workspace_root_for_dataset(
-            dataset_id=str(dataset_id), signature=signature
-        )
-        eval_root.mkdir(parents=True, exist_ok=True)
-        self._eval_settings = self._settings_for_eval_root(eval_root)
-        self._doc_repo = self._new_doc_repo()
-        items = [
-            SqlDocumentStorage.UpsertDoc(
-                external_id=d.external_id,
-                content=d.content,
-                source_id=d.source_id,
-                metadata={"dataset_id": dataset_id, **(d.metadata or {})},
-            )
-            for d in docs
-        ]
-        results, _changed, _updated = self._doc_repo.upsert_documents_by_external_id(items)
-        self._active_dataset_id = str(dataset_id)
-        self._active_dataset_signature = signature
-        self._active_external_ids = external_ids
-        return tuple(str(r.external_id) for r in results if r.external_id is not None)
-
-    def list_documents(self) -> tuple[Any, ...]:
-        return tuple(self._get_doc_repo().get_all_documents())
-
-    def get_retriever_storage(self) -> Any:
-        return self._get_doc_repo()
-
-    def get_eval_settings(self) -> Any:
-        return self._eval_settings
-
-
-class _QueryCachingEmbedder(EmbedderPort):
-    """Cache exact single-text query embeddings within a prepared eval workspace."""
-
-    def __init__(self, base: EmbedderPort) -> None:
-        self._base = base
-        self.dim = base.dim
-        self._cache: dict[str, Any] = {}
-
-    def embed(self, texts: Sequence[str]) -> Sequence[Any]:
-        if len(texts) != 1:
-            return self._base.embed(texts)
-        text = str(texts[0])
-        cached = self._cache.get(text)
-        if cached is not None:
-            return [cached]
-        vector = self._base.embed(texts)[0]
-        self._cache[text] = vector
-        return [vector]
-
-
-class _PreparedEvalWorkspace:
-    """Prepared, immutable snapshot used by eval retriever assembly.
-
-    The class centralizes: workspace manifest checks, embedder caching,
-    vector index warm-up/rebuild and retriever combination. All heavy side effects are
-    deferred until the corresponding retriever/embedding path is actually requested.
-    """
-
-    def __init__(
-        self,
-        *,
-        storage: EvalStoragePort,
-        openai_embedder_factory: Callable[[], EmbedderPort],
-        st_embedder_factory: Callable[[str], EmbedderPort],
-        dense_retriever_factory: Callable[..., RetrieverPort],
-        hybrid_retriever_factory: Callable[..., RetrieverPort],
-        vector_repo_factory: Callable[..., Any],
-        reranker_factory: Callable[..., Any],
-    ) -> None:
-        self._storage = storage
-        self._docs = self._snapshot_documents(storage=storage)
-        self._doc_repo = storage.get_retriever_storage()
-        self._eval_settings = storage.get_eval_settings()
-        self._dataset_signature = (
-            getattr(storage, "get_dataset_signature", lambda: None)()
-            if callable(getattr(storage, "get_dataset_signature", None))
-            else None
-        )
-        self._openai_embedder_factory = openai_embedder_factory
-        self._st_embedder_factory = st_embedder_factory
-        self._dense_retriever_factory = dense_retriever_factory
-        self._hybrid_retriever_factory = hybrid_retriever_factory
-        self._vector_repo_factory = vector_repo_factory
-        self._reranker_factory = reranker_factory
-        self._query_embedder: EmbedderPort | None = None
-        self._vector_repo: Any | None = None
-        self._vector_repo_ready = False
-        self._sparse_retriever: RetrieverPort | None = None
-        self._dense_retriever: RetrieverPort | None = None
-
-    def _snapshot_documents(self, *, storage: EvalStoragePort) -> tuple[Any, ...]:
-        """Take a stable document snapshot for the active dataset revision."""
-        return tuple(storage.list_documents())
-
-    def _workspace_manifest_path(self) -> Path:
-        return Path(self._eval_settings.data_dir) / "eval_workspace_manifest.json"
-
-    def _doc_ids_signature(self) -> str:
-        digest = hashlib.sha256()
-        for doc in self._docs:
-            digest.update(str(doc.id).encode("utf-8"))
-            digest.update(b"\0")
-        return digest.hexdigest()
-
-    def _expected_workspace_manifest(self) -> dict[str, object]:
-        return {
-            "dataset_signature": self._dataset_signature,
-            "doc_ids_signature": self._doc_ids_signature(),
-            "doc_count": len(self._docs),
-            "index_path": str(self._eval_settings.index_path),
-            "id_map_path": str(self._eval_settings.id_map_path),
-            "vector_backend": str(getattr(self._eval_settings, "vector_backend", "auto")),
-            "vector_manifest_config": expected_manifest_config_from_settings(self._eval_settings),
-        }
-
-    def _workspace_manifest_matches(self) -> bool:
-        path = self._workspace_manifest_path()
-        if not path.exists():
-            return False
-        if not Path(self._eval_settings.index_path).exists():
-            return False
-        if not Path(self._eval_settings.id_map_path).exists():
-            return False
-        try:
-            payload = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, TypeError, ValueError):
-            return False
-        return isinstance(payload, dict) and payload == self._expected_workspace_manifest()
-
-    def _write_workspace_manifest(self) -> None:
-        path = self._workspace_manifest_path()
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(
-            json.dumps(self._expected_workspace_manifest(), indent=2) + "\n",
-            encoding="utf-8",
-        )
-
-    def _dense_embedder(self) -> EmbedderPort:
-        if self._query_embedder is not None:
-            return self._query_embedder
-        base = build_dense_embedder_from_settings(
-            settings_obj=self._eval_settings,
-            openai_embedder_factory=self._openai_embedder_factory,
-            st_embedder_factory=self._st_embedder_factory,
-            missing_backend_message=DEFAULT_DENSE_BACKEND_MESSAGE,
-        )
-        self._query_embedder = _QueryCachingEmbedder(base)
-        return self._query_embedder
-
-    def _dense_vector_repo(self) -> Any:
-        if self._vector_repo is not None:
-            return self._vector_repo
-        embedder = self._dense_embedder()
-        self._vector_repo = self._vector_repo_factory(
-            index_path=self._eval_settings.index_path,
-            id_map_path=self._eval_settings.id_map_path,
-            dim=embedder.dim,
-            backend=getattr(self._eval_settings, "vector_backend", "auto"),
-            settings_obj=self._eval_settings,
-        )
-        return self._vector_repo
-
-    def _ensure_vector_repo_ready(self) -> Any:
-        vector_repo = self._dense_vector_repo()
-        if self._vector_repo_ready:
-            return vector_repo
-        # Offline eval reuses a dataset-scoped workspace only when both the stored dense
-        # index files and the manifest agree on corpus identity plus vector backend/model
-        # expectations. Any drift forces a rebuild in the isolated eval workspace.
-        if self._workspace_manifest_matches():
-            self._vector_repo_ready = True
-            return vector_repo
-        if self._docs:
-            embedder = self._dense_embedder()
-            rebuild_batches: list[tuple[list[Any], Sequence[Any]]] = []
-            for start in range(0, len(self._docs), EVAL_DENSE_REBUILD_BATCH_SIZE):
-                chunk = self._docs[start : start + EVAL_DENSE_REBUILD_BATCH_SIZE]
-                chunk_ids = [doc.id for doc in chunk]
-                chunk_embeddings = embedder.embed([doc.content for doc in chunk])
-                rebuild_batches.append((chunk_ids, chunk_embeddings))
-            rebuild_from_batches = getattr(vector_repo, "rebuild_from_batches", None)
-            if callable(rebuild_from_batches):
-                rebuild_from_batches(rebuild_batches)
-            else:  # pragma: no cover
-                doc_ids = [doc.id for doc in self._docs]
-                embeddings = [vector for _ids, vectors in rebuild_batches for vector in vectors]
-                vector_repo.rebuild(doc_ids, embeddings)
-            self._write_workspace_manifest()
-        self._vector_repo_ready = True
-        return vector_repo
-
-    def _cached_sparse_retriever(self) -> RetrieverPort:
-        if self._sparse_retriever is None:
-            self._sparse_retriever = SparseBM25Retriever(
-                documents=[doc.content for doc in self._docs],
-                doc_ids=[doc.id for doc in self._docs],
-                doc_repo=self._doc_repo,
-                preloaded_docs=self._docs,
-            )
-        return self._sparse_retriever
-
-    def _build_eval_mode_retriever(self, *, config: EvalRetrievalConfig) -> RetrieverPort:
-        mode = str(config.retrieval_mode)
-        if mode in {"sparse", "dense", "dual"}:
-            return LocalSplitSearchRetriever(
-                doc_repo=self._doc_repo,
-                embedder=(self._dense_embedder() if mode in {"dense", "dual"} else None),
-                vector_repo=(self._ensure_vector_repo_ready() if mode == "dense" else None),
-                preloaded_docs=self._docs,
-                cached_sparse_retriever=cast(
-                    "SparseBM25Retriever", self._cached_sparse_retriever()
-                ),
-            )
-
-        dense_retriever = self._cached_dense_retriever()
-        sparse_retriever = self._cached_sparse_retriever()
-        return self._hybrid_retriever_factory(
-            dense=dense_retriever,
-            sparse=sparse_retriever,
-            alpha=self._select_hybrid_alpha(config=config),
-        )
-
-    def _select_hybrid_alpha(self, *, config: EvalRetrievalConfig) -> float:
-        """Resolve hybrid alpha with config override precedence."""
-        return (
-            config.hybrid_alpha
-            if config.hybrid_alpha is not None
-            else self._eval_settings.hybrid_retrieval_alpha
-        )
-
-    def _cached_dense_retriever(self) -> RetrieverPort:
-        if self._dense_retriever is None:
-            self._dense_retriever = self._dense_retriever_factory(
-                embedder=self._dense_embedder(),
-                vector_repo=self._ensure_vector_repo_ready(),
-                doc_repo=self._doc_repo,
-            )
-        return self._dense_retriever
-
-    def build_retriever(
-        self,
-        *,
-        config: EvalRetrievalConfig,
-        reranker_candidate_k: int,
-        reranker_strategy: str,
-    ) -> EvalRetrieverPort:
-        mode = str(config.retrieval_mode)
-        if mode not in {"sparse", "dense", "dual", "hybrid"}:
-            raise ValueError(f"Unsupported retrieval_mode: {mode}")
-
-        retriever = self._build_eval_mode_retriever(config=config)
-
-        if config.reranker_enabled:
-            retriever = self._reranker_factory(
-                retriever,
-                candidate_k=int(reranker_candidate_k),
-                strategy=str(reranker_strategy),
-            )
-        return cast("EvalRetrieverPort", retriever)
-
-    def retrieve_hybrid_alpha_group(
-        self,
-        *,
-        query: str,
-        top_k: int,
-        alphas: Sequence[float],
-    ) -> dict[float, RetrievalResult]:
-        if not alphas:
-            return {}
-        dense_result = self._cached_dense_retriever().retrieve(
-            RetrievalRequest(query=query, top_k=top_k, mode="dense")
-        )
-        sparse_result = self._cached_sparse_retriever().retrieve(
-            RetrievalRequest(query=query, top_k=top_k, mode="sparse")
-        )
-        return {
-            float(alpha): combine_hybrid_results(
-                dense_result=dense_result,
-                sparse_result=sparse_result,
-                alpha=float(alpha),
-                top_k=top_k,
-            )
-            for alpha in alphas
-        }
-
-
-@dataclass(frozen=True)
-class _DefaultEvalRetrieverFactoryPort(EvalRetrieverFactoryPort):
-    openai_embedder_factory: Callable[[], EmbedderPort]
-    st_embedder_factory: Callable[[str], EmbedderPort]
-    sparse_retriever_factory: Callable[..., RetrieverPort]
-    dense_retriever_factory: Callable[..., RetrieverPort]
-    hybrid_retriever_factory: Callable[..., RetrieverPort]
-    vector_repo_factory: Callable[..., Any]
-    reranker_factory: Callable[..., Any]
-
-    def build_retriever(
-        self,
-        *,
-        storage: EvalStoragePort,
-        config: EvalRetrievalConfig,
-        reranker_candidate_k: int,
-        reranker_strategy: str,
-    ) -> EvalRetrieverPort:
-        workspace = self.prepare_workspace(storage=storage)
-        return workspace.build_retriever(
-            config=config,
-            reranker_candidate_k=reranker_candidate_k,
-            reranker_strategy=reranker_strategy,
-        )
-
-    def prepare_workspace(self, *, storage: EvalStoragePort) -> _PreparedEvalWorkspace:
-        return _PreparedEvalWorkspace(
-            storage=storage,
-            openai_embedder_factory=self.openai_embedder_factory,
-            st_embedder_factory=self.st_embedder_factory,
-            dense_retriever_factory=self.dense_retriever_factory,
-            hybrid_retriever_factory=self.hybrid_retriever_factory,
-            vector_repo_factory=self.vector_repo_factory,
-            reranker_factory=self.reranker_factory,
-        )
-
-
 @dataclass(frozen=True)
 class _OpenAICompatibleOpenRouterClient(OpenRouterClientPort):
     client: Any
@@ -874,34 +440,6 @@ def build_rag_runtime_factory(
     )
 
 
-def build_eval_storage_port(
-    *,
-    settings_obj: Settings,
-) -> EvalStoragePort:
-    return _SqlEvalStoragePort(settings_obj=settings_obj)
-
-
-def build_eval_retriever_factory_port(
-    *,
-    openai_embedder_factory: Callable[[], EmbedderPort] | None = None,
-    st_embedder_factory: Callable[[str], EmbedderPort] | None = None,
-    sparse_retriever_factory: Callable[..., RetrieverPort] = SparseBM25Retriever,
-    dense_retriever_factory: Callable[..., RetrieverPort] = DenseVectorRetriever,
-    hybrid_retriever_factory: Callable[..., RetrieverPort] = HybridRetriever,
-    vector_repo_factory: Callable[..., Any] = VectorStorage,
-    reranker_factory: Callable[..., Any] = RerankingRetriever,
-) -> EvalRetrieverFactoryPort:
-    return _DefaultEvalRetrieverFactoryPort(
-        openai_embedder_factory=openai_embedder_factory or _build_default_openai_embedder,
-        st_embedder_factory=st_embedder_factory or _build_default_st_embedder,
-        sparse_retriever_factory=sparse_retriever_factory,
-        dense_retriever_factory=dense_retriever_factory,
-        hybrid_retriever_factory=hybrid_retriever_factory,
-        vector_repo_factory=vector_repo_factory,
-        reranker_factory=reranker_factory,
-    )
-
-
 def build_blocking_executor(
     *,
     run_blocking_fn: Callable[..., Awaitable[Any]] = run_blocking,
@@ -935,22 +473,6 @@ def build_openrouter_client_from_settings(
         client=client,
         default_model=str(settings_obj.openrouter_model),
     )
-
-
-def _build_default_openai_embedder() -> EmbedderPort:
-    from local_rag_backend.infrastructure.embeddings.openai import OpenAIEmbedder
-
-    return OpenAIEmbedder()
-
-
-def _build_default_st_embedder(model_name: str) -> EmbedderPort:
-    from local_rag_backend.infrastructure.embeddings.sentence_transformers import (
-        SentenceTransformerEmbedder,
-    )
-
-    return SentenceTransformerEmbedder(model_name=model_name)
-
-
 def get_available_llm_providers(*, settings_obj: Settings) -> dict[str, str]:
     providers: dict[str, str] = {}
     if settings_obj.openai_api_key:
@@ -962,52 +484,6 @@ def get_available_llm_providers(*, settings_obj: Settings) -> dict[str, str]:
     ):
         providers["openrouter"] = "configured"
     return providers
-
-
-def build_dense_embedder_from_settings(
-    *,
-    settings_obj: Settings,
-    openai_embedder_factory: Callable[[], EmbedderPort] | None = None,
-    st_embedder_factory: Callable[[str], EmbedderPort] | None = None,
-    missing_backend_message: str | None = None,
-) -> EmbedderPort:
-    """Build the dense embedder stack selected by settings.
-
-    OpenAI takes precedence when an API key is configured; otherwise the local
-    SentenceTransformers backend is attempted. The selected backend is always wrapped
-    in the persistent content-addressed cache used by retrieval and eval flows.
-    """
-    resolved_openai_factory = openai_embedder_factory or _build_default_openai_embedder
-    resolved_st_factory = st_embedder_factory or _build_default_st_embedder
-    backend_message = missing_backend_message or DEFAULT_DENSE_BACKEND_MESSAGE
-    cache_db_path = resolve_embedding_cache_db_path(
-        data_dir=Path(getattr(settings_obj, "data_dir", "data")),
-        configured_path=getattr(settings_obj, "embedding_cache_db_path", None),
-    )
-    if settings_obj.openai_api_key:
-        base = resolved_openai_factory()
-        provider = "openai"
-    else:
-        try:
-            base = resolved_st_factory(str(settings_obj.st_embedding_model))
-        except RuntimeError as e:
-            raise EmbeddingsBackendUnavailableError(backend_message) from e
-        provider = "sentence_transformers"
-    logger.info(
-        "dense_embedder_selected provider=%s mode=%s cache_key=%s backend=%s cfg_version=%s",
-        provider,
-        str(getattr(settings_obj, "retrieval_mode", "unknown")),
-        str(cache_db_path),
-        str(getattr(settings_obj, "search_backend", "local_split")),
-        _settings_cfg_version(settings_obj),
-    )
-    return ContentAddressedCachingEmbedder(
-        base=base,
-        cache_db_path=cache_db_path,
-        disabled=bool(getattr(settings_obj, "disable_embedding_cache", False)),
-    )
-
-
 def build_retriever_with_default_embedder_from_settings(
     *,
     settings_obj: Settings,
@@ -1053,12 +529,6 @@ def build_retriever_with_default_embedder_from_settings(
         vector_repo_factory=vector_repo_factory,
         reranker_factory=reranker_factory,
     )
-
-
-def _settings_cfg_version(settings_obj: Settings) -> str:
-    return str(getattr(settings_obj, "storage_profile", "") or "default")
-
-
 def _load_local_sparse_inputs(
     *,
     doc_repo: DocumentRepoPort,

--- a/src/local_rag_backend/composition/embeddings.py
+++ b/src/local_rag_backend/composition/embeddings.py
@@ -1,0 +1,83 @@
+"""Composition helpers for dense embedder selection."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from local_rag_backend.core.errors import EmbeddingsBackendUnavailableError
+from local_rag_backend.core.ports import EmbedderPort
+from local_rag_backend.infrastructure.embeddings.cached import (
+    ContentAddressedCachingEmbedder,
+    resolve_embedding_cache_db_path,
+)
+
+if TYPE_CHECKING:
+    from local_rag_backend.settings import Settings
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_DENSE_BACKEND_MESSAGE = (
+    "Dense/hybrid retrieval requires an embeddings backend. "
+    "Configure openai_api_key in config.yaml to use OpenAI embeddings, or install the "
+    "'dense-st' extra for SentenceTransformers (e.g. `uv sync --extra dense-st`)."
+)
+
+
+def _settings_cfg_version(settings_obj: Settings) -> str:
+    return str(getattr(settings_obj, "storage_profile", "") or "default")
+
+
+def _build_default_openai_embedder() -> EmbedderPort:
+    from local_rag_backend.infrastructure.embeddings.openai import OpenAIEmbedder
+
+    return OpenAIEmbedder()
+
+
+def _build_default_st_embedder(model_name: str) -> EmbedderPort:
+    from local_rag_backend.infrastructure.embeddings.sentence_transformers import (
+        SentenceTransformerEmbedder,
+    )
+
+    return SentenceTransformerEmbedder(model_name=model_name)
+
+
+def build_dense_embedder_from_settings(
+    *,
+    settings_obj: Settings,
+    openai_embedder_factory: Callable[[], EmbedderPort] | None = None,
+    st_embedder_factory: Callable[[str], EmbedderPort] | None = None,
+    missing_backend_message: str | None = None,
+) -> EmbedderPort:
+    """Build the dense embedder stack selected by settings."""
+    resolved_openai_factory = openai_embedder_factory or _build_default_openai_embedder
+    resolved_st_factory = st_embedder_factory or _build_default_st_embedder
+    backend_message = missing_backend_message or DEFAULT_DENSE_BACKEND_MESSAGE
+    cache_db_path = resolve_embedding_cache_db_path(
+        data_dir=Path(getattr(settings_obj, "data_dir", "data")),
+        configured_path=getattr(settings_obj, "embedding_cache_db_path", None),
+    )
+    if settings_obj.openai_api_key:
+        base = resolved_openai_factory()
+        provider = "openai"
+    else:
+        try:
+            base = resolved_st_factory(str(settings_obj.st_embedding_model))
+        except RuntimeError as e:
+            raise EmbeddingsBackendUnavailableError(backend_message) from e
+        provider = "sentence_transformers"
+    logger.info(
+        "dense_embedder_selected provider=%s mode=%s cache_key=%s backend=%s cfg_version=%s",
+        provider,
+        str(getattr(settings_obj, "retrieval_mode", "unknown")),
+        str(cache_db_path),
+        str(getattr(settings_obj, "search_backend", "local_split")),
+        _settings_cfg_version(settings_obj),
+    )
+    return ContentAddressedCachingEmbedder(
+        base=base,
+        cache_db_path=cache_db_path,
+        disabled=bool(getattr(settings_obj, "disable_embedding_cache", False)),
+    )

--- a/src/local_rag_backend/composition/evaluation.py
+++ b/src/local_rag_backend/composition/evaluation.py
@@ -1,0 +1,492 @@
+"""Composition adapters for isolated offline evaluation workspaces."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from local_rag_backend.composition.embeddings import (
+    DEFAULT_DENSE_BACKEND_MESSAGE,
+    _build_default_openai_embedder,
+    _build_default_st_embedder,
+    build_dense_embedder_from_settings,
+)
+from local_rag_backend.core.domain.retrieval import RetrievalRequest, RetrievalResult
+from local_rag_backend.core.ports import (
+    EmbedderPort,
+    EvalDatasetDocInput,
+    EvalRetrieverFactoryPort,
+    EvalRetrieverPort,
+    EvalStoragePort,
+    RetrieverPort,
+)
+from local_rag_backend.core.services.evaluation_models import EvalRetrievalConfig
+from local_rag_backend.core.services.reranking import RerankingRetriever
+from local_rag_backend.infrastructure.persistence.sql import (
+    SqlDocumentStorage,
+    base as db_base,
+)
+from local_rag_backend.infrastructure.persistence.vector.manifest import (
+    expected_manifest_config_from_settings,
+)
+from local_rag_backend.infrastructure.persistence.vector.storage import VectorStorage
+from local_rag_backend.infrastructure.retrieval.dense_vector import DenseVectorRetriever
+from local_rag_backend.infrastructure.retrieval.hybrid import (
+    HybridRetriever,
+    combine_hybrid_results,
+)
+from local_rag_backend.infrastructure.retrieval.sparse_bm25 import SparseBM25Retriever
+from local_rag_backend.infrastructure.search_backends import LocalSplitSearchRetriever
+
+if TYPE_CHECKING:
+    from local_rag_backend.settings import Settings
+
+# Keep eval rebuild batches bounded so large offline datasets do not materialize every
+# document embedding in memory at once.
+EVAL_DENSE_REBUILD_BATCH_SIZE = 64
+
+
+class _SqlEvalStoragePort(EvalStoragePort):
+    """Evaluation storage adapter for offline/e2e workflows.
+
+    The port isolates evaluation from production persistence by creating a dedicated
+    local SQLite-backed workspace per dataset signature.
+    """
+
+    def __init__(self, *, settings_obj: Settings) -> None:
+        self._base_settings = settings_obj
+        self._workspace_root = Path(settings_obj.data_dir).resolve() / "_eval_workspaces"
+        self._active_dataset_signature: str | None = None
+        self._active_dataset_id: str | None = None
+        self._active_external_ids: tuple[str, ...] = ()
+        self._eval_settings = self._settings_for_eval_root(self._workspace_root / "_pending")
+        self._doc_repo: SqlDocumentStorage | None = None
+
+    def _get_doc_repo(self) -> SqlDocumentStorage:
+        """Return the active dataset repository, initializing it when first used."""
+        if self._doc_repo is None:
+            self._doc_repo = self._new_doc_repo()
+        return self._doc_repo
+
+    def _new_doc_repo(self) -> SqlDocumentStorage:
+        engine = create_engine(
+            "sqlite:///:memory:",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        session_local = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+        # Side-effect import: registers SQLAlchemy model metadata with db_base.
+        from local_rag_backend.infrastructure.persistence.sql import models as _models  # noqa: F401
+
+        db_base.ensure_sqlite_schema_compatible(engine_to_use=engine)
+        return SqlDocumentStorage(session_factory=session_local)
+
+    def _settings_for_eval_root(self, eval_root: Path) -> Settings:
+        return self._base_settings.model_copy(
+            update={
+                "persistence_backend": "local_split",
+                "search_backend": "local_split",
+                "data_dir": eval_root,
+                "index_path": str(eval_root / "eval.index"),
+                "id_map_path": str(eval_root / "eval_id_map.json"),
+                "sqlite_url": f"sqlite:///{eval_root / 'eval.db'}",
+            }
+        )
+
+    def _dataset_signature(
+        self,
+        *,
+        dataset_id: str,
+        docs: tuple[EvalDatasetDocInput, ...],
+    ) -> str:
+        digest = hashlib.sha256()
+        digest.update(str(dataset_id).encode("utf-8"))
+        for doc in docs:
+            digest.update(b"\0")
+            digest.update(str(doc.external_id).encode("utf-8"))
+            digest.update(b"\0")
+            digest.update(str(doc.source_id or "").encode("utf-8"))
+            digest.update(b"\0")
+            digest.update(
+                hashlib.sha256(str(doc.content).encode("utf-8")).hexdigest().encode("ascii")
+            )
+        return digest.hexdigest()
+
+    def _workspace_slug(self, dataset_id: str) -> str:
+        collapsed = "".join(ch if ch.isalnum() else "-" for ch in str(dataset_id).strip().lower())
+        normalized = "-".join(part for part in collapsed.split("-") if part)
+        return normalized[:48] or "dataset"
+
+    def _workspace_root_for_dataset(self, *, dataset_id: str, signature: str) -> Path:
+        slug = self._workspace_slug(dataset_id)
+        return self._workspace_root / f"{slug}-{signature[:16]}"
+
+    def get_dataset_signature(self) -> str | None:
+        return self._active_dataset_signature
+
+    def upsert_dataset_docs(
+        self,
+        *,
+        dataset_id: str,
+        docs: tuple[EvalDatasetDocInput, ...],
+    ) -> tuple[str, ...]:
+        signature = self._dataset_signature(dataset_id=dataset_id, docs=docs)
+        external_ids = tuple(str(doc.external_id) for doc in docs)
+        if (
+            self._active_dataset_id == str(dataset_id)
+            and self._active_dataset_signature == signature
+            and self._active_external_ids == external_ids
+        ):
+            return external_ids
+
+        eval_root = self._workspace_root_for_dataset(
+            dataset_id=str(dataset_id), signature=signature
+        )
+        eval_root.mkdir(parents=True, exist_ok=True)
+        self._eval_settings = self._settings_for_eval_root(eval_root)
+        self._doc_repo = self._new_doc_repo()
+        items = [
+            SqlDocumentStorage.UpsertDoc(
+                external_id=d.external_id,
+                content=d.content,
+                source_id=d.source_id,
+                metadata={"dataset_id": dataset_id, **(d.metadata or {})},
+            )
+            for d in docs
+        ]
+        results, _changed, _updated = self._doc_repo.upsert_documents_by_external_id(items)
+        self._active_dataset_id = str(dataset_id)
+        self._active_dataset_signature = signature
+        self._active_external_ids = external_ids
+        return tuple(str(r.external_id) for r in results if r.external_id is not None)
+
+    def list_documents(self) -> tuple[Any, ...]:
+        return tuple(self._get_doc_repo().get_all_documents())
+
+    def get_retriever_storage(self) -> Any:
+        return self._get_doc_repo()
+
+    def get_eval_settings(self) -> Any:
+        return self._eval_settings
+
+
+class _QueryCachingEmbedder(EmbedderPort):
+    """Cache exact single-text query embeddings within a prepared eval workspace."""
+
+    def __init__(self, base: EmbedderPort) -> None:
+        self._base = base
+        self.dim = base.dim
+        self._cache: dict[str, Any] = {}
+
+    def embed(self, texts: Sequence[str]) -> Sequence[Any]:
+        if len(texts) != 1:
+            return self._base.embed(texts)
+        text = str(texts[0])
+        cached = self._cache.get(text)
+        if cached is not None:
+            return [cached]
+        vector = self._base.embed(texts)[0]
+        self._cache[text] = vector
+        return [vector]
+
+
+class _PreparedEvalWorkspace:
+    """Prepared, immutable snapshot used by eval retriever assembly."""
+
+    def __init__(
+        self,
+        *,
+        storage: EvalStoragePort,
+        openai_embedder_factory: Callable[[], EmbedderPort],
+        st_embedder_factory: Callable[[str], EmbedderPort],
+        dense_retriever_factory: Callable[..., RetrieverPort],
+        hybrid_retriever_factory: Callable[..., RetrieverPort],
+        vector_repo_factory: Callable[..., Any],
+        reranker_factory: Callable[..., Any],
+    ) -> None:
+        self._storage = storage
+        self._docs = self._snapshot_documents(storage=storage)
+        self._doc_repo = storage.get_retriever_storage()
+        self._eval_settings = storage.get_eval_settings()
+        self._dataset_signature = (
+            getattr(storage, "get_dataset_signature", lambda: None)()
+            if callable(getattr(storage, "get_dataset_signature", None))
+            else None
+        )
+        self._openai_embedder_factory = openai_embedder_factory
+        self._st_embedder_factory = st_embedder_factory
+        self._dense_retriever_factory = dense_retriever_factory
+        self._hybrid_retriever_factory = hybrid_retriever_factory
+        self._vector_repo_factory = vector_repo_factory
+        self._reranker_factory = reranker_factory
+        self._query_embedder: EmbedderPort | None = None
+        self._vector_repo: Any | None = None
+        self._vector_repo_ready = False
+        self._sparse_retriever: RetrieverPort | None = None
+        self._dense_retriever: RetrieverPort | None = None
+
+    def _snapshot_documents(self, *, storage: EvalStoragePort) -> tuple[Any, ...]:
+        """Take a stable document snapshot for the active dataset revision."""
+        return tuple(storage.list_documents())
+
+    def _workspace_manifest_path(self) -> Path:
+        return Path(self._eval_settings.data_dir) / "eval_workspace_manifest.json"
+
+    def _doc_ids_signature(self) -> str:
+        digest = hashlib.sha256()
+        for doc in self._docs:
+            digest.update(str(doc.id).encode("utf-8"))
+            digest.update(b"\0")
+        return digest.hexdigest()
+
+    def _expected_workspace_manifest(self) -> dict[str, object]:
+        return {
+            "dataset_signature": self._dataset_signature,
+            "doc_ids_signature": self._doc_ids_signature(),
+            "doc_count": len(self._docs),
+            "index_path": str(self._eval_settings.index_path),
+            "id_map_path": str(self._eval_settings.id_map_path),
+            "vector_backend": str(getattr(self._eval_settings, "vector_backend", "auto")),
+            "vector_manifest_config": expected_manifest_config_from_settings(self._eval_settings),
+        }
+
+    def _workspace_manifest_matches(self) -> bool:
+        path = self._workspace_manifest_path()
+        if not path.exists():
+            return False
+        if not Path(self._eval_settings.index_path).exists():
+            return False
+        if not Path(self._eval_settings.id_map_path).exists():
+            return False
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, TypeError, ValueError):
+            return False
+        return isinstance(payload, dict) and payload == self._expected_workspace_manifest()
+
+    def _write_workspace_manifest(self) -> None:
+        path = self._workspace_manifest_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(self._expected_workspace_manifest(), indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+    def _dense_embedder(self) -> EmbedderPort:
+        if self._query_embedder is not None:
+            return self._query_embedder
+        base = build_dense_embedder_from_settings(
+            settings_obj=self._eval_settings,
+            openai_embedder_factory=self._openai_embedder_factory,
+            st_embedder_factory=self._st_embedder_factory,
+            missing_backend_message=DEFAULT_DENSE_BACKEND_MESSAGE,
+        )
+        self._query_embedder = _QueryCachingEmbedder(base)
+        return self._query_embedder
+
+    def _dense_vector_repo(self) -> Any:
+        if self._vector_repo is not None:
+            return self._vector_repo
+        embedder = self._dense_embedder()
+        self._vector_repo = self._vector_repo_factory(
+            index_path=self._eval_settings.index_path,
+            id_map_path=self._eval_settings.id_map_path,
+            dim=embedder.dim,
+            backend=getattr(self._eval_settings, "vector_backend", "auto"),
+            settings_obj=self._eval_settings,
+        )
+        return self._vector_repo
+
+    def _ensure_vector_repo_ready(self) -> Any:
+        vector_repo = self._dense_vector_repo()
+        if self._vector_repo_ready:
+            return vector_repo
+        if self._workspace_manifest_matches():
+            self._vector_repo_ready = True
+            return vector_repo
+        if self._docs:
+            embedder = self._dense_embedder()
+            rebuild_batches: list[tuple[list[Any], Sequence[Any]]] = []
+            for start in range(0, len(self._docs), EVAL_DENSE_REBUILD_BATCH_SIZE):
+                chunk = self._docs[start : start + EVAL_DENSE_REBUILD_BATCH_SIZE]
+                chunk_ids = [doc.id for doc in chunk]
+                chunk_embeddings = embedder.embed([doc.content for doc in chunk])
+                rebuild_batches.append((chunk_ids, chunk_embeddings))
+            rebuild_from_batches = getattr(vector_repo, "rebuild_from_batches", None)
+            if callable(rebuild_from_batches):
+                rebuild_from_batches(rebuild_batches)
+            else:  # pragma: no cover
+                doc_ids = [doc.id for doc in self._docs]
+                embeddings = [vector for _ids, vectors in rebuild_batches for vector in vectors]
+                vector_repo.rebuild(doc_ids, embeddings)
+            self._write_workspace_manifest()
+        self._vector_repo_ready = True
+        return vector_repo
+
+    def _cached_sparse_retriever(self) -> RetrieverPort:
+        if self._sparse_retriever is None:
+            self._sparse_retriever = SparseBM25Retriever(
+                documents=[doc.content for doc in self._docs],
+                doc_ids=[doc.id for doc in self._docs],
+                doc_repo=self._doc_repo,
+                preloaded_docs=self._docs,
+            )
+        return self._sparse_retriever
+
+    def _build_eval_mode_retriever(self, *, config: EvalRetrievalConfig) -> RetrieverPort:
+        mode = str(config.retrieval_mode)
+        if mode in {"sparse", "dense", "dual"}:
+            return LocalSplitSearchRetriever(
+                doc_repo=self._doc_repo,
+                embedder=(self._dense_embedder() if mode in {"dense", "dual"} else None),
+                vector_repo=(self._ensure_vector_repo_ready() if mode == "dense" else None),
+                preloaded_docs=self._docs,
+                cached_sparse_retriever=cast(
+                    "SparseBM25Retriever", self._cached_sparse_retriever()
+                ),
+            )
+
+        dense_retriever = self._cached_dense_retriever()
+        sparse_retriever = self._cached_sparse_retriever()
+        return self._hybrid_retriever_factory(
+            dense=dense_retriever,
+            sparse=sparse_retriever,
+            alpha=self._select_hybrid_alpha(config=config),
+        )
+
+    def _select_hybrid_alpha(self, *, config: EvalRetrievalConfig) -> float:
+        """Resolve hybrid alpha with config override precedence."""
+        return (
+            config.hybrid_alpha
+            if config.hybrid_alpha is not None
+            else self._eval_settings.hybrid_retrieval_alpha
+        )
+
+    def _cached_dense_retriever(self) -> RetrieverPort:
+        if self._dense_retriever is None:
+            self._dense_retriever = self._dense_retriever_factory(
+                embedder=self._dense_embedder(),
+                vector_repo=self._ensure_vector_repo_ready(),
+                doc_repo=self._doc_repo,
+            )
+        return self._dense_retriever
+
+    def build_retriever(
+        self,
+        *,
+        config: EvalRetrievalConfig,
+        reranker_candidate_k: int,
+        reranker_strategy: str,
+    ) -> EvalRetrieverPort:
+        mode = str(config.retrieval_mode)
+        if mode not in {"sparse", "dense", "dual", "hybrid"}:
+            raise ValueError(f"Unsupported retrieval_mode: {mode}")
+
+        retriever = self._build_eval_mode_retriever(config=config)
+
+        if config.reranker_enabled:
+            retriever = self._reranker_factory(
+                retriever,
+                candidate_k=int(reranker_candidate_k),
+                strategy=str(reranker_strategy),
+            )
+        return cast("EvalRetrieverPort", retriever)
+
+    def retrieve_hybrid_alpha_group(
+        self,
+        *,
+        query: str,
+        top_k: int,
+        alphas: Sequence[float],
+    ) -> dict[float, RetrievalResult]:
+        if not alphas:
+            return {}
+        dense_result = self._cached_dense_retriever().retrieve(
+            RetrievalRequest(query=query, top_k=top_k, mode="dense")
+        )
+        sparse_result = self._cached_sparse_retriever().retrieve(
+            RetrievalRequest(query=query, top_k=top_k, mode="sparse")
+        )
+        return {
+            float(alpha): combine_hybrid_results(
+                dense_result=dense_result,
+                sparse_result=sparse_result,
+                alpha=float(alpha),
+                top_k=top_k,
+            )
+            for alpha in alphas
+        }
+
+
+@dataclass(frozen=True)
+class _DefaultEvalRetrieverFactoryPort(EvalRetrieverFactoryPort):
+    openai_embedder_factory: Callable[[], EmbedderPort]
+    st_embedder_factory: Callable[[str], EmbedderPort]
+    sparse_retriever_factory: Callable[..., RetrieverPort]
+    dense_retriever_factory: Callable[..., RetrieverPort]
+    hybrid_retriever_factory: Callable[..., RetrieverPort]
+    vector_repo_factory: Callable[..., Any]
+    reranker_factory: Callable[..., Any]
+
+    def build_retriever(
+        self,
+        *,
+        storage: EvalStoragePort,
+        config: EvalRetrievalConfig,
+        reranker_candidate_k: int,
+        reranker_strategy: str,
+    ) -> EvalRetrieverPort:
+        workspace = self.prepare_workspace(storage=storage)
+        return workspace.build_retriever(
+            config=config,
+            reranker_candidate_k=reranker_candidate_k,
+            reranker_strategy=reranker_strategy,
+        )
+
+    def prepare_workspace(self, *, storage: EvalStoragePort) -> _PreparedEvalWorkspace:
+        return _PreparedEvalWorkspace(
+            storage=storage,
+            openai_embedder_factory=self.openai_embedder_factory,
+            st_embedder_factory=self.st_embedder_factory,
+            dense_retriever_factory=self.dense_retriever_factory,
+            hybrid_retriever_factory=self.hybrid_retriever_factory,
+            vector_repo_factory=self.vector_repo_factory,
+            reranker_factory=self.reranker_factory,
+        )
+
+
+def build_eval_storage_port(
+    *,
+    settings_obj: Settings,
+) -> EvalStoragePort:
+    return _SqlEvalStoragePort(settings_obj=settings_obj)
+
+
+def build_eval_retriever_factory_port(
+    *,
+    openai_embedder_factory: Callable[[], EmbedderPort] | None = None,
+    st_embedder_factory: Callable[[str], EmbedderPort] | None = None,
+    sparse_retriever_factory: Callable[..., RetrieverPort] = SparseBM25Retriever,
+    dense_retriever_factory: Callable[..., RetrieverPort] = DenseVectorRetriever,
+    hybrid_retriever_factory: Callable[..., RetrieverPort] = HybridRetriever,
+    vector_repo_factory: Callable[..., Any] = VectorStorage,
+    reranker_factory: Callable[..., Any] = RerankingRetriever,
+) -> EvalRetrieverFactoryPort:
+    return _DefaultEvalRetrieverFactoryPort(
+        openai_embedder_factory=openai_embedder_factory or _build_default_openai_embedder,
+        st_embedder_factory=st_embedder_factory or _build_default_st_embedder,
+        sparse_retriever_factory=sparse_retriever_factory,
+        dense_retriever_factory=dense_retriever_factory,
+        hybrid_retriever_factory=hybrid_retriever_factory,
+        vector_repo_factory=vector_repo_factory,
+        reranker_factory=reranker_factory,
+    )

--- a/src/local_rag_backend/core/ports/use_cases.py
+++ b/src/local_rag_backend/core/ports/use_cases.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeVar
 
-from local_rag_backend.core.services.types import EvalRetrievalConfig
+from local_rag_backend.core.services.evaluation_models import EvalRetrievalConfig
 
 if TYPE_CHECKING:
     from local_rag_backend.core.domain.retrieval import (

--- a/src/local_rag_backend/core/services/evaluation.py
+++ b/src/local_rag_backend/core/services/evaluation.py
@@ -1,401 +1,127 @@
-"""
-Offline IR evaluation for retrieval quality.
-
-Focus: reproducible retrieval metrics without requiring an LLM provider.
-"""
+"""Facade for evaluation services during the eval surface cleanup."""
 
 from __future__ import annotations
 
-import json
-from pathlib import Path
-from typing import TYPE_CHECKING, Any
-
-import ir_measures
-from ir_measures import AP, RR, P, R, nDCG
-
-if TYPE_CHECKING:
-    from collections.abc import Callable, Sequence
-
-
-from local_rag_backend.core.services.types import (
+from local_rag_backend.core.services.evaluation_datasets import (
+    default_eval_dataset_path,
+    load_eval_dataset,
+    qrels_for_query,
+)
+from local_rag_backend.core.services.evaluation_metrics import (
+    calculate_eval_metrics,
+    compare_eval_results,
+    compare_metrics_delta,
+    run_retrieval_eval,
+)
+from local_rag_backend.core.services.evaluation_models import (
+    EvalAnomaly,
+    EvalBatchResult,
+    EvalBatchSpec,
+    EvalBenchmark,
+    EvalCompareConfig,
     EvalCompareDelta,
     EvalCompareGate,
+    EvalCompareQueryDelta,
     EvalCompareResult,
+    EvalCompareSpec,
+    EvalCompareThresholds,
     EvalDataset,
     EvalDoc,
+    EvalJudge,
+    EvalQrel,
     EvalQuery,
+    EvalQueryMetrics,
+    EvalQueryResult,
+    EvalReport,
     EvalResult,
+    EvalRetrievalConfig,
     EvalRetrievalMode,
+    EvalRetrievedItem,
+    EvalRunItem,
+)
+from local_rag_backend.core.services.evaluation_serialization import (
+    eval_anomalies_to_jsonl,
+    eval_compare_report_to_json,
+    eval_compare_result_to_json,
+    eval_metrics_to_json,
+    eval_query_metrics_to_json,
+    eval_result_report_to_json,
+    eval_result_summary_to_json,
+    eval_result_to_json,
+    format_eval_compare_result,
+    format_eval_result,
+    write_eval_run_jsonl,
+)
+from local_rag_backend.core.services.evaluation_validation import (
+    VALID_EVAL_RETRIEVAL_MODES,
+    build_eval_retrieval_config,
+    eval_compare_config_to_retrieval_config,
+    parse_bool_field,
+    parse_eval_batch_spec,
+    parse_eval_compare_config,
+    parse_eval_compare_spec,
+    parse_eval_compare_thresholds,
+    parse_eval_retrieval_mode,
+    parse_int_field,
+    parse_optional_float_field,
+    parse_optional_int_field,
+    validate_eval_retrieval_config,
 )
 
-
-def _default_eval_dataset_path() -> Path:
-    # src/local_rag_backend/core/services/evaluation.py -> repo root
-    return Path(__file__).resolve().parents[4] / "datasets" / "rag_eval_v1.jsonl"
-
-
-def _parse_schema_version(raw_value: Any, *, lineno: int) -> int:
-    try:
-        return int(raw_value or 0)
-    except (TypeError, ValueError) as exc:
-        raise ValueError(
-            f"Invalid dataset line {lineno}: schema_version must be an integer."
-        ) from exc
-
-
-def load_eval_dataset(path: str | Path | None = None) -> EvalDataset:
-    content: str
-    if path is None:
-        p = _default_eval_dataset_path()
-        if not p.is_file():
-            raise FileNotFoundError(
-                f"Default eval dataset not found: {p}. Pass --dataset or configure "
-                "eval_dataset_path in config.yaml."
-            )
-        content = p.read_text(encoding="utf-8")
-    else:
-        p = Path(path)
-        if not p.is_file():
-            raise FileNotFoundError(f"Dataset not found: {p}")
-        content = p.read_text(encoding="utf-8")
-
-    dataset_id = "unknown"
-    schema_version = 0
-    docs: list[EvalDoc] = []
-    queries: list[EvalQuery] = []
-    known_doc_ids: set[str] = set()
-
-    for lineno, line in enumerate(content.splitlines(), 1):
-        s = line.strip()
-        if not s:
-            continue
-        obj = json.loads(s)
-        if not isinstance(obj, dict):
-            raise ValueError(f"Invalid dataset line {lineno}: expected JSON object.")
-        t = obj.get("type")
-        if t == "meta":
-            dataset_id = str(obj.get("dataset_id") or dataset_id)
-            schema_version = _parse_schema_version(obj.get("schema_version"), lineno=lineno)
-        elif t == "doc":
-            external_id = str(obj["external_id"]).strip()
-            if not external_id:
-                raise ValueError(f"Invalid dataset line {lineno}: external_id must not be blank.")
-            if external_id in known_doc_ids:
-                raise ValueError(
-                    f"Invalid dataset line {lineno}: duplicate doc external_id={external_id!r}."
-                )
-            known_doc_ids.add(external_id)
-            docs.append(
-                EvalDoc(
-                    external_id=external_id,
-                    content=str(obj["content"]),
-                    source_id=(
-                        str(obj.get("source_id")) if obj.get("source_id") is not None else None
-                    ),
-                )
-            )
-        elif t == "query":
-            rel = obj.get("relevant_external_ids") or []
-            if not isinstance(rel, list) or not all(isinstance(x, str) for x in rel):
-                raise ValueError(
-                    f"Invalid dataset line {lineno}: relevant_external_ids must be list[str]."
-                )
-            normalized_rel = tuple(str(external_id).strip() for external_id in rel)
-            if not normalized_rel:
-                raise ValueError(
-                    f"Invalid dataset line {lineno}: relevant_external_ids must not be empty."
-                )
-            if any(not external_id for external_id in normalized_rel):
-                raise ValueError(
-                    f"Invalid dataset line {lineno}: relevant_external_ids must not contain blank IDs."
-                )
-            queries.append(
-                EvalQuery(
-                    query=str(obj["query"]),
-                    relevant_external_ids=normalized_rel,
-                )
-            )
-        else:
-            raise ValueError(f"Invalid dataset line {lineno}: unknown type={t!r}")
-
-    if schema_version != 1:
-        raise ValueError(f"Unsupported schema_version={schema_version} (expected 1).")
-    if not docs:
-        raise ValueError("Dataset contains no docs.")
-    if not queries:
-        raise ValueError("Dataset contains no queries.")
-    for query in queries:
-        missing_ids = sorted(
-            {
-                external_id
-                for external_id in query.relevant_external_ids
-                if external_id not in known_doc_ids
-            }
-        )
-        if missing_ids:
-            raise ValueError(
-                "Dataset query references relevant_external_ids outside the corpus: "
-                + ", ".join(missing_ids[:10])
-            )
-
-    return EvalDataset(
-        dataset_id=str(dataset_id),
-        schema_version=int(schema_version),
-        docs=tuple(docs),
-        queries=tuple(queries),
-    )
-
-
-def run_retrieval_eval(
-    *,
-    dataset: EvalDataset,
-    retrieve_external_ids: Callable[[str, int], Sequence[str]] | None = None,
-    retrieval_mode: EvalRetrievalMode = "sparse",
-    k: int = 3,
-    reranker_enabled: bool = False,
-    reranker_candidate_k: int = 20,
-    reranker_strategy: str = "overlap_v1",
-    max_queries: int | None = None,
-    run_out: Path | None = None,
-) -> EvalResult:
-    # Backward-compatible kwargs retained for callers migrating from the previous
-    # infra-coupled implementation where reranker wiring happened in this layer.
-    _ = (reranker_candidate_k, reranker_strategy)
-    if k <= 0:
-        raise ValueError("k must be positive")
-
-    qs: list[EvalQuery] = list(dataset.queries)
-    if max_queries is not None:
-        qs = qs[: max(0, int(max_queries))]
-    if not qs:
-        raise ValueError("No queries to evaluate after max_queries.")
-    if retrieve_external_ids is None:
-        raise ValueError("retrieve_external_ids callback is required for offline IR evaluation.")
-    known_doc_ids = {
-        str(doc.external_id).strip() for doc in dataset.docs if str(doc.external_id).strip()
-    }
-    if not known_doc_ids:
-        raise ValueError("Dataset contains no known corpus document IDs.")
-
-    qrels: dict[str, dict[str, int]] = {}
-    run: dict[str, dict[str, float]] = {}
-    for idx, q in enumerate(qs, start=1):
-        query_id = f"q{idx:06d}"
-        qrels[query_id] = {
-            external_id: 1
-            for external_id in q.relevant_external_ids
-            if external_id in known_doc_ids
-        }
-        if not qrels[query_id]:
-            raise ValueError(
-                f"Query {query_id} has no relevant corpus IDs after dataset validation."
-            )
-
-        ranked_docs: dict[str, float] = {}
-        seen_external_ids: set[str] = set()
-        for external_id in retrieve_external_ids(q.query, k):
-            normalized_external_id = str(external_id).strip()
-            if (
-                not normalized_external_id
-                or normalized_external_id in seen_external_ids
-                or normalized_external_id not in known_doc_ids
-            ):
-                continue
-            seen_external_ids.add(normalized_external_id)
-            rank = len(ranked_docs) + 1
-            ranked_docs[normalized_external_id] = float(max(k - rank + 1, 1))
-            if len(ranked_docs) >= int(k):
-                break
-        run[query_id] = ranked_docs
-
-    if run_out is not None:
-        run_out.parent.mkdir(parents=True, exist_ok=True)
-        with run_out.open("w", encoding="utf-8") as _f:
-            for idx, q in enumerate(qs, start=1):
-                query_id = f"q{idx:06d}"
-                ranked_list = sorted(run[query_id].items(), key=lambda x: -x[1])
-                _f.write(
-                    json.dumps(
-                        {
-                            "query_id": query_id,
-                            "query_text": q.query,
-                            "retrieval_mode": retrieval_mode,
-                            "k": k,
-                            "ranked_docs": [
-                                {"external_id": ext_id, "rank": rank, "score": score}
-                                for rank, (ext_id, score) in enumerate(ranked_list, start=1)
-                            ],
-                        }
-                    )
-                    + "\n"
-                )
-
-    measures = (
-        nDCG @ k,
-        AP @ k,
-        RR @ k,
-        P @ k,
-        R @ k,
-    )
-    aggregated = ir_measures.calc_aggregate(measures, qrels, run)
-    n = len(qs)
-    return EvalResult(
-        dataset_id=dataset.dataset_id,
-        retrieval_mode=retrieval_mode,
-        reranker_enabled=bool(reranker_enabled),
-        k=int(k),
-        queries=n,
-        ndcg_at_k=float(aggregated[nDCG @ k]),
-        map_at_k=float(aggregated[AP @ k]),
-        mrr_at_k=float(aggregated[RR @ k]),
-        precision_at_k=float(aggregated[P @ k]),
-        recall_at_k=float(aggregated[R @ k]),
-    )
-
-
-def format_eval_result(result: EvalResult) -> str:
-    return (
-        f"dataset={result.dataset_id} mode={result.retrieval_mode} reranker={result.reranker_enabled} "
-        f"k={result.k} queries={result.queries} "
-        f"nDCG@{result.k}={result.ndcg_at_k:.3f} "
-        f"MAP@{result.k}={result.map_at_k:.3f} "
-        f"MRR@{result.k}={result.mrr_at_k:.3f} "
-        f"P@{result.k}={result.precision_at_k:.3f} "
-        f"Recall@{result.k}={result.recall_at_k:.3f}"
-    )
-
-
-def _eval_metrics_to_json(result: EvalResult) -> dict[str, float]:
-    return {
-        f"nDCG@{result.k}": result.ndcg_at_k,
-        f"MAP@{result.k}": result.map_at_k,
-        f"MRR@{result.k}": result.mrr_at_k,
-        f"P@{result.k}": result.precision_at_k,
-        f"Recall@{result.k}": result.recall_at_k,
-    }
-
-
-def eval_result_to_json(result: EvalResult) -> dict[str, Any]:
-    return {
-        "dataset_id": result.dataset_id,
-        "retrieval_mode": result.retrieval_mode,
-        "reranker_enabled": result.reranker_enabled,
-        "k": result.k,
-        "queries": result.queries,
-        "metrics": _eval_metrics_to_json(result),
-    }
-
-
-def compare_eval_results(
-    *,
-    baseline: EvalResult,
-    candidate: EvalResult,
-    min_delta_ndcg: float = 0.0,
-    min_delta_map: float = 0.0,
-    min_delta_mrr: float = 0.0,
-    max_regression_precision: float = 0.0,
-    max_regression_recall: float = 0.0,
-) -> EvalCompareResult:
-    if baseline.dataset_id != candidate.dataset_id:
-        raise ValueError("Baseline and candidate dataset_id must match.")
-    if baseline.k != candidate.k:
-        raise ValueError("Baseline and candidate k must match.")
-
-    delta = EvalCompareDelta(
-        ndcg_at_k=float(candidate.ndcg_at_k - baseline.ndcg_at_k),
-        map_at_k=float(candidate.map_at_k - baseline.map_at_k),
-        mrr_at_k=float(candidate.mrr_at_k - baseline.mrr_at_k),
-        precision_at_k=float(candidate.precision_at_k - baseline.precision_at_k),
-        recall_at_k=float(candidate.recall_at_k - baseline.recall_at_k),
-    )
-
-    reasons: list[str] = []
-    if delta.ndcg_at_k < float(min_delta_ndcg):
-        reasons.append(
-            f"nDCG@{baseline.k} delta={delta.ndcg_at_k:.3f} (min {float(min_delta_ndcg):.3f})"
-        )
-    if delta.map_at_k < float(min_delta_map):
-        reasons.append(
-            f"MAP@{baseline.k} delta={delta.map_at_k:.3f} (min {float(min_delta_map):.3f})"
-        )
-    if delta.mrr_at_k < float(min_delta_mrr):
-        reasons.append(
-            f"MRR@{baseline.k} delta={delta.mrr_at_k:.3f} (min {float(min_delta_mrr):.3f})"
-        )
-    if delta.precision_at_k < -abs(float(max_regression_precision)):
-        reasons.append(
-            f"P@{baseline.k} delta={delta.precision_at_k:.3f} "
-            f"(max regression {float(max_regression_precision):.3f})"
-        )
-    if delta.recall_at_k < -abs(float(max_regression_recall)):
-        reasons.append(
-            f"Recall@{baseline.k} delta={delta.recall_at_k:.3f} "
-            f"(max regression {float(max_regression_recall):.3f})"
-        )
-
-    return EvalCompareResult(
-        dataset_id=baseline.dataset_id,
-        k=int(baseline.k),
-        baseline=baseline,
-        candidate=candidate,
-        delta=delta,
-        gate=EvalCompareGate(
-            passed=not reasons,
-            reasons=tuple(reasons),
-            min_delta_ndcg=float(min_delta_ndcg),
-            min_delta_map=float(min_delta_map),
-            min_delta_mrr=float(min_delta_mrr),
-            max_regression_precision=float(max_regression_precision),
-            max_regression_recall=float(max_regression_recall),
-        ),
-    )
-
-
-def format_eval_compare_result(result: EvalCompareResult) -> tuple[str, str, str, str]:
-    k = int(result.k)
-    baseline_line = "BASELINE  " + format_eval_result(result.baseline)
-    candidate_line = "CANDIDATE " + format_eval_result(result.candidate)
-    delta_line = (
-        f"DELTA     nDCG@{k}={result.delta.ndcg_at_k:+.3f} "
-        f"MAP@{k}={result.delta.map_at_k:+.3f} "
-        f"MRR@{k}={result.delta.mrr_at_k:+.3f} "
-        f"P@{k}={result.delta.precision_at_k:+.3f} "
-        f"Recall@{k}={result.delta.recall_at_k:+.3f}"
-    )
-    gate_line = "PASS" if result.gate.passed else "FAIL: " + "; ".join(result.gate.reasons)
-    return baseline_line, candidate_line, delta_line, gate_line
-
-
-def eval_compare_result_to_json(result: EvalCompareResult) -> dict[str, Any]:
-    return {
-        "dataset_id": result.dataset_id,
-        "k": result.k,
-        "baseline": {
-            "retrieval_mode": result.baseline.retrieval_mode,
-            "reranker_enabled": result.baseline.reranker_enabled,
-            "metrics": _eval_metrics_to_json(result.baseline),
-        },
-        "candidate": {
-            "retrieval_mode": result.candidate.retrieval_mode,
-            "reranker_enabled": result.candidate.reranker_enabled,
-            "metrics": _eval_metrics_to_json(result.candidate),
-        },
-        "delta": {
-            f"nDCG@{result.k}": result.delta.ndcg_at_k,
-            f"MAP@{result.k}": result.delta.map_at_k,
-            f"MRR@{result.k}": result.delta.mrr_at_k,
-            f"P@{result.k}": result.delta.precision_at_k,
-            f"Recall@{result.k}": result.delta.recall_at_k,
-        },
-        "gate": {
-            "passed": result.gate.passed,
-            "reasons": list(result.gate.reasons),
-            "thresholds": {
-                "min_delta_ndcg": result.gate.min_delta_ndcg,
-                "min_delta_map": result.gate.min_delta_map,
-                "min_delta_mrr": result.gate.min_delta_mrr,
-                "max_regression_precision": result.gate.max_regression_precision,
-                "max_regression_recall": result.gate.max_regression_recall,
-            },
-        },
-    }
+__all__ = [
+    "VALID_EVAL_RETRIEVAL_MODES",
+    "EvalAnomaly",
+    "EvalBatchResult",
+    "EvalBatchSpec",
+    "EvalBenchmark",
+    "EvalCompareConfig",
+    "EvalCompareDelta",
+    "EvalCompareGate",
+    "EvalCompareQueryDelta",
+    "EvalCompareResult",
+    "EvalCompareSpec",
+    "EvalCompareThresholds",
+    "EvalDataset",
+    "EvalDoc",
+    "EvalJudge",
+    "EvalQrel",
+    "EvalQuery",
+    "EvalQueryMetrics",
+    "EvalQueryResult",
+    "EvalReport",
+    "EvalResult",
+    "EvalRetrievalConfig",
+    "EvalRetrievalMode",
+    "EvalRetrievedItem",
+    "EvalRunItem",
+    "build_eval_retrieval_config",
+    "calculate_eval_metrics",
+    "compare_eval_results",
+    "compare_metrics_delta",
+    "default_eval_dataset_path",
+    "eval_anomalies_to_jsonl",
+    "eval_compare_config_to_retrieval_config",
+    "eval_compare_report_to_json",
+    "eval_compare_result_to_json",
+    "eval_metrics_to_json",
+    "eval_query_metrics_to_json",
+    "eval_result_report_to_json",
+    "eval_result_summary_to_json",
+    "eval_result_to_json",
+    "format_eval_compare_result",
+    "format_eval_result",
+    "load_eval_dataset",
+    "parse_bool_field",
+    "parse_eval_batch_spec",
+    "parse_eval_compare_config",
+    "parse_eval_compare_spec",
+    "parse_eval_compare_thresholds",
+    "parse_eval_retrieval_mode",
+    "parse_int_field",
+    "parse_optional_float_field",
+    "parse_optional_int_field",
+    "qrels_for_query",
+    "run_retrieval_eval",
+    "validate_eval_retrieval_config",
+    "write_eval_run_jsonl",
+]

--- a/src/local_rag_backend/core/services/evaluation_datasets.py
+++ b/src/local_rag_backend/core/services/evaluation_datasets.py
@@ -1,0 +1,214 @@
+"""Evaluation dataset and qrels parsing."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from local_rag_backend.core.services.evaluation_models import (
+    EvalDataset,
+    EvalDoc,
+    EvalQrel,
+    EvalQuery,
+)
+
+
+def default_eval_dataset_path() -> Path:
+    return Path(__file__).resolve().parents[4] / "datasets" / "rag_eval_v1.jsonl"
+
+
+def _parse_schema_version(raw_value: Any, *, lineno: int) -> int:
+    try:
+        return int(raw_value or 0)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"Invalid dataset line {lineno}: schema_version must be an integer."
+        ) from exc
+
+
+def _normalize_external_id(raw_value: object, *, lineno: int, field_name: str) -> str:
+    external_id = str(raw_value).strip()
+    if not external_id:
+        raise ValueError(f"Invalid dataset line {lineno}: {field_name} must not be blank.")
+    return external_id
+
+
+def _parse_qrel_relevance(raw_value: object, *, lineno: int) -> int:
+    try:
+        if raw_value is None:
+            relevance = 1
+        elif isinstance(raw_value, bool):
+            raise ValueError
+        elif isinstance(raw_value, int):
+            relevance = raw_value
+        elif isinstance(raw_value, str):
+            relevance = int(raw_value.strip())
+        else:
+            raise ValueError
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"Invalid dataset line {lineno}: qrel relevance must be an integer."
+        ) from exc
+    if relevance < 0:
+        raise ValueError(f"Invalid dataset line {lineno}: qrel relevance must be >= 0.")
+    return relevance
+
+
+def _parse_query_qrels(
+    obj: dict[str, Any],
+    *,
+    lineno: int,
+    schema_version: int,
+) -> tuple[EvalQrel, ...]:
+    raw_qrels = obj.get("qrels")
+    if raw_qrels is not None:
+        if schema_version != 2:
+            raise ValueError(f"Invalid dataset line {lineno}: qrels require schema_version=2.")
+        if not isinstance(raw_qrels, list):
+            raise ValueError(f"Invalid dataset line {lineno}: qrels must be a list.")
+        qrels: list[EvalQrel] = []
+        seen: set[str] = set()
+        for index, raw_item in enumerate(raw_qrels):
+            if not isinstance(raw_item, dict):
+                raise ValueError(
+                    f"Invalid dataset line {lineno}: qrels[{index}] must be an object."
+                )
+            external_id = _normalize_external_id(
+                raw_item.get("external_id"),
+                lineno=lineno,
+                field_name=f"qrels[{index}].external_id",
+            )
+            if external_id in seen:
+                raise ValueError(
+                    f"Invalid dataset line {lineno}: duplicate qrel external_id={external_id!r}."
+                )
+            seen.add(external_id)
+            qrels.append(
+                EvalQrel(
+                    external_id=external_id,
+                    relevance=_parse_qrel_relevance(raw_item.get("relevance", 1), lineno=lineno),
+                )
+            )
+        if not any(qrel.relevance > 0 for qrel in qrels):
+            raise ValueError(
+                f"Invalid dataset line {lineno}: qrels must contain at least one positive relevance."
+            )
+        return tuple(qrels)
+
+    rel = obj.get("relevant_external_ids") or []
+    if not isinstance(rel, list) or not all(isinstance(x, str) for x in rel):
+        raise ValueError(f"Invalid dataset line {lineno}: relevant_external_ids must be list[str].")
+    normalized_rel = tuple(str(external_id).strip() for external_id in rel)
+    if not normalized_rel:
+        raise ValueError(f"Invalid dataset line {lineno}: relevant_external_ids must not be empty.")
+    if any(not external_id for external_id in normalized_rel):
+        raise ValueError(
+            f"Invalid dataset line {lineno}: relevant_external_ids must not contain blank IDs."
+        )
+    if len(set(normalized_rel)) != len(normalized_rel):
+        raise ValueError(f"Invalid dataset line {lineno}: duplicate relevant_external_ids.")
+    return tuple(EvalQrel(external_id=external_id, relevance=1) for external_id in normalized_rel)
+
+
+def qrels_for_query(query: EvalQuery) -> tuple[EvalQrel, ...]:
+    if query.qrels:
+        return query.qrels
+    return tuple(
+        EvalQrel(external_id=str(external_id).strip(), relevance=1)
+        for external_id in query.relevant_external_ids
+        if str(external_id).strip()
+    )
+
+
+def load_eval_dataset(path: str | Path | None = None) -> EvalDataset:
+    content: str
+    if path is None:
+        p = default_eval_dataset_path()
+        if not p.is_file():
+            raise FileNotFoundError(
+                f"Default eval dataset not found: {p}. Pass --dataset or configure "
+                "eval_dataset_path in config.yaml."
+            )
+        content = p.read_text(encoding="utf-8")
+    else:
+        p = Path(path)
+        if not p.is_file():
+            raise FileNotFoundError(f"Dataset not found: {p}")
+        content = p.read_text(encoding="utf-8")
+
+    dataset_id = "unknown"
+    schema_version = 0
+    docs: list[EvalDoc] = []
+    queries: list[EvalQuery] = []
+    known_doc_ids: set[str] = set()
+
+    for lineno, line in enumerate(content.splitlines(), 1):
+        s = line.strip()
+        if not s:
+            continue
+        obj = json.loads(s)
+        if not isinstance(obj, dict):
+            raise ValueError(f"Invalid dataset line {lineno}: expected JSON object.")
+        t = obj.get("type")
+        if t == "meta":
+            dataset_id = str(obj.get("dataset_id") or dataset_id)
+            schema_version = _parse_schema_version(obj.get("schema_version"), lineno=lineno)
+        elif t == "doc":
+            external_id = _normalize_external_id(
+                obj.get("external_id"), lineno=lineno, field_name="external_id"
+            )
+            if external_id in known_doc_ids:
+                raise ValueError(
+                    f"Invalid dataset line {lineno}: duplicate doc external_id={external_id!r}."
+                )
+            known_doc_ids.add(external_id)
+            docs.append(
+                EvalDoc(
+                    external_id=external_id,
+                    content=str(obj["content"]),
+                    source_id=(
+                        str(obj.get("source_id")) if obj.get("source_id") is not None else None
+                    ),
+                )
+            )
+        elif t == "query":
+            qrels = _parse_query_qrels(obj, lineno=lineno, schema_version=schema_version)
+            queries.append(
+                EvalQuery(
+                    query=str(obj["query"]),
+                    relevant_external_ids=tuple(
+                        qrel.external_id for qrel in qrels if qrel.relevance > 0
+                    ),
+                    qrels=qrels,
+                )
+            )
+        else:
+            raise ValueError(f"Invalid dataset line {lineno}: unknown type={t!r}")
+
+    if schema_version not in {1, 2}:
+        raise ValueError(f"Unsupported schema_version={schema_version} (expected 1 or 2).")
+    if not docs:
+        raise ValueError("Dataset contains no docs.")
+    if not queries:
+        raise ValueError("Dataset contains no queries.")
+    for query in queries:
+        missing_ids = sorted(
+            {
+                qrel.external_id
+                for qrel in qrels_for_query(query)
+                if qrel.external_id not in known_doc_ids
+            }
+        )
+        if missing_ids:
+            raise ValueError(
+                "Dataset query references relevant_external_ids outside the corpus: "
+                + ", ".join(missing_ids[:10])
+            )
+
+    return EvalDataset(
+        dataset_id=str(dataset_id),
+        schema_version=int(schema_version),
+        docs=tuple(docs),
+        queries=tuple(queries),
+    )

--- a/src/local_rag_backend/core/services/evaluation_metrics.py
+++ b/src/local_rag_backend/core/services/evaluation_metrics.py
@@ -1,0 +1,345 @@
+"""IR metric calculation and retrieval-eval comparison."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import ir_measures
+from ir_measures import AP, RR, P, R, nDCG
+
+from local_rag_backend.core.services.evaluation_datasets import qrels_for_query
+from local_rag_backend.core.services.evaluation_models import (
+    EvalAnomaly,
+    EvalCompareDelta,
+    EvalCompareGate,
+    EvalCompareQueryDelta,
+    EvalCompareResult,
+    EvalDataset,
+    EvalQuery,
+    EvalQueryMetrics,
+    EvalQueryResult,
+    EvalResult,
+    EvalRetrievalMode,
+    EvalRetrievedItem,
+    EvalRunItem,
+)
+from local_rag_backend.core.services.evaluation_serialization import write_eval_run_jsonl
+
+
+def _coerce_retrieved_item(raw_item: object, *, rank: int, k: int) -> EvalRetrievedItem:
+    fallback_score = float(max(int(k) - int(rank) + 1, 1))
+    if isinstance(raw_item, EvalRetrievedItem):
+        return raw_item
+    if isinstance(raw_item, str):
+        return EvalRetrievedItem(external_id=raw_item, score=fallback_score)
+    if isinstance(raw_item, tuple) and raw_item:
+        external_id = str(raw_item[0])
+        raw_score = raw_item[1] if len(raw_item) > 1 else fallback_score
+        return EvalRetrievedItem(external_id=external_id, score=float(raw_score))
+    if isinstance(raw_item, dict):
+        external_id = str(raw_item.get("external_id") or raw_item.get("id") or "")
+        raw_score = raw_item.get("score", fallback_score)
+        return EvalRetrievedItem(external_id=external_id, score=float(raw_score))
+    external_id = str(raw_item)
+    return EvalRetrievedItem(external_id=external_id, score=fallback_score)
+
+
+def _coerce_retrieved_items(
+    raw_items: Sequence[object], *, k: int
+) -> tuple[EvalRetrievedItem, ...]:
+    return tuple(
+        _coerce_retrieved_item(raw_item, rank=rank, k=k)
+        for rank, raw_item in enumerate(raw_items, start=1)
+    )
+
+
+def _query_qrels_dict(query: EvalQuery) -> dict[str, int]:
+    return {
+        qrel.external_id: int(qrel.relevance)
+        for qrel in qrels_for_query(query)
+        if int(qrel.relevance) > 0
+    }
+
+
+def _metrics_from_aggregate(
+    aggregated: Mapping[Any, float | int],
+    *,
+    k: int,
+) -> EvalQueryMetrics:
+    return EvalQueryMetrics(
+        ndcg_at_k=float(aggregated[nDCG @ k]),
+        map_at_k=float(aggregated[AP @ k]),
+        mrr_at_k=float(aggregated[RR @ k]),
+        precision_at_k=float(aggregated[P @ k]),
+        recall_at_k=float(aggregated[R @ k]),
+    )
+
+
+def calculate_eval_metrics(
+    *,
+    qrels: dict[str, dict[str, int]],
+    run: dict[str, dict[str, float]],
+    k: int,
+) -> EvalQueryMetrics:
+    measures = (
+        nDCG @ k,
+        AP @ k,
+        RR @ k,
+        P @ k,
+        R @ k,
+    )
+    aggregated = ir_measures.calc_aggregate(measures, qrels, run)
+    return _metrics_from_aggregate(aggregated, k=k)
+
+
+def run_retrieval_eval(
+    *,
+    dataset: EvalDataset,
+    retrieve_external_ids: Callable[[str, int], Sequence[str]] | None = None,
+    retrieve_ranked_items: Callable[[str, int], Sequence[object]] | None = None,
+    retrieval_mode: EvalRetrievalMode = "sparse",
+    k: int = 3,
+    reranker_enabled: bool = False,
+    reranker_candidate_k: int = 20,
+    reranker_strategy: str = "overlap_v1",
+    max_queries: int | None = None,
+    run_out: Path | None = None,
+) -> EvalResult:
+    # Backward-compatible kwargs retained for callers migrating from the previous
+    # infra-coupled implementation where reranker wiring happened in this layer.
+    _ = (reranker_candidate_k, reranker_strategy)
+    if k <= 0:
+        raise ValueError("k must be positive")
+    if retrieve_external_ids is not None and retrieve_ranked_items is not None:
+        raise ValueError("Pass only one of retrieve_external_ids or retrieve_ranked_items.")
+
+    qs: list[EvalQuery] = list(dataset.queries)
+    if max_queries is not None:
+        qs = qs[: max(0, int(max_queries))]
+    if not qs:
+        raise ValueError("No queries to evaluate after max_queries.")
+    if retrieve_external_ids is None and retrieve_ranked_items is None:
+        raise ValueError("retrieve_ranked_items callback is required for offline IR evaluation.")
+    known_doc_ids = {
+        str(doc.external_id).strip() for doc in dataset.docs if str(doc.external_id).strip()
+    }
+    if not known_doc_ids:
+        raise ValueError("Dataset contains no known corpus document IDs.")
+
+    qrels: dict[str, dict[str, int]] = {}
+    run: dict[str, dict[str, float]] = {}
+    per_query_rows: dict[str, tuple[EvalRunItem, ...]] = {}
+    per_query: list[EvalQueryResult] = []
+    anomalies: list[EvalAnomaly] = []
+    for idx, q in enumerate(qs, start=1):
+        query_id = f"q{idx:06d}"
+        query_qrels = _query_qrels_dict(q)
+        qrels[query_id] = query_qrels
+        if not qrels[query_id]:
+            raise ValueError(
+                f"Query {query_id} has no relevant corpus IDs after dataset validation."
+            )
+
+        ranked_docs: dict[str, float] = {}
+        seen_external_ids: set[str] = set()
+        query_run_items: list[EvalRunItem] = []
+        if retrieve_ranked_items is not None:
+            raw_ranked_items = retrieve_ranked_items(q.query, k)
+        elif retrieve_external_ids is not None:
+            raw_ranked_items = retrieve_external_ids(q.query, k)
+        else:  # pragma: no cover - guarded above, keeps type checkers honest
+            raw_ranked_items = ()
+        for raw_item in _coerce_retrieved_items(raw_ranked_items, k=k):
+            normalized_external_id = str(raw_item.external_id).strip()
+            if not normalized_external_id:
+                anomalies.append(
+                    EvalAnomaly(
+                        query_id=query_id,
+                        kind="blank_external_id",
+                        message="Retriever returned a blank external_id.",
+                    )
+                )
+                continue
+            if normalized_external_id in seen_external_ids:
+                anomalies.append(
+                    EvalAnomaly(
+                        query_id=query_id,
+                        kind="duplicate_external_id",
+                        external_id=normalized_external_id,
+                        message="Retriever returned a duplicate external_id.",
+                    )
+                )
+                continue
+            seen_external_ids.add(normalized_external_id)
+            known = normalized_external_id in known_doc_ids
+            anomaly_kind = None if known else "unknown_external_id"
+            if not known:
+                anomalies.append(
+                    EvalAnomaly(
+                        query_id=query_id,
+                        kind="unknown_external_id",
+                        external_id=normalized_external_id,
+                        message="Retriever returned an external_id outside the eval corpus.",
+                    )
+                )
+            score = float(
+                raw_item.score if raw_item.score is not None else max(k - len(ranked_docs), 1)
+            )
+            ranked_docs[normalized_external_id] = score
+            query_run_items.append(
+                EvalRunItem(
+                    external_id=normalized_external_id,
+                    rank=len(query_run_items) + 1,
+                    score=score,
+                    known=known,
+                    relevance=int(query_qrels.get(normalized_external_id, 0)),
+                    anomaly=anomaly_kind,
+                )
+            )
+            if len(ranked_docs) >= int(k):
+                break
+        run[query_id] = ranked_docs
+        per_query_rows[query_id] = tuple(query_run_items)
+
+    for idx, q in enumerate(qs, start=1):
+        query_id = f"q{idx:06d}"
+        query_metrics = calculate_eval_metrics(
+            qrels={query_id: qrels[query_id]},
+            run={query_id: run[query_id]},
+            k=k,
+        )
+        per_query.append(
+            EvalQueryResult(
+                query_id=query_id,
+                query_text=q.query,
+                qrels=qrels_for_query(q),
+                ranked_docs=per_query_rows[query_id],
+                metrics=query_metrics,
+            )
+        )
+
+    if run_out is not None:
+        write_eval_run_jsonl(
+            path=run_out,
+            per_query=per_query,
+            retrieval_mode=str(retrieval_mode),
+            k=k,
+        )
+
+    aggregated_metrics = calculate_eval_metrics(qrels=qrels, run=run, k=k)
+    n = len(qs)
+    return EvalResult(
+        dataset_id=dataset.dataset_id,
+        retrieval_mode=retrieval_mode,
+        reranker_enabled=bool(reranker_enabled),
+        k=int(k),
+        queries=n,
+        ndcg_at_k=aggregated_metrics.ndcg_at_k,
+        map_at_k=aggregated_metrics.map_at_k,
+        mrr_at_k=aggregated_metrics.mrr_at_k,
+        precision_at_k=aggregated_metrics.precision_at_k,
+        recall_at_k=aggregated_metrics.recall_at_k,
+        per_query=tuple(per_query),
+        anomalies=tuple(anomalies),
+    )
+
+
+def compare_metrics_delta(
+    *,
+    baseline: EvalQueryMetrics,
+    candidate: EvalQueryMetrics,
+) -> EvalCompareDelta:
+    return EvalCompareDelta(
+        ndcg_at_k=float(candidate.ndcg_at_k - baseline.ndcg_at_k),
+        map_at_k=float(candidate.map_at_k - baseline.map_at_k),
+        mrr_at_k=float(candidate.mrr_at_k - baseline.mrr_at_k),
+        precision_at_k=float(candidate.precision_at_k - baseline.precision_at_k),
+        recall_at_k=float(candidate.recall_at_k - baseline.recall_at_k),
+    )
+
+
+def _result_metrics(result: EvalResult) -> EvalQueryMetrics:
+    return EvalQueryMetrics(
+        ndcg_at_k=result.ndcg_at_k,
+        map_at_k=result.map_at_k,
+        mrr_at_k=result.mrr_at_k,
+        precision_at_k=result.precision_at_k,
+        recall_at_k=result.recall_at_k,
+    )
+
+
+def compare_eval_results(
+    *,
+    baseline: EvalResult,
+    candidate: EvalResult,
+    min_delta_ndcg: float = 0.0,
+    min_delta_map: float = 0.0,
+    min_delta_mrr: float = 0.0,
+    max_regression_precision: float = 0.0,
+    max_regression_recall: float = 0.0,
+) -> EvalCompareResult:
+    if baseline.dataset_id != candidate.dataset_id:
+        raise ValueError("Baseline and candidate dataset_id must match.")
+    if baseline.k != candidate.k:
+        raise ValueError("Baseline and candidate k must match.")
+
+    delta = compare_metrics_delta(baseline=_result_metrics(baseline), candidate=_result_metrics(candidate))
+
+    reasons: list[str] = []
+    if delta.ndcg_at_k < float(min_delta_ndcg):
+        reasons.append(
+            f"nDCG@{baseline.k} delta={delta.ndcg_at_k:.3f} (min {float(min_delta_ndcg):.3f})"
+        )
+    if delta.map_at_k < float(min_delta_map):
+        reasons.append(
+            f"MAP@{baseline.k} delta={delta.map_at_k:.3f} (min {float(min_delta_map):.3f})"
+        )
+    if delta.mrr_at_k < float(min_delta_mrr):
+        reasons.append(
+            f"MRR@{baseline.k} delta={delta.mrr_at_k:.3f} (min {float(min_delta_mrr):.3f})"
+        )
+    if delta.precision_at_k < -abs(float(max_regression_precision)):
+        reasons.append(
+            f"P@{baseline.k} delta={delta.precision_at_k:.3f} "
+            f"(max regression {float(max_regression_precision):.3f})"
+        )
+    if delta.recall_at_k < -abs(float(max_regression_recall)):
+        reasons.append(
+            f"Recall@{baseline.k} delta={delta.recall_at_k:.3f} "
+            f"(max regression {float(max_regression_recall):.3f})"
+        )
+
+    baseline_by_query = {query.query_id: query for query in baseline.per_query}
+    candidate_by_query = {query.query_id: query for query in candidate.per_query}
+    per_query = tuple(
+        EvalCompareQueryDelta(
+            query_id=query_id,
+            baseline=baseline_by_query[query_id].metrics,
+            candidate=candidate_by_query[query_id].metrics,
+            delta=compare_metrics_delta(
+                baseline=baseline_by_query[query_id].metrics,
+                candidate=candidate_by_query[query_id].metrics,
+            ),
+        )
+        for query_id in sorted(baseline_by_query.keys() & candidate_by_query.keys())
+    )
+
+    return EvalCompareResult(
+        dataset_id=baseline.dataset_id,
+        k=int(baseline.k),
+        baseline=baseline,
+        candidate=candidate,
+        delta=delta,
+        gate=EvalCompareGate(
+            passed=not reasons,
+            reasons=tuple(reasons),
+            min_delta_ndcg=float(min_delta_ndcg),
+            min_delta_map=float(min_delta_map),
+            min_delta_mrr=float(min_delta_mrr),
+            max_regression_precision=float(max_regression_precision),
+            max_regression_recall=float(max_regression_recall),
+        ),
+        per_query=per_query,
+    )

--- a/src/local_rag_backend/core/services/evaluation_models.py
+++ b/src/local_rag_backend/core/services/evaluation_models.py
@@ -1,0 +1,221 @@
+"""Evaluation DTOs and transport-agnostic model types."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+EvalRetrievalMode = Literal["sparse", "dense", "dual", "hybrid"]
+
+
+@dataclass(frozen=True)
+class EvalDoc:
+    external_id: str
+    content: str
+    source_id: str | None = None
+
+
+@dataclass(frozen=True)
+class EvalQrel:
+    external_id: str
+    relevance: int = 1
+
+
+@dataclass(frozen=True)
+class EvalQuery:
+    query: str
+    relevant_external_ids: tuple[str, ...]
+    qrels: tuple[EvalQrel, ...] = ()
+
+
+@dataclass(frozen=True)
+class EvalDataset:
+    dataset_id: str
+    schema_version: int
+    docs: tuple[EvalDoc, ...]
+    queries: tuple[EvalQuery, ...]
+
+
+@dataclass(frozen=True)
+class EvalRetrievalConfig:
+    retrieval_mode: EvalRetrievalMode
+    k: int
+    candidate_k: int | None = None
+    dual_candidate_k: int | None = None
+    hybrid_alpha: float | None = None
+    reranker_enabled: bool = False
+
+
+@dataclass(frozen=True)
+class EvalBatchSpec:
+    name: str
+    retrieval_mode: EvalRetrievalMode
+    k: int
+    candidate_k: int | None = None
+    dual_candidate_k: int | None = None
+    hybrid_alpha: float | None = None
+    reranker_enabled: bool = False
+    json_out: str | None = None
+    run_out: str | None = None
+    report_out: str | None = None
+    anomalies_out: str | None = None
+
+
+@dataclass(frozen=True)
+class EvalBatchResult:
+    name: str
+    result: EvalResult
+    json_out: str | None = None
+    run_out: str | None = None
+    report_out: str | None = None
+    anomalies_out: str | None = None
+
+
+@dataclass(frozen=True)
+class EvalRetrievedItem:
+    external_id: str
+    score: float | None = None
+
+
+@dataclass(frozen=True)
+class EvalRunItem:
+    external_id: str
+    rank: int
+    score: float
+    known: bool
+    relevance: int = 0
+    anomaly: str | None = None
+
+
+@dataclass(frozen=True)
+class EvalQueryMetrics:
+    ndcg_at_k: float
+    map_at_k: float
+    mrr_at_k: float
+    precision_at_k: float
+    recall_at_k: float
+
+
+@dataclass(frozen=True)
+class EvalAnomaly:
+    query_id: str
+    kind: str
+    external_id: str | None = None
+    message: str = ""
+
+
+@dataclass(frozen=True)
+class EvalQueryResult:
+    query_id: str
+    query_text: str
+    qrels: tuple[EvalQrel, ...]
+    ranked_docs: tuple[EvalRunItem, ...]
+    metrics: EvalQueryMetrics
+
+
+@dataclass(frozen=True)
+class EvalCompareConfig:
+    retrieval_mode: EvalRetrievalMode
+    candidate_k: int | None = None
+    dual_candidate_k: int | None = None
+    hybrid_alpha: float | None = None
+    reranker_enabled: bool = False
+
+
+@dataclass(frozen=True)
+class EvalCompareThresholds:
+    min_delta_ndcg: float = 0.0
+    min_delta_map: float = 0.0
+    min_delta_mrr: float = 0.0
+    max_regression_precision: float = 0.0
+    max_regression_recall: float = 0.0
+
+
+@dataclass(frozen=True)
+class EvalCompareSpec:
+    baseline: EvalCompareConfig
+    candidate: EvalCompareConfig
+    thresholds: EvalCompareThresholds = field(default_factory=EvalCompareThresholds)
+    k: int = 3
+    max_queries: int | None = None
+
+
+@dataclass(frozen=True)
+class EvalResult:
+    dataset_id: str
+    retrieval_mode: EvalRetrievalMode
+    reranker_enabled: bool
+    k: int
+    queries: int
+    ndcg_at_k: float
+    map_at_k: float
+    mrr_at_k: float
+    precision_at_k: float
+    recall_at_k: float
+    per_query: tuple[EvalQueryResult, ...] = ()
+    anomalies: tuple[EvalAnomaly, ...] = ()
+
+
+@dataclass(frozen=True)
+class EvalCompareGate:
+    passed: bool
+    reasons: tuple[str, ...]
+    min_delta_ndcg: float
+    min_delta_map: float
+    min_delta_mrr: float
+    max_regression_precision: float
+    max_regression_recall: float
+
+
+@dataclass(frozen=True)
+class EvalCompareDelta:
+    ndcg_at_k: float
+    map_at_k: float
+    mrr_at_k: float
+    precision_at_k: float
+    recall_at_k: float
+
+
+@dataclass(frozen=True)
+class EvalCompareQueryDelta:
+    query_id: str
+    baseline: EvalQueryMetrics
+    candidate: EvalQueryMetrics
+    delta: EvalCompareDelta
+
+
+@dataclass(frozen=True)
+class EvalCompareResult:
+    dataset_id: str
+    k: int
+    baseline: EvalResult
+    candidate: EvalResult
+    delta: EvalCompareDelta
+    gate: EvalCompareGate
+    per_query: tuple[EvalCompareQueryDelta, ...] = ()
+
+
+@dataclass(frozen=True)
+class EvalReport:
+    run_id: str
+    result: EvalResult
+    config: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class EvalJudge:
+    judge_id: str
+    provider: str
+    model: str
+    prompt_version: str
+    rubric_version: str
+    temperature: float = 0.0
+
+
+@dataclass(frozen=True)
+class EvalBenchmark:
+    benchmark_id: str
+    adapter: str
+    dataset_id: str
+    split: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)

--- a/src/local_rag_backend/core/services/evaluation_serialization.py
+++ b/src/local_rag_backend/core/services/evaluation_serialization.py
@@ -1,0 +1,253 @@
+"""Evaluation result formatting and JSON serialization."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from local_rag_backend.core.services.evaluation_models import (
+    EvalAnomaly,
+    EvalCompareResult,
+    EvalQrel,
+    EvalQueryMetrics,
+    EvalQueryResult,
+    EvalResult,
+    EvalRunItem,
+)
+
+
+def format_eval_result(result: EvalResult) -> str:
+    return (
+        f"dataset={result.dataset_id} mode={result.retrieval_mode} reranker={result.reranker_enabled} "
+        f"k={result.k} queries={result.queries} "
+        f"nDCG@{result.k}={result.ndcg_at_k:.3f} "
+        f"MAP@{result.k}={result.map_at_k:.3f} "
+        f"MRR@{result.k}={result.mrr_at_k:.3f} "
+        f"P@{result.k}={result.precision_at_k:.3f} "
+        f"Recall@{result.k}={result.recall_at_k:.3f}"
+    )
+
+
+def eval_metrics_to_json(result: EvalResult) -> dict[str, float]:
+    return {
+        f"nDCG@{result.k}": result.ndcg_at_k,
+        f"MAP@{result.k}": result.map_at_k,
+        f"MRR@{result.k}": result.mrr_at_k,
+        f"P@{result.k}": result.precision_at_k,
+        f"Recall@{result.k}": result.recall_at_k,
+    }
+
+
+def eval_query_metrics_to_json(metrics: EvalQueryMetrics, *, k: int) -> dict[str, float]:
+    return {
+        f"nDCG@{k}": metrics.ndcg_at_k,
+        f"MAP@{k}": metrics.map_at_k,
+        f"MRR@{k}": metrics.mrr_at_k,
+        f"P@{k}": metrics.precision_at_k,
+        f"Recall@{k}": metrics.recall_at_k,
+    }
+
+
+def eval_anomaly_to_json(anomaly: EvalAnomaly) -> dict[str, Any]:
+    return {
+        "query_id": anomaly.query_id,
+        "kind": anomaly.kind,
+        "external_id": anomaly.external_id,
+        "message": anomaly.message,
+    }
+
+
+def eval_run_item_to_json(item: EvalRunItem) -> dict[str, Any]:
+    return {
+        "external_id": item.external_id,
+        "rank": item.rank,
+        "score": item.score,
+        "known": item.known,
+        "relevance": item.relevance,
+        "anomaly": item.anomaly,
+    }
+
+
+def eval_qrel_to_json(qrel: EvalQrel) -> dict[str, Any]:
+    return {"external_id": qrel.external_id, "relevance": qrel.relevance}
+
+
+def eval_query_result_to_json(query_result: EvalQueryResult) -> dict[str, Any]:
+    return {
+        "query_id": query_result.query_id,
+        "query_text": query_result.query_text,
+        "qrels": [eval_qrel_to_json(qrel) for qrel in query_result.qrels],
+        "ranked_docs": [eval_run_item_to_json(item) for item in query_result.ranked_docs],
+        "metrics": {
+            "nDCG": query_result.metrics.ndcg_at_k,
+            "MAP": query_result.metrics.map_at_k,
+            "MRR": query_result.metrics.mrr_at_k,
+            "P": query_result.metrics.precision_at_k,
+            "Recall": query_result.metrics.recall_at_k,
+        },
+    }
+
+
+def eval_result_to_json(result: EvalResult, *, include_details: bool = False) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "dataset_id": result.dataset_id,
+        "retrieval_mode": result.retrieval_mode,
+        "reranker_enabled": result.reranker_enabled,
+        "k": result.k,
+        "queries": result.queries,
+        "metrics": eval_metrics_to_json(result),
+    }
+    if include_details:
+        payload["anomalies_count"] = len(result.anomalies)
+        payload["per_query"] = [
+            {
+                **eval_query_result_to_json(query_result),
+                "metrics": eval_query_metrics_to_json(query_result.metrics, k=result.k),
+            }
+            for query_result in result.per_query
+        ]
+        payload["anomalies"] = [eval_anomaly_to_json(anomaly) for anomaly in result.anomalies]
+    return payload
+
+
+def eval_result_summary_to_json(result: EvalResult) -> dict[str, object]:
+    return {
+        "dataset_id": result.dataset_id,
+        "retrieval_mode": result.retrieval_mode,
+        "reranker_enabled": result.reranker_enabled,
+        "k": result.k,
+        "queries": result.queries,
+        "ndcg_at_k": result.ndcg_at_k,
+        "map_at_k": result.map_at_k,
+        "mrr_at_k": result.mrr_at_k,
+        "precision_at_k": result.precision_at_k,
+        "recall_at_k": result.recall_at_k,
+        "anomalies_count": len(result.anomalies),
+    }
+
+
+def eval_result_report_to_json(
+    result: EvalResult,
+    *,
+    config: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "type": "eval_report",
+        "schema_version": 1,
+        "config": dict(config or {}),
+        **eval_result_to_json(result, include_details=True),
+    }
+
+
+def eval_anomalies_to_jsonl(result: EvalResult) -> str:
+    return "\n".join(json.dumps(eval_anomaly_to_json(anomaly)) for anomaly in result.anomalies)
+
+
+def write_eval_run_jsonl(
+    *, path: Path, per_query: Sequence[EvalQueryResult], retrieval_mode: str, k: int
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as out:
+        for query_result in per_query:
+            out.write(
+                json.dumps(
+                    {
+                        "query_id": query_result.query_id,
+                        "query_text": query_result.query_text,
+                        "retrieval_mode": retrieval_mode,
+                        "k": k,
+                        "qrels": [
+                            eval_qrel_to_json(qrel)
+                            for qrel in query_result.qrels
+                            if qrel.relevance > 0
+                        ],
+                        "ranked_docs": [
+                            eval_run_item_to_json(item) for item in query_result.ranked_docs
+                        ],
+                    }
+                )
+                + "\n"
+            )
+
+
+def format_eval_compare_result(result: EvalCompareResult) -> tuple[str, str, str, str]:
+    k = int(result.k)
+    baseline_line = "BASELINE  " + format_eval_result(result.baseline)
+    candidate_line = "CANDIDATE " + format_eval_result(result.candidate)
+    delta_line = (
+        f"DELTA     nDCG@{k}={result.delta.ndcg_at_k:+.3f} "
+        f"MAP@{k}={result.delta.map_at_k:+.3f} "
+        f"MRR@{k}={result.delta.mrr_at_k:+.3f} "
+        f"P@{k}={result.delta.precision_at_k:+.3f} "
+        f"Recall@{k}={result.delta.recall_at_k:+.3f}"
+    )
+    gate_line = "PASS" if result.gate.passed else "FAIL: " + "; ".join(result.gate.reasons)
+    return baseline_line, candidate_line, delta_line, gate_line
+
+
+def eval_compare_result_to_json(
+    result: EvalCompareResult,
+    *,
+    include_details: bool = False,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "dataset_id": result.dataset_id,
+        "k": result.k,
+        "baseline": {
+            "retrieval_mode": result.baseline.retrieval_mode,
+            "reranker_enabled": result.baseline.reranker_enabled,
+            "metrics": eval_metrics_to_json(result.baseline),
+        },
+        "candidate": {
+            "retrieval_mode": result.candidate.retrieval_mode,
+            "reranker_enabled": result.candidate.reranker_enabled,
+            "metrics": eval_metrics_to_json(result.candidate),
+        },
+        "delta": {
+            f"nDCG@{result.k}": result.delta.ndcg_at_k,
+            f"MAP@{result.k}": result.delta.map_at_k,
+            f"MRR@{result.k}": result.delta.mrr_at_k,
+            f"P@{result.k}": result.delta.precision_at_k,
+            f"Recall@{result.k}": result.delta.recall_at_k,
+        },
+        "gate": {
+            "passed": result.gate.passed,
+            "reasons": list(result.gate.reasons),
+            "thresholds": {
+                "min_delta_ndcg": result.gate.min_delta_ndcg,
+                "min_delta_map": result.gate.min_delta_map,
+                "min_delta_mrr": result.gate.min_delta_mrr,
+                "max_regression_precision": result.gate.max_regression_precision,
+                "max_regression_recall": result.gate.max_regression_recall,
+            },
+        },
+    }
+    if include_details:
+        payload["baseline"]["anomalies_count"] = len(result.baseline.anomalies)
+        payload["candidate"]["anomalies_count"] = len(result.candidate.anomalies)
+        payload["per_query"] = [
+            {
+                "query_id": item.query_id,
+                "baseline": eval_query_metrics_to_json(item.baseline, k=result.k),
+                "candidate": eval_query_metrics_to_json(item.candidate, k=result.k),
+                "delta": {
+                    f"nDCG@{result.k}": item.delta.ndcg_at_k,
+                    f"MAP@{result.k}": item.delta.map_at_k,
+                    f"MRR@{result.k}": item.delta.mrr_at_k,
+                    f"P@{result.k}": item.delta.precision_at_k,
+                    f"Recall@{result.k}": item.delta.recall_at_k,
+                },
+            }
+            for item in result.per_query
+        ]
+    return payload
+
+
+def eval_compare_report_to_json(result: EvalCompareResult) -> dict[str, Any]:
+    return {
+        "type": "eval_compare_report",
+        "schema_version": 1,
+        **eval_compare_result_to_json(result, include_details=True),
+    }

--- a/src/local_rag_backend/core/services/evaluation_validation.py
+++ b/src/local_rag_backend/core/services/evaluation_validation.py
@@ -1,0 +1,308 @@
+"""Validation and parsing helpers for evaluation configs."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import cast
+
+from local_rag_backend.core.services.evaluation_models import (
+    EvalBatchSpec,
+    EvalCompareConfig,
+    EvalCompareSpec,
+    EvalCompareThresholds,
+    EvalRetrievalConfig,
+    EvalRetrievalMode,
+)
+
+VALID_EVAL_RETRIEVAL_MODES = frozenset({"sparse", "dense", "dual", "hybrid"})
+
+
+def parse_int_field(value: object, *, field_name: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{field_name} must be an integer, got boolean.")
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        return int(value.strip())
+    raise ValueError(f"{field_name} must be an integer.")
+
+
+def parse_optional_int_field(value: object, *, field_name: str) -> int | None:
+    if value is None:
+        return None
+    return parse_int_field(value, field_name=field_name)
+
+
+def parse_optional_float_field(value: object, *, field_name: str) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise ValueError(f"{field_name} must be numeric, got boolean.")
+    if isinstance(value, int | float):
+        return float(value)
+    if isinstance(value, str):
+        return float(value.strip())
+    raise ValueError(f"{field_name} must be numeric.")
+
+
+def parse_bool_field(value: object, *, field_name: str) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    raise ValueError(f"{field_name} must be boolean.")
+
+
+def parse_eval_retrieval_mode(
+    value: object | None,
+    *,
+    field_name: str = "retrieval_mode",
+    default: EvalRetrievalMode | None = None,
+) -> EvalRetrievalMode:
+    raw = default if value is None else value
+    normalized = str(raw).strip().lower()
+    if normalized not in VALID_EVAL_RETRIEVAL_MODES:
+        raise ValueError(f"{field_name} must be one of sparse, dense, dual, hybrid.")
+    return cast("EvalRetrievalMode", normalized)
+
+
+def validate_eval_retrieval_config(
+    config: EvalRetrievalConfig,
+    *,
+    field_names: Mapping[str, str] | None = None,
+) -> EvalRetrievalConfig:
+    labels = field_names or {}
+    mode = parse_eval_retrieval_mode(
+        config.retrieval_mode,
+        field_name=labels.get("retrieval_mode", "retrieval_mode"),
+    )
+    if int(config.k) <= 0:
+        raise ValueError(f"{labels.get('k', 'k')} must be positive")
+    if config.candidate_k is not None and mode != "dense":
+        raise ValueError(
+            f"{labels.get('candidate_k', 'candidate_k')} is supported only with "
+            "retrieval_mode=dense"
+        )
+    if config.dual_candidate_k is not None and mode != "dual":
+        raise ValueError(
+            f"{labels.get('dual_candidate_k', 'dual_candidate_k')} is supported only with "
+            "retrieval_mode=dual"
+        )
+    if config.hybrid_alpha is not None and mode != "hybrid":
+        raise ValueError(
+            f"{labels.get('hybrid_alpha', 'hybrid_alpha')} is supported only with "
+            "retrieval_mode=hybrid"
+        )
+    if config.candidate_k is not None and int(config.candidate_k) <= 0:
+        raise ValueError(f"{labels.get('candidate_k', 'candidate_k')} must be positive")
+    if config.dual_candidate_k is not None and int(config.dual_candidate_k) <= 0:
+        raise ValueError(
+            f"{labels.get('dual_candidate_k', 'dual_candidate_k')} must be positive"
+        )
+    if config.hybrid_alpha is not None and not 0.0 <= float(config.hybrid_alpha) <= 1.0:
+        raise ValueError(
+            f"{labels.get('hybrid_alpha', 'hybrid_alpha')} must be between 0.0 and 1.0"
+        )
+    return EvalRetrievalConfig(
+        retrieval_mode=mode,
+        k=int(config.k),
+        candidate_k=(int(config.candidate_k) if config.candidate_k is not None else None),
+        dual_candidate_k=(
+            int(config.dual_candidate_k) if config.dual_candidate_k is not None else None
+        ),
+        hybrid_alpha=(float(config.hybrid_alpha) if config.hybrid_alpha is not None else None),
+        reranker_enabled=bool(config.reranker_enabled),
+    )
+
+
+def build_eval_retrieval_config(
+    *,
+    retrieval_mode: object | None = None,
+    k: object = 3,
+    candidate_k: object | None = None,
+    dual_candidate_k: object | None = None,
+    hybrid_alpha: object | None = None,
+    reranker_enabled: object = False,
+    default_mode: EvalRetrievalMode = "sparse",
+    field_names: Mapping[str, str] | None = None,
+) -> EvalRetrievalConfig:
+    labels = field_names or {}
+    parsed = EvalRetrievalConfig(
+        retrieval_mode=parse_eval_retrieval_mode(
+            retrieval_mode,
+            field_name=labels.get("retrieval_mode", "retrieval_mode"),
+            default=default_mode,
+        ),
+        k=parse_int_field(k, field_name=labels.get("k", "k")),
+        candidate_k=parse_optional_int_field(
+            candidate_k,
+            field_name=labels.get("candidate_k", "candidate_k"),
+        ),
+        dual_candidate_k=parse_optional_int_field(
+            dual_candidate_k,
+            field_name=labels.get("dual_candidate_k", "dual_candidate_k"),
+        ),
+        hybrid_alpha=parse_optional_float_field(
+            hybrid_alpha,
+            field_name=labels.get("hybrid_alpha", "hybrid_alpha"),
+        ),
+        reranker_enabled=(
+            reranker_enabled
+            if isinstance(reranker_enabled, bool)
+            else parse_bool_field(
+                reranker_enabled,
+                field_name=labels.get("reranker_enabled", "reranker_enabled"),
+            )
+        ),
+    )
+    return validate_eval_retrieval_config(parsed, field_names=labels)
+
+
+def eval_compare_config_to_retrieval_config(
+    config: EvalCompareConfig,
+    *,
+    k: int,
+) -> EvalRetrievalConfig:
+    return validate_eval_retrieval_config(
+        EvalRetrievalConfig(
+            retrieval_mode=config.retrieval_mode,
+            k=int(k),
+            candidate_k=config.candidate_k,
+            dual_candidate_k=config.dual_candidate_k,
+            hybrid_alpha=config.hybrid_alpha,
+            reranker_enabled=config.reranker_enabled,
+        )
+    )
+
+
+def parse_eval_compare_config(raw: object, *, field_name: str) -> EvalCompareConfig:
+    if not isinstance(raw, Mapping):
+        raise ValueError(f"{field_name} must be an object.")
+    mode = parse_eval_retrieval_mode(
+        raw.get("retrieval_mode"),
+        field_name=f"{field_name}.retrieval_mode",
+    )
+    config = EvalCompareConfig(
+        retrieval_mode=mode,
+        candidate_k=parse_optional_int_field(
+            raw.get("candidate_k"),
+            field_name=f"{field_name}.candidate_k",
+        ),
+        dual_candidate_k=parse_optional_int_field(
+            raw.get("dual_candidate_k"),
+            field_name=f"{field_name}.dual_candidate_k",
+        ),
+        hybrid_alpha=parse_optional_float_field(
+            raw.get("hybrid_alpha"),
+            field_name=f"{field_name}.hybrid_alpha",
+        ),
+        reranker_enabled=(
+            bool(raw.get("reranker_enabled", False))
+            if isinstance(raw.get("reranker_enabled", False), bool)
+            else parse_bool_field(
+                raw.get("reranker_enabled"),
+                field_name=f"{field_name}.reranker_enabled",
+            )
+        ),
+    )
+    validate_eval_retrieval_config(
+        EvalRetrievalConfig(
+            retrieval_mode=config.retrieval_mode,
+            k=1,
+            candidate_k=config.candidate_k,
+            dual_candidate_k=config.dual_candidate_k,
+            hybrid_alpha=config.hybrid_alpha,
+            reranker_enabled=config.reranker_enabled,
+        ),
+        field_names={
+            "retrieval_mode": f"{field_name}.retrieval_mode",
+            "candidate_k": f"{field_name}.candidate_k",
+            "dual_candidate_k": f"{field_name}.dual_candidate_k",
+            "hybrid_alpha": f"{field_name}.hybrid_alpha",
+        },
+    )
+    return config
+
+
+def parse_eval_compare_thresholds(raw: object | None) -> EvalCompareThresholds:
+    if raw is None:
+        return EvalCompareThresholds()
+    if not isinstance(raw, Mapping):
+        raise ValueError("thresholds must be an object.")
+    return EvalCompareThresholds(
+        min_delta_ndcg=float(raw.get("min_delta_ndcg", 0.0)),
+        min_delta_map=float(raw.get("min_delta_map", 0.0)),
+        min_delta_mrr=float(raw.get("min_delta_mrr", 0.0)),
+        max_regression_precision=float(raw.get("max_regression_precision", 0.0)),
+        max_regression_recall=float(raw.get("max_regression_recall", 0.0)),
+    )
+
+
+def parse_eval_compare_spec(payload: object) -> EvalCompareSpec:
+    if not isinstance(payload, Mapping):
+        raise ValueError("Compare spec must be a JSON object.")
+    if "baseline" not in payload:
+        raise ValueError("Compare spec is missing required field 'baseline'.")
+    if "candidate" not in payload:
+        raise ValueError("Compare spec is missing required field 'candidate'.")
+    k = parse_int_field(payload.get("k", 3), field_name="k")
+    if k <= 0:
+        raise ValueError("k must be positive")
+    max_queries = parse_optional_int_field(payload.get("max_queries"), field_name="max_queries")
+    if max_queries is not None and max_queries < 0:
+        raise ValueError("max_queries must be >= 0")
+    baseline = parse_eval_compare_config(payload["baseline"], field_name="baseline")
+    candidate = parse_eval_compare_config(payload["candidate"], field_name="candidate")
+    return EvalCompareSpec(
+        baseline=baseline,
+        candidate=candidate,
+        thresholds=parse_eval_compare_thresholds(payload.get("thresholds")),
+        k=k,
+        max_queries=max_queries,
+    )
+
+
+def parse_eval_batch_spec(raw: Mapping[str, object], *, index: int) -> EvalBatchSpec:
+    required_fields = ("name", "retrieval_mode", "k")
+    for field_name in required_fields:
+        if field_name not in raw:
+            raise ValueError(f"Spec at index {index} is missing required field {field_name!r}.")
+    config = build_eval_retrieval_config(
+        retrieval_mode=raw["retrieval_mode"],
+        k=raw["k"],
+        candidate_k=raw.get("candidate_k"),
+        dual_candidate_k=raw.get("dual_candidate_k"),
+        hybrid_alpha=raw.get("hybrid_alpha"),
+        reranker_enabled=raw.get("reranker_enabled", False),
+        field_names={
+            "retrieval_mode": f"specs[{index}].retrieval_mode",
+            "k": f"specs[{index}].k",
+            "candidate_k": f"specs[{index}].candidate_k",
+            "dual_candidate_k": f"specs[{index}].dual_candidate_k",
+            "hybrid_alpha": f"specs[{index}].hybrid_alpha",
+            "reranker_enabled": f"specs[{index}].reranker_enabled",
+        },
+    )
+    return EvalBatchSpec(
+        name=str(raw["name"]),
+        retrieval_mode=config.retrieval_mode,
+        k=config.k,
+        candidate_k=config.candidate_k,
+        dual_candidate_k=config.dual_candidate_k,
+        hybrid_alpha=config.hybrid_alpha,
+        reranker_enabled=config.reranker_enabled,
+        json_out=(str(raw["json_out"]).strip() if raw.get("json_out") is not None else None),
+        run_out=(str(raw["run_out"]).strip() if raw.get("run_out") is not None else None),
+        report_out=(
+            str(raw["report_out"]).strip() if raw.get("report_out") is not None else None
+        ),
+        anomalies_out=(
+            str(raw["anomalies_out"]).strip()
+            if raw.get("anomalies_out") is not None
+            else None
+        ),
+    )

--- a/src/local_rag_backend/core/services/retrieval_coercion.py
+++ b/src/local_rag_backend/core/services/retrieval_coercion.py
@@ -1,0 +1,37 @@
+"""Shared coercion for retriever outputs accepted by eval/use-case boundaries."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any, cast
+
+from local_rag_backend.core.domain.entities import Document as DomainDocument
+from local_rag_backend.core.domain.retrieval import (
+    RetrievalRequest,
+    RetrievalResult,
+    retrieval_result_from_pairs,
+)
+
+
+def coerce_retrieval_result(
+    raw_result: Any,
+    *,
+    request: RetrievalRequest,
+    backend_used: str = "eval",
+) -> RetrievalResult:
+    if isinstance(raw_result, RetrievalResult):
+        return raw_result
+    if (
+        isinstance(raw_result, tuple)
+        and len(raw_result) == 2
+        and isinstance(raw_result[0], (list, tuple))
+        and isinstance(raw_result[1], (list, tuple))
+    ):
+        docs, scores = raw_result
+        return retrieval_result_from_pairs(
+            docs=cast("Sequence[DomainDocument]", docs),
+            scores=cast("Sequence[float]", scores),
+            mode_used=request.mode,
+            backend_used=backend_used,
+        )
+    raise RuntimeError(f"Unsupported eval retriever response type: {type(raw_result)!r}")

--- a/src/local_rag_backend/core/services/types.py
+++ b/src/local_rag_backend/core/services/types.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal
 
-EvalRetrievalMode = Literal["sparse", "dense", "dual", "hybrid"]
-
 
 # --- CHUNKING ---
 @dataclass(frozen=True)
@@ -15,112 +13,6 @@ class TextChunk:
     chunk_index: int
     start_char: int
     end_char: int  # exclusive
-
-
-# --- EVALUATION ---
-@dataclass(frozen=True)
-class EvalDoc:
-    external_id: str
-    content: str
-    source_id: str | None = None
-
-
-@dataclass(frozen=True)
-class EvalQuery:
-    query: str
-    relevant_external_ids: tuple[str, ...]
-
-
-@dataclass(frozen=True)
-class EvalDataset:
-    dataset_id: str
-    schema_version: int
-    docs: tuple[EvalDoc, ...]
-    queries: tuple[EvalQuery, ...]
-
-
-@dataclass(frozen=True)
-class EvalRetrievalConfig:
-    retrieval_mode: EvalRetrievalMode
-    k: int
-    candidate_k: int | None = None
-    dual_candidate_k: int | None = None
-    hybrid_alpha: float | None = None
-    reranker_enabled: bool = False
-
-
-@dataclass(frozen=True)
-class EvalBatchSpec:
-    name: str
-    retrieval_mode: EvalRetrievalMode
-    k: int
-    candidate_k: int | None = None
-    dual_candidate_k: int | None = None
-    hybrid_alpha: float | None = None
-    reranker_enabled: bool = False
-    json_out: str | None = None
-    run_out: str | None = None
-
-
-@dataclass(frozen=True)
-class EvalBatchResult:
-    name: str
-    result: EvalResult
-    json_out: str | None = None
-    run_out: str | None = None
-
-
-@dataclass(frozen=True)
-class EvalCompareConfig:
-    retrieval_mode: EvalRetrievalMode
-    candidate_k: int | None = None
-    dual_candidate_k: int | None = None
-    hybrid_alpha: float | None = None
-    reranker_enabled: bool = False
-
-
-@dataclass(frozen=True)
-class EvalResult:
-    dataset_id: str
-    retrieval_mode: EvalRetrievalMode
-    reranker_enabled: bool
-    k: int
-    queries: int
-    ndcg_at_k: float
-    map_at_k: float
-    mrr_at_k: float
-    precision_at_k: float
-    recall_at_k: float
-
-
-@dataclass(frozen=True)
-class EvalCompareGate:
-    passed: bool
-    reasons: tuple[str, ...]
-    min_delta_ndcg: float
-    min_delta_map: float
-    min_delta_mrr: float
-    max_regression_precision: float
-    max_regression_recall: float
-
-
-@dataclass(frozen=True)
-class EvalCompareDelta:
-    ndcg_at_k: float
-    map_at_k: float
-    mrr_at_k: float
-    precision_at_k: float
-    recall_at_k: float
-
-
-@dataclass(frozen=True)
-class EvalCompareResult:
-    dataset_id: str
-    k: int
-    baseline: EvalResult
-    candidate: EvalResult
-    delta: EvalCompareDelta
-    gate: EvalCompareGate
 
 
 # --- INFRASTRUCTURE INGESTION DETECTION ---

--- a/src/local_rag_backend/core/use_cases/evaluation.py
+++ b/src/local_rag_backend/core/use_cases/evaluation.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 from local_rag_backend.core.domain.retrieval import (
+    RetrievalFilter,
     RetrievalRequest,
     RetrievalResult,
-    retrieval_result_from_pairs,
 )
 from local_rag_backend.core.ports import (
     EvalDatasetDocInput,
@@ -25,13 +25,20 @@ from local_rag_backend.core.services.evaluation import (
     compare_eval_results,
     run_retrieval_eval as run_retrieval_eval_core,
 )
-from local_rag_backend.core.services.types import (
+from local_rag_backend.core.services.evaluation_models import (
     EvalBatchResult,
     EvalBatchSpec,
     EvalCompareConfig,
     EvalRetrievalConfig,
     EvalRetrievalMode,
+    EvalRetrievedItem,
 )
+from local_rag_backend.core.services.evaluation_validation import (
+    build_eval_retrieval_config,
+    eval_compare_config_to_retrieval_config,
+    validate_eval_retrieval_config,
+)
+from local_rag_backend.core.services.retrieval_coercion import coerce_retrieval_result
 
 
 @dataclass(frozen=True)
@@ -65,28 +72,23 @@ def _resolve_prepared_retriever_workspace(
     return prepare_workspace(storage=eval_storage_port)
 
 
-def _external_ids_from_retrieval(retrieval: RetrievalResult) -> list[str]:
+def _ranked_items_from_retrieval(retrieval: RetrievalResult) -> list[EvalRetrievedItem]:
     return [
-        str(external_id)
-        for external_id in (
-            getattr(document, "external_id", None) for document in retrieval.documents
+        EvalRetrievedItem(external_id=str(external_id), score=float(item.score))
+        for item, external_id in (
+            (item, getattr(item.document, "external_id", None)) for item in retrieval.items
         )
         if external_id is not None and str(external_id).strip()
     ]
 
 
-def _rankings_lookup(rankings: dict[str, list[str]]) -> Callable[[str, int], Sequence[str]]:
-    def retrieve_external_ids(query: str, _top_k: int) -> list[str]:
+def _rankings_lookup(
+    rankings: dict[str, list[EvalRetrievedItem]],
+) -> Callable[[str, int], Sequence[EvalRetrievedItem]]:
+    def retrieve_ranked_items(query: str, _top_k: int) -> list[EvalRetrievedItem]:
         return rankings.get(query, [])
 
-    return retrieve_external_ids
-
-
-def _coerce_eval_retrieval_mode(retrieval_mode: str) -> EvalRetrievalMode:
-    normalized = str(retrieval_mode)
-    if normalized not in {"sparse", "dense", "dual", "hybrid"}:
-        raise ValueError(f"Unsupported retrieval_mode: {retrieval_mode}")
-    return cast("EvalRetrievalMode", normalized)
+    return retrieve_ranked_items
 
 
 def _run_eval_with_retriever(
@@ -100,21 +102,23 @@ def _run_eval_with_retriever(
     dual_candidate_k: int | None,
     max_queries: int | None,
     run_out: Path | None,
+    filters: tuple[RetrievalFilter, ...] = (),
 ) -> EvalResult:
-    def _retrieve_external_ids(query: str, top_k: int) -> list[str]:
+    def _retrieve_ranked_items(query: str, top_k: int) -> list[EvalRetrievedItem]:
         request = RetrievalRequest(
             query=query,
             top_k=top_k,
             mode=retrieval_mode,
             candidate_k=(int(candidate_k) if candidate_k is not None else None),
             dual_candidate_k=(int(dual_candidate_k) if dual_candidate_k is not None else None),
+            filters=filters,
         )
-        retrieval = _coerce_retrieval_result(retriever.retrieve(request), request=request)
-        return _external_ids_from_retrieval(retrieval)
+        retrieval = coerce_retrieval_result(retriever.retrieve(request), request=request)
+        return _ranked_items_from_retrieval(retrieval)
 
     return run_retrieval_eval_core(
         dataset=dataset,
-        retrieve_external_ids=_retrieve_external_ids,
+        retrieve_ranked_items=_retrieve_ranked_items,
         retrieval_mode=retrieval_mode,
         k=k,
         reranker_enabled=reranker_enabled,
@@ -143,50 +147,6 @@ def prepare_eval_workspace(
     )
 
 
-def _coerce_retrieval_result(
-    raw_result: Any,
-    *,
-    request: RetrievalRequest,
-) -> RetrievalResult:
-    if isinstance(raw_result, RetrievalResult):
-        return raw_result
-    if (
-        isinstance(raw_result, tuple)
-        and len(raw_result) == 2
-        and isinstance(raw_result[0], (list, tuple))
-        and isinstance(raw_result[1], (list, tuple))
-    ):
-        docs, scores = raw_result
-        return retrieval_result_from_pairs(
-            docs=docs,
-            scores=scores,
-            mode_used=request.mode,
-            backend_used="eval",
-        )
-    raise RuntimeError(f"Unsupported eval retriever response type: {type(raw_result)!r}")
-
-
-def _validate_eval_options(
-    *,
-    retrieval_mode: str,
-    candidate_k: int | None,
-    dual_candidate_k: int | None,
-    hybrid_alpha: float | None,
-) -> None:
-    if candidate_k is not None and retrieval_mode != "dense":
-        raise ValueError("--candidate-k is supported only with retrieval_mode=dense")
-    if dual_candidate_k is not None and retrieval_mode != "dual":
-        raise ValueError("--dual-candidate-k is supported only with retrieval_mode=dual")
-    if hybrid_alpha is not None and retrieval_mode != "hybrid":
-        raise ValueError("--hybrid-alpha is supported only with retrieval_mode=hybrid")
-    if candidate_k is not None and int(candidate_k) <= 0:
-        raise ValueError("candidate_k must be positive")
-    if dual_candidate_k is not None and int(dual_candidate_k) <= 0:
-        raise ValueError("dual_candidate_k must be positive")
-    if hybrid_alpha is not None and not 0.0 <= float(hybrid_alpha) <= 1.0:
-        raise ValueError("hybrid_alpha must be between 0.0 and 1.0")
-
-
 def run_retrieval_eval(
     *,
     dataset: EvalDataset,
@@ -202,18 +162,21 @@ def run_retrieval_eval(
     reranker_strategy: str = "overlap_v1",
     max_queries: int | None = None,
     run_out: Path | None = None,
+    filters: tuple[RetrievalFilter, ...] = (),
 ) -> EvalResult:
-    if retrieval_mode not in {"sparse", "dense", "dual", "hybrid"}:
-        raise ValueError(f"Unsupported retrieval_mode: {retrieval_mode}")
-    if k <= 0:
-        raise ValueError("k must be positive")
-    _validate_eval_options(
-        retrieval_mode=str(retrieval_mode),
+    config = build_eval_retrieval_config(
+        retrieval_mode=retrieval_mode,
+        k=k,
         candidate_k=candidate_k,
         dual_candidate_k=dual_candidate_k,
         hybrid_alpha=hybrid_alpha,
+        reranker_enabled=bool(reranker_enabled),
+        field_names={
+            "candidate_k": "--candidate-k",
+            "dual_candidate_k": "--dual-candidate-k",
+            "hybrid_alpha": "--hybrid-alpha",
+        },
     )
-    normalized_retrieval_mode = _coerce_eval_retrieval_mode(retrieval_mode)
     workspace = prepare_eval_workspace(
         dataset=dataset,
         eval_storage_port=eval_storage_port,
@@ -221,18 +184,12 @@ def run_retrieval_eval(
     )
     return run_prepared_retrieval_eval(
         workspace=workspace,
-        config=EvalRetrievalConfig(
-            retrieval_mode=normalized_retrieval_mode,
-            k=int(k),
-            candidate_k=(int(candidate_k) if candidate_k is not None else None),
-            dual_candidate_k=(int(dual_candidate_k) if dual_candidate_k is not None else None),
-            hybrid_alpha=(float(hybrid_alpha) if hybrid_alpha is not None else None),
-            reranker_enabled=bool(reranker_enabled),
-        ),
+        config=config,
         reranker_candidate_k=reranker_candidate_k,
         reranker_strategy=reranker_strategy,
         max_queries=max_queries,
         run_out=run_out,
+        filters=filters,
     )
 
 
@@ -244,13 +201,9 @@ def run_prepared_retrieval_eval(
     reranker_strategy: str = "overlap_v1",
     max_queries: int | None = None,
     run_out: Path | None = None,
+    filters: tuple[RetrievalFilter, ...] = (),
 ) -> EvalResult:
-    _validate_eval_options(
-        retrieval_mode=str(config.retrieval_mode),
-        candidate_k=config.candidate_k,
-        dual_candidate_k=config.dual_candidate_k,
-        hybrid_alpha=config.hybrid_alpha,
-    )
+    config = validate_eval_retrieval_config(config)
     prepared = workspace.prepared_retriever_workspace
     if prepared is not None and hasattr(prepared, "build_retriever"):
         retriever = prepared.build_retriever(
@@ -275,6 +228,7 @@ def run_prepared_retrieval_eval(
         dual_candidate_k=config.dual_candidate_k,
         max_queries=max_queries,
         run_out=run_out,
+        filters=filters,
     )
 
 
@@ -315,6 +269,8 @@ def _run_exact_hybrid_alpha_group(
                 ),
                 json_out=spec.json_out,
                 run_out=spec.run_out,
+                report_out=spec.report_out,
+                anomalies_out=spec.anomalies_out,
             )
             for spec in specs
         )
@@ -330,7 +286,9 @@ def _run_exact_hybrid_alpha_group(
     alpha_by_name = {
         spec.name: _effective_hybrid_alpha(workspace=workspace, spec=spec) for spec in specs
     }
-    ranking_by_name: dict[str, dict[str, list[str]]] = {spec.name: {} for spec in specs}
+    ranking_by_name: dict[str, dict[str, list[EvalRetrievedItem]]] = {
+        spec.name: {} for spec in specs
+    }
     queries = list(workspace.dataset.queries)
     if max_queries is not None:
         queries = queries[: max(0, int(max_queries))]
@@ -340,7 +298,7 @@ def _run_exact_hybrid_alpha_group(
         hybrid_results = retrieve_group(query=query.query, top_k=k, alphas=alphas)
         for spec in specs:
             retrieval = hybrid_results[alpha_by_name[spec.name]]
-            ranking_by_name[spec.name][query.query] = _external_ids_from_retrieval(retrieval)
+            ranking_by_name[spec.name][query.query] = _ranked_items_from_retrieval(retrieval)
 
     out: list[EvalBatchResult] = []
     for spec in specs:
@@ -349,7 +307,7 @@ def _run_exact_hybrid_alpha_group(
 
         result = run_retrieval_eval_core(
             dataset=workspace.dataset,
-            retrieve_external_ids=_rankings_lookup(rankings),
+            retrieve_ranked_items=_rankings_lookup(rankings),
             retrieval_mode="hybrid",
             k=k,
             reranker_enabled=False,
@@ -362,6 +320,8 @@ def _run_exact_hybrid_alpha_group(
                 result=result,
                 json_out=spec.json_out,
                 run_out=spec.run_out,
+                report_out=spec.report_out,
+                anomalies_out=spec.anomalies_out,
             )
         )
     return tuple(out)
@@ -411,6 +371,8 @@ def run_retrieval_eval_batch(
                 ),
                 json_out=spec.json_out,
                 run_out=spec.run_out,
+                report_out=spec.report_out,
+                anomalies_out=spec.anomalies_out,
             )
             for spec in specs
         )
@@ -452,6 +414,8 @@ def run_retrieval_eval_batch(
                 result=result,
                 json_out=spec.json_out,
                 run_out=spec.run_out,
+                report_out=spec.report_out,
+                anomalies_out=spec.anomalies_out,
             )
         )
 
@@ -487,16 +451,18 @@ def compare_retrieval_eval(
     max_regression_precision: float = 0.0,
     max_regression_recall: float = 0.0,
 ) -> EvalCompareResult:
+    baseline_config = eval_compare_config_to_retrieval_config(baseline, k=k)
+    candidate_config = eval_compare_config_to_retrieval_config(candidate, k=k)
     baseline_result = run_retrieval_eval(
         dataset=dataset,
         eval_storage_port=eval_storage_port,
         eval_retriever_factory_port=eval_retriever_factory_port,
-        retrieval_mode=baseline.retrieval_mode,
-        k=k,
-        candidate_k=baseline.candidate_k,
-        reranker_enabled=baseline.reranker_enabled,
-        dual_candidate_k=baseline.dual_candidate_k,
-        hybrid_alpha=baseline.hybrid_alpha,
+        retrieval_mode=baseline_config.retrieval_mode,
+        k=baseline_config.k,
+        candidate_k=baseline_config.candidate_k,
+        reranker_enabled=baseline_config.reranker_enabled,
+        dual_candidate_k=baseline_config.dual_candidate_k,
+        hybrid_alpha=baseline_config.hybrid_alpha,
         reranker_candidate_k=reranker_candidate_k,
         reranker_strategy=reranker_strategy,
         max_queries=max_queries,
@@ -505,12 +471,12 @@ def compare_retrieval_eval(
         dataset=dataset,
         eval_storage_port=eval_storage_port,
         eval_retriever_factory_port=eval_retriever_factory_port,
-        retrieval_mode=candidate.retrieval_mode,
-        k=k,
-        candidate_k=candidate.candidate_k,
-        reranker_enabled=candidate.reranker_enabled,
-        dual_candidate_k=candidate.dual_candidate_k,
-        hybrid_alpha=candidate.hybrid_alpha,
+        retrieval_mode=candidate_config.retrieval_mode,
+        k=candidate_config.k,
+        candidate_k=candidate_config.candidate_k,
+        reranker_enabled=candidate_config.reranker_enabled,
+        dual_candidate_k=candidate_config.dual_candidate_k,
+        hybrid_alpha=candidate_config.hybrid_alpha,
         reranker_candidate_k=reranker_candidate_k,
         reranker_strategy=reranker_strategy,
         max_queries=max_queries,

--- a/src/local_rag_backend/infrastructure/evaluation/__init__.py
+++ b/src/local_rag_backend/infrastructure/evaluation/__init__.py
@@ -1,0 +1,29 @@
+"""Optional evaluation adapters."""
+
+from local_rag_backend.infrastructure.evaluation.benchmarks import (
+    eval_dataset_from_ir_mappings,
+)
+from local_rag_backend.infrastructure.evaluation.llm_judge import (
+    EvalConsensusResult,
+    EvalJudgeClient,
+    EvalJudgeRequest,
+    EvalJudgeResult,
+    run_judge_consensus,
+    run_single_judge,
+)
+from local_rag_backend.infrastructure.evaluation.ragas_adapter import (
+    EvalAdapterUnavailableError,
+    RagasEvaluationAdapter,
+)
+
+__all__ = [
+    "EvalAdapterUnavailableError",
+    "EvalConsensusResult",
+    "EvalJudgeClient",
+    "EvalJudgeRequest",
+    "EvalJudgeResult",
+    "RagasEvaluationAdapter",
+    "eval_dataset_from_ir_mappings",
+    "run_judge_consensus",
+    "run_single_judge",
+]

--- a/src/local_rag_backend/infrastructure/evaluation/benchmarks.py
+++ b/src/local_rag_backend/infrastructure/evaluation/benchmarks.py
@@ -1,0 +1,79 @@
+"""Benchmark dataset adapters for IR-style corpora."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from local_rag_backend.core.services.evaluation_models import (
+    EvalBenchmark,
+    EvalDataset,
+    EvalDoc,
+    EvalQrel,
+    EvalQuery,
+)
+
+
+def _document_content(raw_doc: object) -> str:
+    if isinstance(raw_doc, str):
+        return raw_doc
+    if isinstance(raw_doc, Mapping):
+        title = str(raw_doc.get("title") or "").strip()
+        text = str(raw_doc.get("text") or raw_doc.get("content") or "").strip()
+        if title and text:
+            return f"{title}\n\n{text}"
+        return title or text
+    return str(raw_doc)
+
+
+def eval_dataset_from_ir_mappings(
+    *,
+    benchmark: EvalBenchmark,
+    corpus: Mapping[str, object],
+    queries: Mapping[str, str],
+    qrels: Mapping[str, Mapping[str, int]],
+) -> EvalDataset:
+    """Convert BEIR/MTEB-like in-memory corpus/query/qrels mappings to EvalDataset."""
+    docs = tuple(
+        EvalDoc(
+            external_id=str(doc_id),
+            content=_document_content(raw_doc),
+            source_id=benchmark.benchmark_id,
+        )
+        for doc_id, raw_doc in corpus.items()
+    )
+    known_doc_ids = {doc.external_id for doc in docs}
+    eval_queries: list[EvalQuery] = []
+    for query_id, query_text in queries.items():
+        raw_qrels = qrels.get(str(query_id), {})
+        parsed_qrels = tuple(
+            EvalQrel(external_id=str(doc_id), relevance=int(relevance))
+            for doc_id, relevance in raw_qrels.items()
+            if int(relevance) > 0
+        )
+        if not parsed_qrels:
+            continue
+        missing = sorted(
+            qrel.external_id for qrel in parsed_qrels if qrel.external_id not in known_doc_ids
+        )
+        if missing:
+            raise ValueError(
+                "Benchmark qrels reference documents outside the corpus: " + ", ".join(missing[:10])
+            )
+        eval_queries.append(
+            EvalQuery(
+                query=str(query_text),
+                relevant_external_ids=tuple(qrel.external_id for qrel in parsed_qrels),
+                qrels=parsed_qrels,
+            )
+        )
+    if not docs:
+        raise ValueError("Benchmark corpus contains no docs.")
+    if not eval_queries:
+        raise ValueError("Benchmark qrels contain no positive relevance judgments.")
+    dataset_id = f"{benchmark.adapter}:{benchmark.dataset_id}"
+    return EvalDataset(
+        dataset_id=dataset_id,
+        schema_version=2,
+        docs=docs,
+        queries=tuple(eval_queries),
+    )

--- a/src/local_rag_backend/infrastructure/evaluation/llm_judge.py
+++ b/src/local_rag_backend/infrastructure/evaluation/llm_judge.py
@@ -1,0 +1,104 @@
+"""LLM-as-a-judge adapter contracts."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Protocol
+
+from local_rag_backend.core.services.evaluation_models import EvalJudge
+
+
+@dataclass(frozen=True)
+class EvalJudgeRequest:
+    question: str
+    answer: str
+    contexts: tuple[str, ...] = ()
+    reference_answer: str | None = None
+
+
+@dataclass(frozen=True)
+class EvalJudgeResult:
+    judge: EvalJudge
+    score: float
+    confidence: float | None
+    raw_judgment: str
+    parsed: dict[str, object]
+    cost_usd: float | None = None
+    latency_ms: int | None = None
+
+
+@dataclass(frozen=True)
+class EvalConsensusResult:
+    results: tuple[EvalJudgeResult, ...]
+    score: float
+    passed: bool
+    variance: float
+    abstained: bool
+
+
+class EvalJudgeClient(Protocol):
+    def judge(self, *, judge: EvalJudge, request: EvalJudgeRequest) -> EvalJudgeResult: ...
+
+
+def run_single_judge(
+    *,
+    judge: EvalJudge,
+    client: EvalJudgeClient,
+    request: EvalJudgeRequest,
+) -> EvalJudgeResult:
+    result = client.judge(judge=judge, request=request)
+    if result.judge != judge:
+        raise ValueError("Judge client returned a result for a different judge.")
+    if not 0.0 <= float(result.score) <= 1.0:
+        raise ValueError("Judge score must be between 0.0 and 1.0.")
+    if result.confidence is not None and not 0.0 <= float(result.confidence) <= 1.0:
+        raise ValueError("Judge confidence must be between 0.0 and 1.0.")
+    return result
+
+
+def run_judge_consensus(
+    *,
+    judges: Sequence[EvalJudge],
+    client: EvalJudgeClient,
+    request: EvalJudgeRequest,
+    pass_threshold: float = 0.5,
+    weights: Mapping[str, float] | None = None,
+    variance_threshold: float | None = None,
+) -> EvalConsensusResult:
+    """Run a weighted score consensus; variance abstention uses the same weights."""
+    if not judges:
+        raise ValueError("At least one judge is required for consensus.")
+    if not 0.0 <= float(pass_threshold) <= 1.0:
+        raise ValueError("pass_threshold must be between 0.0 and 1.0.")
+    results = tuple(
+        run_single_judge(judge=judge, client=client, request=request) for judge in judges
+    )
+    score_by_judge = {result.judge.judge_id: float(result.score) for result in results}
+    weight_by_judge = {judge_id: float(weight) for judge_id, weight in dict(weights or {}).items()}
+    total_weight = 0.0
+    weighted_score = 0.0
+    for judge_id, score in score_by_judge.items():
+        weight = weight_by_judge.get(judge_id, 1.0)
+        if weight < 0.0:
+            raise ValueError("Consensus weights must be non-negative.")
+        total_weight += weight
+        weighted_score += score * weight
+    if total_weight <= 0.0:
+        raise ValueError("At least one consensus weight must be positive.")
+    consensus_score = weighted_score / total_weight
+    variance = (
+        sum(
+            weight_by_judge.get(judge_id, 1.0) * (score - consensus_score) ** 2
+            for judge_id, score in score_by_judge.items()
+        )
+        / total_weight
+    )
+    abstained = variance_threshold is not None and variance > float(variance_threshold)
+    return EvalConsensusResult(
+        results=results,
+        score=consensus_score,
+        passed=bool(consensus_score >= float(pass_threshold) and not abstained),
+        variance=variance,
+        abstained=abstained,
+    )

--- a/src/local_rag_backend/infrastructure/evaluation/ragas_adapter.py
+++ b/src/local_rag_backend/infrastructure/evaluation/ragas_adapter.py
@@ -1,0 +1,39 @@
+"""Optional RAGAS adapter boundary.
+
+The adapter keeps RAGAS-specific objects outside the core evaluation model.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+from local_rag_backend.core.services.evaluation import eval_result_report_to_json
+from local_rag_backend.core.services.evaluation_models import EvalResult
+
+
+class EvalAdapterUnavailableError(RuntimeError):
+    """Raised when an optional evaluation adapter dependency is unavailable."""
+
+
+class RagasEvaluationAdapter:
+    def __init__(self) -> None:
+        self._ragas: Any | None = None
+
+    def _load_ragas(self) -> Any:
+        if self._ragas is None:
+            try:
+                self._ragas = import_module("ragas")
+            except ImportError as exc:
+                raise EvalAdapterUnavailableError(
+                    "RAGAS support requires installing ragas in the runtime environment."
+                ) from exc
+        return self._ragas
+
+    def ensure_available(self) -> None:
+        self._load_ragas()
+
+    def build_report_payload(self, result: EvalResult) -> dict[str, Any]:
+        payload = eval_result_report_to_json(result)
+        payload["adapter"] = "ragas"
+        return payload

--- a/src/local_rag_backend/mcp_server.py
+++ b/src/local_rag_backend/mcp_server.py
@@ -18,26 +18,19 @@ from local_rag_backend.cli_commands.runtime import (
     get_cli_runtime_snapshot,
     run_cli_mutation,
 )
-from local_rag_backend.core.domain.entities import Document as DomainDocument
-from local_rag_backend.core.domain.retrieval import (
-    RetrievalFilter,
-    RetrievalRequest,
-    RetrievalResult,
-    retrieval_result_from_pairs,
-)
+from local_rag_backend.core.domain.retrieval import RetrievalFilter
 from local_rag_backend.core.services.canonical_import_transport import (
     build_canonical_import_request_input_from_raw,
 )
 from local_rag_backend.core.services.evaluation import (
-    EvalResult,
+    build_eval_retrieval_config,
+    eval_result_to_json,
     load_eval_dataset,
-    run_retrieval_eval as run_retrieval_eval_core,
 )
-from local_rag_backend.core.services.types import EvalRetrievalConfig, EvalRetrievalMode
 from local_rag_backend.core.use_cases.docs_import_canonical import (
     execute_import_canonical_sync,
 )
-from local_rag_backend.core.use_cases.evaluation import prepare_eval_workspace
+from local_rag_backend.core.use_cases.evaluation import run_retrieval_eval
 
 logging.basicConfig(level=logging.INFO, format="%(message)s", stream=sys.stderr)
 logger = logging.getLogger("rag_prototype_mcp")
@@ -64,51 +57,6 @@ def _parse_filters(raw_filters: object | None) -> tuple[RetrievalFilter, ...]:
             )
         )
     return tuple(parsed)
-
-
-def _coerce_retrieval_result(
-    raw_result: object,
-    *,
-    request: RetrievalRequest,
-) -> RetrievalResult:
-    if isinstance(raw_result, RetrievalResult):
-        return raw_result
-    if (
-        isinstance(raw_result, tuple)
-        and len(raw_result) == 2
-        and isinstance(raw_result[0], (list, tuple))
-        and isinstance(raw_result[1], (list, tuple))
-    ):
-        docs, scores = raw_result
-        return retrieval_result_from_pairs(
-            docs=cast("Sequence[DomainDocument]", docs),
-            scores=cast("Sequence[float]", scores),
-            mode_used=request.mode,
-            backend_used="eval",
-        )
-    raise RuntimeError(f"Unsupported eval retriever response type: {type(raw_result)!r}")
-
-
-def _eval_result_to_dict(result: EvalResult) -> dict[str, object]:
-    return {
-        "dataset_id": result.dataset_id,
-        "retrieval_mode": result.retrieval_mode,
-        "reranker_enabled": result.reranker_enabled,
-        "k": result.k,
-        "queries": result.queries,
-        "ndcg_at_k": result.ndcg_at_k,
-        "map_at_k": result.map_at_k,
-        "mrr_at_k": result.mrr_at_k,
-        "precision_at_k": result.precision_at_k,
-        "recall_at_k": result.recall_at_k,
-    }
-
-
-def _resolve_eval_mode(raw_mode: object | None) -> EvalRetrievalMode:
-    mode = str(raw_mode or "sparse").strip().lower()
-    if mode not in {"sparse", "dense", "dual", "hybrid"}:
-        raise ValueError("retrieval_mode must be one of sparse, dense, dual, hybrid.")
-    return cast("EvalRetrievalMode", mode)
 
 
 def tool_status() -> dict[str, object]:
@@ -189,7 +137,8 @@ def tool_import_canonical(
             "deleted_external_ids": list(summary.deleted_external_ids or []),
         }
 
-    return run_cli_mutation(_run_sync, use_lock=True)
+    result: dict[str, object] = run_cli_mutation(_run_sync, use_lock=True)
+    return result
 
 
 def tool_rebuild_index() -> dict[str, object]:
@@ -203,7 +152,9 @@ def tool_rebuild_index() -> dict[str, object]:
     ports = container.index_mutation_ports(build_embedder=build_dense_embedder)
 
     def _rebuild_sync() -> int:
-        return index_service.rebuild_index_sync(settings_obj=container.settings_obj, ports=ports)
+        return int(
+            index_service.rebuild_index_sync(settings_obj=container.settings_obj, ports=ports)
+        )
 
     rebuilt = run_cli_mutation(_rebuild_sync)
     return {"vectors": rebuilt, "retrieval_mode": runtime.retrieval_mode}
@@ -218,58 +169,25 @@ def tool_eval(
     runtime = get_cli_runtime_snapshot()
     dataset = load_eval_dataset(dataset_path or runtime.eval_dataset_path)
     parsed_filters = _parse_filters(filters)
-    mode = _resolve_eval_mode(retrieval_mode)
-    top_k = int(k or 3)
-    if top_k <= 0:
-        raise ValueError("k must be positive.")
+    config = build_eval_retrieval_config(
+        retrieval_mode=retrieval_mode,
+        k=(3 if k is None else k),
+    )
 
     container = get_cli_container()
     eval_bundle = container.build_eval_execution_bundle()
-    workspace = prepare_eval_workspace(
+    result = run_retrieval_eval(
         dataset=dataset,
         eval_storage_port=eval_bundle.eval_storage_port,
         eval_retriever_factory_port=eval_bundle.eval_retriever_factory_port,
-    )
-    config = EvalRetrievalConfig(retrieval_mode=mode, k=top_k, reranker_enabled=False)
-    prepared = workspace.prepared_retriever_workspace
-    if prepared is not None and hasattr(prepared, "build_retriever"):
-        retriever = prepared.build_retriever(
-            config=config,
-            reranker_candidate_k=eval_bundle.reranker_candidate_k,
-            reranker_strategy=eval_bundle.reranker_strategy,
-        )
-    else:
-        retriever = workspace.eval_retriever_factory_port.build_retriever(
-            storage=workspace.eval_storage_port,
-            config=config,
-            reranker_candidate_k=eval_bundle.reranker_candidate_k,
-            reranker_strategy=eval_bundle.reranker_strategy,
-        )
-
-    def _retrieve_external_ids(query: str, requested_top_k: int) -> list[str]:
-        request = RetrievalRequest(
-            query=query,
-            top_k=requested_top_k,
-            mode=mode,
-            filters=parsed_filters,
-        )
-        retrieval = _coerce_retrieval_result(retriever.retrieve(request), request=request)
-        return [
-            str(item.document.external_id)
-            for item in retrieval.items
-            if getattr(item.document, "external_id", None) is not None
-        ]
-
-    result = run_retrieval_eval_core(
-        dataset=dataset,
-        retrieve_external_ids=_retrieve_external_ids,
-        retrieval_mode=mode,
-        k=top_k,
+        retrieval_mode=config.retrieval_mode,
+        k=config.k,
         reranker_enabled=False,
-        max_queries=None,
-        run_out=None,
+        reranker_candidate_k=eval_bundle.reranker_candidate_k,
+        reranker_strategy=eval_bundle.reranker_strategy,
+        filters=parsed_filters,
     )
-    response = _eval_result_to_dict(result)
+    response = eval_result_to_json(result)
     response["filters"] = [
         {"field": item.field, "values": list(item.values)} for item in parsed_filters
     ]

--- a/tests/unit/application/services/test_app_evaluation_service.py
+++ b/tests/unit/application/services/test_app_evaluation_service.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import pytest
 
-from local_rag_backend.composition import adapters as adapters_module
+from local_rag_backend.composition import evaluation as eval_adapters_module
 from local_rag_backend.composition.adapters import (
     build_eval_retriever_factory_port,
     build_eval_storage_port,
@@ -25,10 +25,11 @@ from local_rag_backend.core.services.evaluation import (
     load_eval_dataset,
     run_retrieval_eval as run_core_eval,
 )
-from local_rag_backend.core.services.types import (
+from local_rag_backend.core.services.evaluation_models import (
     EvalBatchSpec,
     EvalCompareConfig,
     EvalRetrievalConfig,
+    EvalRetrievedItem,
 )
 from local_rag_backend.core.use_cases.evaluation import (
     compare_retrieval_eval,
@@ -143,20 +144,20 @@ def test_run_retrieval_eval_app_service_matches_core_semantics() -> None:
         reranker_strategy="overlap_v1",
     )
 
-    def _retrieve_external_ids(query: str, top_k: int) -> list[str]:
+    def _retrieve_ranked_items(query: str, top_k: int) -> list[EvalRetrievedItem]:
         request = RetrievalRequest(query=query, top_k=top_k, mode="sparse")
         retrieval = _coerce_retrieval_result(retriever.retrieve(request), request=request)
         return [
-            str(external_id)
-            for external_id in (
-                getattr(document, "external_id", None) for document in retrieval.documents
+            EvalRetrievedItem(external_id=str(external_id), score=float(item.score))
+            for item, external_id in (
+                (item, getattr(item.document, "external_id", None)) for item in retrieval.items
             )
             if external_id is not None and str(external_id).strip()
         ]
 
     core_res = run_core_eval(
         dataset=ds,
-        retrieve_external_ids=_retrieve_external_ids,
+        retrieve_ranked_items=_retrieve_ranked_items,
         retrieval_mode="sparse",
         k=3,
         reranker_enabled=True,
@@ -174,7 +175,16 @@ def test_run_retrieval_eval_app_service_matches_core_semantics() -> None:
         reranker_strategy="overlap_v1",
     )
 
-    assert app_res == core_res
+    assert app_res.dataset_id == core_res.dataset_id
+    assert app_res.retrieval_mode == core_res.retrieval_mode
+    assert app_res.ndcg_at_k == pytest.approx(core_res.ndcg_at_k)
+    assert app_res.map_at_k == pytest.approx(core_res.map_at_k)
+    assert app_res.mrr_at_k == pytest.approx(core_res.mrr_at_k)
+    assert app_res.precision_at_k == pytest.approx(core_res.precision_at_k)
+    assert app_res.recall_at_k == pytest.approx(core_res.recall_at_k)
+    assert [item.metrics for item in app_res.per_query] == [
+        item.metrics for item in core_res.per_query
+    ]
 
 
 def test_build_eval_storage_port_uses_isolated_local_paths(tmp_path: Path) -> None:
@@ -431,18 +441,18 @@ def test_run_retrieval_eval_reuses_persisted_dense_eval_index(
             return super().embed(texts)
 
     monkeypatch.setattr(
-        adapters_module,
+        eval_adapters_module,
         "build_dense_embedder_from_settings",
         lambda **_kwargs: FakeEmbedder(),
     )
 
-    workspace = adapters_module._PreparedEvalWorkspace(
+    workspace = eval_adapters_module._PreparedEvalWorkspace(
         storage=storage,
         openai_embedder_factory=lambda: FakeEmbedder(),
         st_embedder_factory=lambda _model_name: FakeEmbedder(),
         dense_retriever_factory=lambda **_kwargs: None,
         hybrid_retriever_factory=lambda **_kwargs: None,
-        vector_repo_factory=adapters_module.VectorStorage,
+        vector_repo_factory=eval_adapters_module.VectorStorage,
         reranker_factory=lambda *_args, **_kwargs: None,
     )
 
@@ -451,13 +461,13 @@ def test_run_retrieval_eval_reuses_persisted_dense_eval_index(
     assert embed_calls == [len(ds.docs)]
 
     embed_calls.clear()
-    second_workspace = adapters_module._PreparedEvalWorkspace(
+    second_workspace = eval_adapters_module._PreparedEvalWorkspace(
         storage=storage,
         openai_embedder_factory=lambda: FakeEmbedder(),
         st_embedder_factory=lambda _model_name: FakeEmbedder(),
         dense_retriever_factory=lambda **_kwargs: None,
         hybrid_retriever_factory=lambda **_kwargs: None,
-        vector_repo_factory=adapters_module.VectorStorage,
+        vector_repo_factory=eval_adapters_module.VectorStorage,
         reranker_factory=lambda *_args, **_kwargs: None,
     )
     second_workspace._ensure_vector_repo_ready()
@@ -516,31 +526,31 @@ def test_run_retrieval_eval_rebuilds_dense_eval_index_when_model_manifest_change
             return super().embed(texts)
 
     monkeypatch.setattr(
-        adapters_module,
+        eval_adapters_module,
         "build_dense_embedder_from_settings",
         lambda **_kwargs: FakeEmbedder(),
     )
 
-    first_workspace = adapters_module._PreparedEvalWorkspace(
+    first_workspace = eval_adapters_module._PreparedEvalWorkspace(
         storage=storage_a,
         openai_embedder_factory=lambda: FakeEmbedder(),
         st_embedder_factory=lambda _model_name: FakeEmbedder(),
         dense_retriever_factory=lambda **_kwargs: None,
         hybrid_retriever_factory=lambda **_kwargs: None,
-        vector_repo_factory=adapters_module.VectorStorage,
+        vector_repo_factory=eval_adapters_module.VectorStorage,
         reranker_factory=lambda *_args, **_kwargs: None,
     )
     first_workspace._ensure_vector_repo_ready()
     assert embed_calls == [len(ds.docs)]
 
     embed_calls.clear()
-    second_workspace = adapters_module._PreparedEvalWorkspace(
+    second_workspace = eval_adapters_module._PreparedEvalWorkspace(
         storage=storage_b,
         openai_embedder_factory=lambda: FakeEmbedder(),
         st_embedder_factory=lambda _model_name: FakeEmbedder(),
         dense_retriever_factory=lambda **_kwargs: None,
         hybrid_retriever_factory=lambda **_kwargs: None,
-        vector_repo_factory=adapters_module.VectorStorage,
+        vector_repo_factory=eval_adapters_module.VectorStorage,
         reranker_factory=lambda *_args, **_kwargs: None,
     )
     second_workspace._ensure_vector_repo_ready()
@@ -591,20 +601,20 @@ def test_run_retrieval_eval_builds_dense_eval_index_in_chunks(
             batch_sizes.append(len(texts))
             return super().embed(texts)
 
-    monkeypatch.setattr(adapters_module, "EVAL_DENSE_REBUILD_BATCH_SIZE", 2)
+    monkeypatch.setattr(eval_adapters_module, "EVAL_DENSE_REBUILD_BATCH_SIZE", 2)
     monkeypatch.setattr(
-        adapters_module,
+        eval_adapters_module,
         "build_dense_embedder_from_settings",
         lambda **_kwargs: FakeEmbedder(),
     )
 
-    workspace = adapters_module._PreparedEvalWorkspace(
+    workspace = eval_adapters_module._PreparedEvalWorkspace(
         storage=storage,
         openai_embedder_factory=lambda: FakeEmbedder(),
         st_embedder_factory=lambda _model_name: FakeEmbedder(),
         dense_retriever_factory=lambda **_kwargs: None,
         hybrid_retriever_factory=lambda **_kwargs: None,
-        vector_repo_factory=adapters_module.VectorStorage,
+        vector_repo_factory=eval_adapters_module.VectorStorage,
         reranker_factory=lambda *_args, **_kwargs: None,
     )
     workspace._ensure_vector_repo_ready()

--- a/tests/unit/cli/test_cli_eval.py
+++ b/tests/unit/cli/test_cli_eval.py
@@ -113,6 +113,44 @@ def test_rag_eval_json_out_uses_metrics_only_shape(tmp_path: Path) -> None:
     assert set(payload["metrics"].keys()) == {"nDCG@1", "MAP@1", "MRR@1", "P@1", "Recall@1"}
 
 
+def test_rag_eval_writes_detailed_report_and_anomalies(tmp_path: Path) -> None:
+    ds = tmp_path / "ds.jsonl"
+    report_out = tmp_path / "report.json"
+    anomalies_out = tmp_path / "anomalies.jsonl"
+    ds.write_text(
+        "\n".join(
+            [
+                '{"type":"meta","dataset_id":"x","schema_version":1}',
+                '{"type":"doc","external_id":"doc:1","source_id":"eval","content":"alpha beta"}',
+                '{"type":"query","query":"alpha","relevant_external_ids":["doc:1"]}',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    r = CliRunner().invoke(
+        cli,
+        [
+            "eval",
+            "--dataset",
+            str(ds),
+            "--k",
+            "1",
+            "--report-out",
+            str(report_out),
+            "--anomalies-out",
+            str(anomalies_out),
+        ],
+    )
+
+    assert r.exit_code == 0, r.output
+    report = json.loads(report_out.read_text(encoding="utf-8"))
+    assert report["type"] == "eval_report"
+    assert report["per_query"][0]["ranked_docs"][0]["external_id"] == "doc:1"
+    assert anomalies_out.read_text(encoding="utf-8") == ""
+
+
 def test_rag_eval_dense_mode_uses_isolated_runtime_and_json_out(
     tmp_path: Path, monkeypatch
 ) -> None:
@@ -231,6 +269,7 @@ def test_rag_eval_rejects_incompatible_mode_specific_flags(tmp_path: Path) -> No
 
 def test_rag_eval_compare_passes_and_writes_json(tmp_path: Path, monkeypatch) -> None:
     ds = tmp_path / "compare.jsonl"
+    spec = tmp_path / "compare-spec.json"
     json_out = tmp_path / "compare-result.json"
     ds.write_text(
         "\n".join(
@@ -242,6 +281,23 @@ def test_rag_eval_compare_passes_and_writes_json(tmp_path: Path, monkeypatch) ->
             ]
         )
         + "\n",
+        encoding="utf-8",
+    )
+    spec.write_text(
+        json.dumps(
+            {
+                "k": 1,
+                "baseline": {"retrieval_mode": "sparse"},
+                "candidate": {"retrieval_mode": "dual", "dual_candidate_k": 1},
+                "thresholds": {
+                    "min_delta_ndcg": 0.0,
+                    "min_delta_map": 0.0,
+                    "min_delta_mrr": 0.0,
+                    "max_regression_precision": 0.0,
+                    "max_regression_recall": 0.0,
+                },
+            }
+        ),
         encoding="utf-8",
     )
 
@@ -261,22 +317,8 @@ def test_rag_eval_compare_passes_and_writes_json(tmp_path: Path, monkeypatch) ->
             "eval-compare",
             "--dataset",
             str(ds),
-            "--k",
-            "1",
-            "--candidate-mode",
-            "dual",
-            "--candidate-dual-candidate-k",
-            "1",
-            "--min-delta-ndcg",
-            "0.0",
-            "--min-delta-map",
-            "0.0",
-            "--min-delta-mrr",
-            "0.0",
-            "--max-regression-precision",
-            "0.0",
-            "--max-regression-recall",
-            "0.0",
+            "--spec",
+            str(spec),
             "--json-out",
             str(json_out),
         ],
@@ -295,6 +337,7 @@ def test_rag_eval_compare_passes_and_writes_json(tmp_path: Path, monkeypatch) ->
 
 def test_rag_eval_compare_fails_gate_with_exit_code_one(tmp_path: Path) -> None:
     ds = tmp_path / "compare.jsonl"
+    spec = tmp_path / "compare-spec.json"
     ds.write_text(
         "\n".join(
             [
@@ -307,6 +350,17 @@ def test_rag_eval_compare_fails_gate_with_exit_code_one(tmp_path: Path) -> None:
         + "\n",
         encoding="utf-8",
     )
+    spec.write_text(
+        json.dumps(
+            {
+                "k": 1,
+                "baseline": {"retrieval_mode": "sparse"},
+                "candidate": {"retrieval_mode": "sparse", "reranker_enabled": True},
+                "thresholds": {"min_delta_ndcg": 0.1},
+            }
+        ),
+        encoding="utf-8",
+    )
 
     r = CliRunner().invoke(
         cli,
@@ -314,13 +368,8 @@ def test_rag_eval_compare_fails_gate_with_exit_code_one(tmp_path: Path) -> None:
             "eval-compare",
             "--dataset",
             str(ds),
-            "--k",
-            "1",
-            "--candidate-mode",
-            "sparse",
-            "--candidate-reranker",
-            "--min-delta-ndcg",
-            "0.1",
+            "--spec",
+            str(spec),
         ],
     )
 
@@ -333,6 +382,7 @@ def test_rag_eval_compare_reports_invalid_candidate_mode_config_with_exit_code_t
     tmp_path: Path,
 ) -> None:
     ds = tmp_path / "compare.jsonl"
+    spec = tmp_path / "compare-spec.json"
     ds.write_text(
         "\n".join(
             [
@@ -344,6 +394,15 @@ def test_rag_eval_compare_reports_invalid_candidate_mode_config_with_exit_code_t
         + "\n",
         encoding="utf-8",
     )
+    spec.write_text(
+        json.dumps(
+            {
+                "baseline": {"retrieval_mode": "sparse"},
+                "candidate": {"retrieval_mode": "sparse", "candidate_k": 5},
+            }
+        ),
+        encoding="utf-8",
+    )
 
     r = CliRunner().invoke(
         cli,
@@ -351,10 +410,8 @@ def test_rag_eval_compare_reports_invalid_candidate_mode_config_with_exit_code_t
             "eval-compare",
             "--dataset",
             str(ds),
-            "--candidate-mode",
-            "sparse",
-            "--candidate-candidate-k",
-            "5",
+            "--spec",
+            str(spec),
         ],
     )
 

--- a/tests/unit/cli/test_cli_eval_repogpt_dataset.py
+++ b/tests/unit/cli/test_cli_eval_repogpt_dataset.py
@@ -36,26 +36,32 @@ def test_rag_eval_repogpt_dataset_sparse_smoke() -> None:
 
 def test_rag_eval_compare_repogpt_dataset_sparse_smoke(tmp_path: Path) -> None:
     json_out = tmp_path / "repogpt-compare.json"
+    spec = tmp_path / "repogpt-compare-spec.json"
+    spec.write_text(
+        json.dumps(
+            {
+                "k": 1,
+                "baseline": {"retrieval_mode": "sparse"},
+                "candidate": {"retrieval_mode": "sparse"},
+                "thresholds": {
+                    "min_delta_ndcg": 0.0,
+                    "min_delta_map": 0.0,
+                    "min_delta_mrr": 0.0,
+                    "max_regression_precision": 0.0,
+                    "max_regression_recall": 0.0,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
     result = CliRunner().invoke(
         cli,
         [
             "eval-compare",
             "--dataset",
             str(DATASET_PATH),
-            "--k",
-            "1",
-            "--candidate-mode",
-            "sparse",
-            "--min-delta-ndcg",
-            "0.0",
-            "--min-delta-map",
-            "0.0",
-            "--min-delta-mrr",
-            "0.0",
-            "--max-regression-precision",
-            "0.0",
-            "--max-regression-recall",
-            "0.0",
+            "--spec",
+            str(spec),
             "--json-out",
             str(json_out),
         ],

--- a/tests/unit/cli/test_cli_eval_vuln_pilot_dataset.py
+++ b/tests/unit/cli/test_cli_eval_vuln_pilot_dataset.py
@@ -36,26 +36,32 @@ def test_rag_eval_vuln_pilot_dataset_sparse_smoke() -> None:
 
 def test_rag_eval_compare_vuln_pilot_dataset_sparse_smoke(tmp_path: Path) -> None:
     json_out = tmp_path / "vuln-pilot-compare.json"
+    spec = tmp_path / "vuln-pilot-compare-spec.json"
+    spec.write_text(
+        json.dumps(
+            {
+                "k": 1,
+                "baseline": {"retrieval_mode": "sparse"},
+                "candidate": {"retrieval_mode": "sparse"},
+                "thresholds": {
+                    "min_delta_ndcg": 0.0,
+                    "min_delta_map": 0.0,
+                    "min_delta_mrr": 0.0,
+                    "max_regression_precision": 0.0,
+                    "max_regression_recall": 0.0,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
     result = CliRunner().invoke(
         cli,
         [
             "eval-compare",
             "--dataset",
             str(DATASET_PATH),
-            "--k",
-            "1",
-            "--candidate-mode",
-            "sparse",
-            "--min-delta-ndcg",
-            "0.0",
-            "--min-delta-map",
-            "0.0",
-            "--min-delta-mrr",
-            "0.0",
-            "--max-regression-precision",
-            "0.0",
-            "--max-regression-recall",
-            "0.0",
+            "--spec",
+            str(spec),
             "--json-out",
             str(json_out),
         ],

--- a/tests/unit/core/services/test_evaluation.py
+++ b/tests/unit/core/services/test_evaluation.py
@@ -7,12 +7,14 @@ import pytest
 from local_rag_backend.core.services.evaluation import (
     EvalDataset,
     compare_eval_results,
+    eval_anomalies_to_jsonl,
     eval_compare_result_to_json,
+    eval_result_report_to_json,
     format_eval_result,
     load_eval_dataset,
     run_retrieval_eval,
 )
-from local_rag_backend.core.services.types import EvalResult
+from local_rag_backend.core.services.evaluation_models import EvalResult
 
 
 def test_load_eval_dataset_missing_file_raises(tmp_path: Path) -> None:
@@ -127,6 +129,53 @@ def test_load_eval_dataset_rejects_blank_ids_after_normalization(tmp_path: Path)
         load_eval_dataset(p)
 
 
+def test_load_eval_dataset_supports_schema_v2_graded_qrels(tmp_path: Path) -> None:
+    p = tmp_path / "graded.jsonl"
+    p.write_text(
+        "\n".join(
+            [
+                '{"type":"meta","dataset_id":"graded","schema_version":2}',
+                '{"type":"doc","external_id":"doc:great","content":"alpha"}',
+                '{"type":"doc","external_id":"doc:ok","content":"alpha beta"}',
+                (
+                    '{"type":"query","query":"alpha","qrels":['
+                    '{"external_id":"doc:great","relevance":3},'
+                    '{"external_id":"doc:ok","relevance":1}]}'
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    ds = load_eval_dataset(p)
+
+    assert ds.schema_version == 2
+    assert ds.queries[0].relevant_external_ids == ("doc:great", "doc:ok")
+    assert [qrel.relevance for qrel in ds.queries[0].qrels] == [3, 1]
+
+
+def test_load_eval_dataset_rejects_qrels_with_schema_v1(tmp_path: Path) -> None:
+    p = tmp_path / "bad-qrels.jsonl"
+    p.write_text(
+        "\n".join(
+            [
+                '{"type":"meta","dataset_id":"bad","schema_version":1}',
+                '{"type":"doc","external_id":"doc:1","content":"alpha"}',
+                (
+                    '{"type":"query","query":"alpha","qrels":['
+                    '{"external_id":"doc:1","relevance":2}]}'
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="qrels require schema_version=2"):
+        load_eval_dataset(p)
+
+
 def test_run_retrieval_eval_allows_non_sparse_modes_when_callback_is_valid() -> None:
     ds = load_eval_dataset()
     result = run_retrieval_eval(
@@ -176,7 +225,7 @@ def test_run_retrieval_eval_reports_standard_ir_metrics_for_perfect_run() -> Non
     assert res.recall_at_k == pytest.approx(1.0)
 
 
-def test_run_retrieval_eval_filters_unknown_ids_and_deduplicates_run() -> None:
+def test_run_retrieval_eval_keeps_unknown_ids_as_non_relevant_and_reports_anomalies() -> None:
     ds = EvalDataset(
         dataset_id="edge",
         schema_version=1,
@@ -192,7 +241,7 @@ def test_run_retrieval_eval_filters_unknown_ids_and_deduplicates_run() -> None:
 
     def _retrieve_external_ids(query: str, top_k: int) -> tuple[str, ...]:
         if "France" in query:
-            return ("doc:unknown", "doc:paris", "doc:paris")
+            return ("doc:unknown", "doc:unknown", "doc:paris")
         if "Spain" in query:
             return ("doc:paris", "doc:madrid")
         return ()
@@ -204,11 +253,54 @@ def test_run_retrieval_eval_filters_unknown_ids_and_deduplicates_run() -> None:
         k=2,
     )
 
-    assert res.ndcg_at_k == pytest.approx(0.8154648767)
-    assert res.map_at_k == pytest.approx(0.75)
-    assert res.mrr_at_k == pytest.approx(0.75)
+    assert res.ndcg_at_k == pytest.approx(0.6309297536)
+    assert res.map_at_k == pytest.approx(0.5)
+    assert res.mrr_at_k == pytest.approx(0.5)
     assert res.precision_at_k == pytest.approx(0.5)
     assert res.recall_at_k == pytest.approx(1.0)
+    assert [anomaly.kind for anomaly in res.anomalies] == [
+        "unknown_external_id",
+        "duplicate_external_id",
+    ]
+    assert res.per_query[0].ranked_docs[0].external_id == "doc:unknown"
+    assert res.per_query[0].ranked_docs[0].known is False
+
+
+def test_run_retrieval_eval_preserves_retriever_scores_in_run_output(tmp_path: Path) -> None:
+    ds = load_eval_dataset()
+    run_out = tmp_path / "run.jsonl"
+
+    res = run_retrieval_eval(
+        dataset=ds,
+        retrieve_ranked_items=lambda _query, _top_k: ({"external_id": "doc:paris", "score": 0.42},),
+        retrieval_mode="sparse",
+        k=1,
+        max_queries=1,
+        run_out=run_out,
+    )
+
+    assert res.per_query[0].ranked_docs[0].score == pytest.approx(0.42)
+    assert '"score": 0.42' in run_out.read_text(encoding="utf-8")
+
+
+def test_eval_result_report_and_anomalies_json_include_audit_details() -> None:
+    ds = load_eval_dataset()
+    res = run_retrieval_eval(
+        dataset=ds,
+        retrieve_external_ids=lambda _query, _top_k: ("doc:unknown",),
+        retrieval_mode="sparse",
+        k=1,
+        max_queries=1,
+    )
+
+    report = eval_result_report_to_json(res, config={"profile": "test"})
+    anomalies_jsonl = eval_anomalies_to_jsonl(res)
+
+    assert report["type"] == "eval_report"
+    assert report["config"] == {"profile": "test"}
+    assert report["anomalies_count"] == 1
+    assert report["per_query"][0]["ranked_docs"][0]["known"] is False
+    assert "unknown_external_id" in anomalies_jsonl
 
 
 def _eval_result(

--- a/tests/unit/core/use_cases/test_characterization.py
+++ b/tests/unit/core/use_cases/test_characterization.py
@@ -74,7 +74,7 @@ def test_rag_query_list_history_entries_sync_delegates_to_crud() -> None:
 def test_evaluation_run_retrieval_eval_validates_inputs() -> None:
     dataset = SimpleNamespace(docs=[], dataset_id="d", queries=[])
 
-    with pytest.raises(ValueError, match="Unsupported retrieval_mode"):
+    with pytest.raises(ValueError, match="retrieval_mode must be one"):
         evaluation.run_retrieval_eval(
             dataset=dataset,
             eval_storage_port=SimpleNamespace(),

--- a/tests/unit/infrastructure/evaluation/test_benchmark_adapters.py
+++ b/tests/unit/infrastructure/evaluation/test_benchmark_adapters.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import pytest
+
+from local_rag_backend.core.services.evaluation_models import EvalBenchmark
+from local_rag_backend.infrastructure.evaluation import eval_dataset_from_ir_mappings
+
+
+def test_eval_dataset_from_ir_mappings_converts_beir_like_records() -> None:
+    dataset = eval_dataset_from_ir_mappings(
+        benchmark=EvalBenchmark(
+            benchmark_id="beir-fixture",
+            adapter="beir",
+            dataset_id="demo",
+            split="test",
+        ),
+        corpus={
+            "d1": {"title": "Alpha", "text": "first doc"},
+            "d2": {"text": "second doc"},
+        },
+        queries={"q1": "alpha?"},
+        qrels={"q1": {"d1": 2, "d2": 1}},
+    )
+
+    assert dataset.dataset_id == "beir:demo"
+    assert dataset.schema_version == 2
+    assert dataset.docs[0].content == "Alpha\n\nfirst doc"
+    assert dataset.queries[0].qrels[0].relevance == 2
+
+
+def test_eval_dataset_from_ir_mappings_rejects_missing_qrel_docs() -> None:
+    with pytest.raises(ValueError, match="outside the corpus"):
+        eval_dataset_from_ir_mappings(
+            benchmark=EvalBenchmark(
+                benchmark_id="beir-fixture",
+                adapter="beir",
+                dataset_id="demo",
+            ),
+            corpus={"d1": "doc"},
+            queries={"q1": "alpha?"},
+            qrels={"q1": {"missing": 1}},
+        )

--- a/tests/unit/infrastructure/evaluation/test_llm_judge.py
+++ b/tests/unit/infrastructure/evaluation/test_llm_judge.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import pytest
+
+from local_rag_backend.core.services.evaluation_models import EvalJudge
+from local_rag_backend.infrastructure.evaluation import (
+    EvalJudgeRequest,
+    EvalJudgeResult,
+    run_judge_consensus,
+    run_single_judge,
+)
+
+
+class FakeJudgeClient:
+    def __init__(self, *, score: float, confidence: float | None = 0.9) -> None:
+        self._score = score
+        self._confidence = confidence
+
+    def judge(self, *, judge: EvalJudge, request: EvalJudgeRequest) -> EvalJudgeResult:
+        return EvalJudgeResult(
+            judge=judge,
+            score=self._score,
+            confidence=self._confidence,
+            raw_judgment="ok",
+            parsed={"question": request.question},
+            latency_ms=10,
+        )
+
+
+class ScoreByJudgeClient:
+    def __init__(self, scores: dict[str, float]) -> None:
+        self._scores = scores
+
+    def judge(self, *, judge: EvalJudge, request: EvalJudgeRequest) -> EvalJudgeResult:
+        return EvalJudgeResult(
+            judge=judge,
+            score=self._scores[judge.judge_id],
+            confidence=0.8,
+            raw_judgment="ok",
+            parsed={"answer": request.answer},
+        )
+
+
+def _judge(judge_id: str = "faithfulness-v1") -> EvalJudge:
+    return EvalJudge(
+        judge_id=judge_id,
+        provider="fake",
+        model="fake-model",
+        prompt_version="p1",
+        rubric_version="r1",
+    )
+
+
+def test_run_single_judge_accepts_valid_client_result() -> None:
+    result = run_single_judge(
+        judge=_judge(),
+        client=FakeJudgeClient(score=0.8),
+        request=EvalJudgeRequest(question="q", answer="a"),
+    )
+
+    assert result.score == pytest.approx(0.8)
+    assert result.parsed == {"question": "q"}
+
+
+def test_run_single_judge_rejects_score_outside_unit_interval() -> None:
+    with pytest.raises(ValueError, match="score"):
+        run_single_judge(
+            judge=_judge(),
+            client=FakeJudgeClient(score=1.2),
+            request=EvalJudgeRequest(question="q", answer="a"),
+        )
+
+
+def test_run_judge_consensus_supports_weighted_vote_and_variance_abstention() -> None:
+    judges = (_judge("a"), _judge("b"))
+    request = EvalJudgeRequest(question="q", answer="a")
+
+    consensus = run_judge_consensus(
+        judges=judges,
+        client=ScoreByJudgeClient({"a": 1.0, "b": 0.0}),
+        request=request,
+        pass_threshold=0.5,
+        weights={"a": 3.0, "b": 1.0},
+        variance_threshold=0.18,
+    )
+
+    assert consensus.score == pytest.approx(0.75)
+    assert consensus.variance == pytest.approx(0.1875)
+    assert consensus.abstained is True
+    assert consensus.passed is False

--- a/tests/unit/infrastructure/evaluation/test_ragas_adapter.py
+++ b/tests/unit/infrastructure/evaluation/test_ragas_adapter.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from local_rag_backend.core.services.evaluation import load_eval_dataset, run_retrieval_eval
+from local_rag_backend.infrastructure.evaluation import (
+    EvalAdapterUnavailableError,
+    RagasEvaluationAdapter,
+)
+
+
+def test_ragas_adapter_builds_core_report_payload_without_importing_ragas() -> None:
+    ds = load_eval_dataset()
+    result = run_retrieval_eval(
+        dataset=ds,
+        retrieve_external_ids=lambda _query, _top_k: ("doc:paris",),
+        retrieval_mode="sparse",
+        k=1,
+        max_queries=1,
+    )
+
+    payload = RagasEvaluationAdapter().build_report_payload(result)
+
+    assert payload["adapter"] == "ragas"
+    assert payload["type"] == "eval_report"
+
+
+def test_ragas_adapter_reports_missing_optional_dependency(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(sys.modules, "ragas", None)
+
+    with pytest.raises(EvalAdapterUnavailableError, match="installing ragas"):
+        RagasEvaluationAdapter().ensure_available()

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -154,4 +154,5 @@ def test_mcp_eval_supports_filters(in_memory_sqlite, tmp_path, monkeypatch) -> N
     assert payload["dataset_id"] == "repogpt_rag_eval_v1"
     assert payload["k"] == 1
     assert payload["queries"] > 0
+    assert set(payload["metrics"]) == {"nDCG@1", "MAP@1", "MRR@1", "P@1", "Recall@1"}
     assert payload["filters"] == [{"field": "source_id", "values": ["eval:repogpt:v1"]}]


### PR DESCRIPTION
## Summary
- Split evaluation services by responsibility: models, datasets/qrels, metrics, validation, serialization, and retrieval coercion.
- Move eval composition into dedicated modules while keeping adapters.py as a facade for builders.
- Centralize eval config validation and JSON/report serialization across CLI, MCP, and use cases.
- Replace rag-eval-compare flag matrix with a canonical --spec input.
- Add infrastructure eval adapters and focused tests/docs for the new surface.

## Breaking change
- rag-eval-compare now requires --spec with baseline, candidate, thresholds, k, and optional max_queries. Old --baseline-* / --candidate-* flags are intentionally removed.

## Validation
- git diff --check chore/eval-stabilize..HEAD
- uv run ruff check src tests
- uv run mypy src
- UV_CACHE_DIR=/tmp/uv-cache PYTHONPATH=src uv run --group lint lint-imports
- UV_CACHE_DIR=/tmp/uv-cache uv run --group test --extra server pytest -q -o addopts='' tests/architecture
- UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q -o addopts='' tests/unit/core/services/test_evaluation.py tests/unit/cli/test_cli_eval.py tests/unit/cli/test_cli_eval_repogpt_dataset.py tests/unit/cli/test_cli_eval_vuln_pilot_dataset.py tests/unit/test_mcp_server.py tests/unit/application/services/test_app_evaluation_service.py tests/unit/core/use_cases/test_characterization.py tests/unit/infrastructure/evaluation
- bash scripts/test_rag_eval_compare_e2e.sh
- UV_CACHE_DIR=/tmp/uv-cache uv run --group test --extra server pytest -q

Result: 707 passed, 7 skipped; coverage 87.45%.