### PR TITLE
Harden HTTP security boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ rag-server
 ## Configuration
 
 Runtime configuration defaults to `config.yaml` in the process working directory.
+When `debug: false`, `cors_allow_origins` accepts only explicit origins such as
+`https://app.example.com`; a wildcard (`"*"`) is rejected at startup. Leave the
+list empty to disable cross-origin access. Debug mode keeps the permissive
+wildcard policy for local development.
 Set `RAG_CONFIG_PATH=/absolute/path/to/runtime.yaml` when an installed console script, including
 `rag-mcp`, runs outside the checkout. The selected YAML remains the single runtime source of truth,
 and relative paths inside it resolve against that file's directory. An explicit path passed to

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -14,6 +14,7 @@ enable_reranker: false
 # --- Security / HTTP ---
 api_key: null
 public_bind_requires_api_key: true
+# Production requires exact origins; "*" is accepted only when debug is true.
 cors_allow_origins: []
 
 # --- Retrieval ---

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -65,6 +65,10 @@ faq_csv: data/faq.csv
 eval_dataset_path: datasets/rag_eval_v1.jsonl
 ```
 
+En producción (`debug: false`), `cors_allow_origins` debe quedar vacío o enumerar
+orígenes exactos, por ejemplo `["https://app.example.com"]`. El comodín `"*"`
+se rechaza al arrancar; solo se habilita automáticamente en modo debug local.
+
 Nota de topología: `search_backend` controla el motor de consulta independientemente de
 `persistence_backend`. Consulta la matriz del README para validar `dense`, `dual` o `hybrid`
 antes de cambiar valores.

--- a/src/local_rag_backend/core/use_cases/health.py
+++ b/src/local_rag_backend/core/use_cases/health.py
@@ -2,11 +2,23 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from local_rag_backend.core.ports import HealthDiagnosticsPort
     from local_rag_backend.settings import Settings
+
+logger = logging.getLogger(__name__)
+
+
+def _public_retrieval_stats(stats: dict[str, Any]) -> dict[str, Any]:
+    """Remove internal paths and raw error text from public readiness data."""
+    hidden_keys = {"error", "hint", "id_map_path", "index_path", "manifest_path"}
+    public = {key: value for key, value in stats.items() if key not in hidden_keys}
+    if "error" in stats:
+        public["error"] = "retrieval index unavailable"
+    return public
 
 
 def ping_database(*, diagnostics: HealthDiagnosticsPort) -> None:
@@ -18,8 +30,9 @@ def check_database(*, checks: dict[str, Any], diagnostics: HealthDiagnosticsPort
         ping_database(diagnostics=diagnostics)
         checks["database"] = "ok"
         return True
-    except Exception as e:
-        checks["database"] = f"failed: {e!s}"
+    except Exception:
+        logger.exception("Database readiness check failed")
+        checks["database"] = "failed: unavailable"
         return False
 
 
@@ -33,14 +46,16 @@ def check_sql_counts(
     try:
         docs_count = diagnostics.get_documents_count()
         checks["documents"] = {"count": docs_count}
-    except Exception as e:
-        checks["documents"] = f"failed: {e!s}"
+    except Exception:
+        logger.exception("Document-count readiness check failed")
+        checks["documents"] = "failed: unavailable"
         is_ready = False
 
     try:
         checks["history"] = {"count": diagnostics.get_history_count()}
-    except Exception as e:
-        checks["history"] = f"failed: {e!s}"
+    except Exception:
+        logger.exception("History-count readiness check failed")
+        checks["history"] = "failed: unavailable"
     return is_ready, docs_count
 
 
@@ -58,8 +73,6 @@ def _check_retrieval_index_id_set_drift(
         if not stale and not missing:
             return True
         checks["retrieval_index_drift"] = {
-            "stale_in_index": stale[:20],
-            "missing_in_index": missing[:20],
             "stale_count": len(stale),
             "missing_count": len(missing),
         }
@@ -68,8 +81,9 @@ def _check_retrieval_index_id_set_drift(
             "Hint: rebuild the index (`rag-rebuild-index` or POST /api/index/rebuild)."
         )
         return False
-    except Exception as e:
-        checks["retrieval_index_drift"] = f"failed: {e!s}"
+    except Exception:
+        logger.exception("Retrieval-index ID drift check failed")
+        checks["retrieval_index_drift"] = "failed: unavailable"
         checks["retrieval_index"] = (
             "failed: unable to verify retrieval index drift. "
             "Hint: inspect the index/id_map and rebuild if needed "
@@ -98,13 +112,13 @@ def check_retrieval_index(
         dim=None,
         expected_manifest=expected_manifest,
     )
-    checks["retrieval_index_stats"] = stats
+    checks["retrieval_index_stats"] = _public_retrieval_stats(stats)
 
     if stats.get("status") != "ok":
         checks["retrieval_index"] = (
             f"failed: {stats.get('status')} "
-            f"(index_path={stats.get('index_path')}, id_map_path={stats.get('id_map_path')}). "
-            f"Hint: {stats.get('hint')}"
+            "Hint: inspect the retrieval index and rebuild it if needed "
+            "(`rag-rebuild-index` or POST /api/index/rebuild)."
         )
         return False
 
@@ -144,8 +158,9 @@ def check_mutation_journal(
         incomplete = diagnostics.get_incomplete_mutation_records_count(
             coordination_dir=settings_obj.get_coordination_dir()
         )
-    except Exception as e:
-        checks["mutation_journal"] = {"status": "failed", "error": str(e)}
+    except Exception:
+        logger.exception("Mutation-journal readiness check failed")
+        checks["mutation_journal"] = {"status": "failed"}
         return
 
     if incomplete > 0:

--- a/src/local_rag_backend/http/exception_handlers.py
+++ b/src/local_rag_backend/http/exception_handlers.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 async def handle_app_error(_request: Request, exc: Exception) -> JSONResponse:
     app_error = exc if isinstance(exc, AppError) else InternalServerError(str(exc))
     detail = app_error.detail
-    if int(app_error.status_code) == 500 and not bool(settings.debug):
+    if int(app_error.status_code) >= 500 and not bool(settings.debug):
         detail = app_error.default_detail
     return JSONResponse(status_code=int(app_error.status_code), content={"detail": detail})
 

--- a/src/local_rag_backend/http/main.py
+++ b/src/local_rag_backend/http/main.py
@@ -125,6 +125,11 @@ def _get_frontend_asset(asset_path: str) -> tuple[bytes, str]:
     """
     Load a frontend asset (css/js/etc.), first from packaged resources, then from repo structure.
     """
+    if not asset_path or "\\" in asset_path:
+        raise NotFoundError("Asset not found.")
+    raw_parts = asset_path.split("/")
+    if any(part in {"", ".", ".."} for part in raw_parts):
+        raise NotFoundError("Asset not found.")
     posix = PurePosixPath(asset_path)
     if posix.is_absolute() or ".." in posix.parts:
         raise NotFoundError("Asset not found.")
@@ -141,7 +146,10 @@ def _get_frontend_asset(asset_path: str) -> tuple[bytes, str]:
         pass
 
     # 2) Repo assets
-    fs_file = FRONTEND_DIR.joinpath(*posix.parts)
+    fs_root = FRONTEND_DIR.resolve()
+    fs_file = fs_root.joinpath(*posix.parts).resolve()
+    if not fs_file.is_relative_to(fs_root):
+        raise NotFoundError("Asset not found.")
     if fs_file.is_file():
         data = fs_file.read_bytes()
         mt = mimetypes.guess_type(fs_file.name)[0] or "application/octet-stream"

--- a/src/local_rag_backend/http/main.py
+++ b/src/local_rag_backend/http/main.py
@@ -33,6 +33,8 @@ if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
     from importlib.resources.abc import Traversable
 
+    from local_rag_backend.settings import Settings
+
 _LOG_LEVEL = getattr(logging, settings.log_level, logging.INFO)
 logging.basicConfig(level=_LOG_LEVEL, stream=sys.stdout)
 logger = logging.getLogger(__name__)
@@ -148,11 +150,16 @@ def _get_frontend_asset(asset_path: str) -> tuple[bytes, str]:
     raise NotFoundError("Asset not found.")
 
 
+def _get_cors_allow_origins(settings_obj: Settings) -> list[str]:
+    """Resolve the CORS policy after settings validation."""
+    return ["*"] if settings_obj.debug else list(settings_obj.cors_allow_origins)
+
+
 app = FastAPI(title="Local RAG Demo", lifespan=lifespan)
 register_exception_handlers(app)
 
 # CORS: keep permissive defaults ONLY in debug mode.
-cors_allow_origins = ["*"] if settings.debug else list(settings.cors_allow_origins)
+cors_allow_origins = _get_cors_allow_origins(settings)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=cors_allow_origins,

--- a/src/local_rag_backend/http/routers/health.py
+++ b/src/local_rag_backend/http/routers/health.py
@@ -4,6 +4,7 @@ Bounded router for health and readiness endpoints.
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Any
 
 import httpx
@@ -32,6 +33,8 @@ if TYPE_CHECKING:
     from local_rag_backend.composition.container import AppContainer
     from local_rag_backend.settings import Settings
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter()
 
 
@@ -40,8 +43,9 @@ async def _check_rag_service(checks: dict[str, Any]) -> bool:
         service = await get_rag_service()
         checks["rag_service"] = "ok" if service else "failed: not initialized"
         return bool(service)
-    except Exception as e:
-        checks["rag_service"] = f"failed: {e!s}"
+    except Exception:
+        logger.exception("RAG-service readiness check failed")
+        checks["rag_service"] = "failed: unavailable"
         return False
 
 
@@ -63,8 +67,9 @@ async def health_check(
         readiness_bundle = container.build_health_readiness_bundle()
         ping_database(diagnostics=readiness_bundle.diagnostics)
         return {"status": "healthy"}
-    except Exception as e:
-        raise ServiceUnavailableError(f"Database connection failed: {e!s}") from e
+    except Exception as exc:
+        logger.exception("Database health check failed")
+        raise ServiceUnavailableError() from exc
 
 
 @router.get("/readyz", tags=["Health"], summary="Readiness probe endpoint")
@@ -118,8 +123,7 @@ async def ollama_health_check(
             httpx.get, settings_obj.ollama_base_url, timeout=5, task_type="network"
         )
         response.raise_for_status()
-        return {"status": "ok", "url": settings_obj.ollama_base_url}
-    except httpx.HTTPError as e:
-        raise ServiceUnavailableError(
-            f"Ollama server not accessible at {settings_obj.ollama_base_url}. Error: {e}",
-        )
+        return {"status": "ok"}
+    except httpx.HTTPError as exc:
+        logger.exception("Ollama health check failed")
+        raise ServiceUnavailableError() from exc

--- a/src/local_rag_backend/infrastructure/llms/ollama_chat.py
+++ b/src/local_rag_backend/infrastructure/llms/ollama_chat.py
@@ -63,16 +63,20 @@ class OllamaGenerator(GeneratorPort):
                 return response_data["response"].strip()
             raise LLMResponseError("Ollama response malformed")
 
-        except httpx.TimeoutException as e:
-            raise LLMTimeoutError(f"Ollama request timed out to {self.api_url}") from e
-        except httpx.ConnectError as e:
-            raise LLMConnectionError(f"Could not connect to Ollama at {self.api_url}") from e
-        except httpx.HTTPStatusError as e:
-            status = e.response.status_code if e.response is not None else 500
-            detail = e.response.text if e.response is not None else str(e)
-            raise LLMResponseError(f"Ollama API error (status={status}): {detail}") from e
-        except httpx.RequestError as e:
-            raise LLMResponseError(f"Ollama API error: {e!s}") from e
-        except Exception as e:
-            logger.error(f"Unexpected error calling Ollama: {e}", exc_info=True)
-            raise LLMResponseError(f"Unexpected error calling Ollama: {e!s}") from e
+        except httpx.TimeoutException as exc:
+            logger.exception("Ollama request timed out")
+            raise LLMTimeoutError("Ollama request timed out") from exc
+        except httpx.ConnectError as exc:
+            logger.exception("Ollama connection failed")
+            raise LLMConnectionError("Could not connect to Ollama") from exc
+        except httpx.HTTPStatusError as exc:
+            logger.exception("Ollama returned an HTTP error")
+            raise LLMResponseError("Ollama returned an error response") from exc
+        except httpx.RequestError as exc:
+            logger.exception("Ollama request failed")
+            raise LLMResponseError("Ollama request failed") from exc
+        except LLMResponseError:
+            raise
+        except Exception as exc:
+            logger.exception("Unexpected error calling Ollama")
+            raise LLMResponseError("Unexpected error calling Ollama") from exc

--- a/src/local_rag_backend/settings.py
+++ b/src/local_rag_backend/settings.py
@@ -568,6 +568,11 @@ class Settings(BaseModel):
         - Backend-specific URL requirements are enforced before runtime wiring.
         - Hybrid/search/persistence combinations are constrained to known-safe modes.
         """
+        if not self.debug and any(origin.strip() == "*" for origin in self.cors_allow_origins):
+            raise ValueError(
+                "cors_allow_origins must contain explicit origins when debug=false; "
+                "the wildcard '*' is allowed only in debug mode"
+            )
         if self.ingest_chunk_overlap >= self.ingest_chunk_chars:
             raise ValueError("ingest_chunk_overlap must be strictly less than ingest_chunk_chars")
         if self.persistence_backend == "elasticsearch":

--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -96,8 +96,14 @@ async def test_get_frontend_assets_packaged_ok(asgi_client, monkeypatch):
 
 
 async def test_get_frontend_assets_path_traversal_404(asgi_client):
-    r = await asgi_client.get("/assets/../pyproject.toml")
-    assert r.status_code == 404
+    paths = (
+        "/assets/../pyproject.toml",
+        "/assets/%2e%2e%2fpyproject.toml",
+        "/assets/%2e%2e%5cpyproject.toml",
+    )
+    for path in paths:
+        r = await asgi_client.get(path)
+        assert r.status_code == 404
 
 
 async def test_api_ask_schema_with_sources(asgi_client, monkeypatch):

--- a/tests/unit/cli/test_server_command.py
+++ b/tests/unit/cli/test_server_command.py
@@ -1,0 +1,34 @@
+from click.testing import CliRunner
+
+from local_rag_backend.cli_commands import server as server_module
+from local_rag_backend.settings import settings
+
+
+def test_server_command_passes_runtime_settings_to_uvicorn(monkeypatch):
+    calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    monkeypatch.setattr(settings, "app_host", "127.0.0.2", raising=False)
+    monkeypatch.setattr(settings, "app_port", 8123, raising=False)
+    monkeypatch.setattr(settings, "debug", True, raising=False)
+    monkeypatch.setattr(settings, "log_level", "WARNING", raising=False)
+    monkeypatch.setattr(settings, "retrieval_mode", "sparse", raising=False)
+    monkeypatch.setattr(
+        "uvicorn.run",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    result = CliRunner().invoke(server_module.server_cmd)
+
+    assert result.exit_code == 0
+    assert calls == [
+        (
+            ("local_rag_backend.http.main:app",),
+            {
+                "host": "127.0.0.2",
+                "port": 8123,
+                "reload": True,
+                "log_level": "warning",
+            },
+        )
+    ]
+    assert "Development (reload)" in result.output
+    assert "Retrieval: sparse" in result.output

--- a/tests/unit/core/use_cases/test_health_use_case.py
+++ b/tests/unit/core/use_cases/test_health_use_case.py
@@ -19,7 +19,7 @@ def test_check_sql_counts_marks_documents_failure_without_failing_history() -> N
 
     assert ready is False
     assert docs_count is None
-    assert str(checks["documents"]).startswith("failed: docs unavailable")
+    assert checks["documents"] == "failed: unavailable"
     assert checks["history"] == {"count": 5}
 
 
@@ -110,7 +110,7 @@ def test_check_retrieval_index_handles_count_mismatch_and_id_drift_errors() -> N
         )
         is False
     )
-    assert str(checks["retrieval_index_drift"]).startswith("failed: cannot read id map")
+    assert checks["retrieval_index_drift"] == "failed: unavailable"
     assert str(checks["retrieval_index"]).startswith(
         "failed: unable to verify retrieval index drift"
     )
@@ -155,7 +155,4 @@ def test_check_mutation_journal_reports_not_applicable_warning_and_failure() -> 
         ),
         diagnostics=_FailingDiagnostics(),
     )
-    assert checks["mutation_journal"] == {
-        "status": "failed",
-        "error": "journal unavailable",
-    }
+    assert checks["mutation_journal"] == {"status": "failed"}

--- a/tests/unit/http/test_api_router_docs_and_eval.py
+++ b/tests/unit/http/test_api_router_docs_and_eval.py
@@ -343,4 +343,5 @@ async def test_openrouter_generate_malformed_response_is_502(asgi_client, monkey
         },
     )
     assert r.status_code == 502
-    assert "malformed response" in r.json()["detail"]
+    assert r.json()["detail"] == "Bad gateway."
+    assert "malformed response" not in r.text

--- a/tests/unit/http/test_api_router_endpoints_extra.py
+++ b/tests/unit/http/test_api_router_endpoints_extra.py
@@ -12,7 +12,8 @@ async def test_health_db_failure(asgi_client, monkeypatch):
     monkeypatch.setattr(health_router, "ping_database", _boom)
     r = await asgi_client.get("/healthz")
     assert r.status_code == 503
-    assert "Database connection failed" in r.json()["detail"]
+    assert r.json()["detail"] == "Service unavailable."
+    assert "db down" not in r.text
 
 
 async def test_ready_not_ready_db_and_no_llm(asgi_client, monkeypatch):
@@ -50,7 +51,7 @@ async def test_ollama_health_ok(asgi_client, monkeypatch):
     monkeypatch.setattr(health_router.httpx, "get", lambda *a, **k: Resp())
     r = await asgi_client.get("/healthz/ollama")
     assert r.status_code == 200
-    assert r.json()["status"] == "ok"
+    assert r.json() == {"status": "ok"}
 
 
 async def test_ollama_health_fail(asgi_client, monkeypatch):
@@ -60,3 +61,5 @@ async def test_ollama_health_fail(asgi_client, monkeypatch):
     monkeypatch.setattr(health_router.httpx, "get", boom)
     r = await asgi_client.get("/healthz/ollama")
     assert r.status_code == 503
+    assert r.json()["detail"] == "Service unavailable."
+    assert "oops" not in r.text

--- a/tests/unit/http/test_api_router_more.py
+++ b/tests/unit/http/test_api_router_more.py
@@ -153,7 +153,8 @@ async def test_ask_returns_503_without_llm_for_valid_payload(
     monkeypatch.setattr(settings, "retrieval_mode", "sparse", raising=False)
     r = await asgi_client.post("/api/ask", json={"question": "hi", "k": 1})
     assert r.status_code == 503
-    assert "No LLM configured" in r.json().get("detail", "")
+    assert r.json()["detail"] == "Service unavailable."
+    assert "No LLM configured" not in r.text
 
 
 @pytest.mark.parametrize("payload", [{"question": "", "k": 1}, {"question": "hi", "k": 0}])
@@ -189,7 +190,8 @@ async def test_ask_maps_typed_llm_timeout_to_504(asgi_client, in_memory_sqlite, 
     r = await asgi_client.post("/api/ask", json={"question": "hi", "k": 1})
 
     assert r.status_code == 504
-    assert "provider timeout" in r.json()["detail"]
+    assert r.json()["detail"] == "Gateway timeout."
+    assert "provider timeout" not in r.text
 
 
 async def test_ask_eval_maps_typed_llm_connection_error_to_503(
@@ -209,4 +211,5 @@ async def test_ask_eval_maps_typed_llm_connection_error_to_503(
         json={"question": "hello", "config": {"retrieval_mode": "sparse", "k": 1}},
     )
     assert r.status_code == 503
-    assert "provider unreachable" in r.json()["detail"]
+    assert r.json()["detail"] == "Service unavailable."
+    assert "provider unreachable" not in r.text

--- a/tests/unit/http/test_cors.py
+++ b/tests/unit/http/test_cors.py
@@ -1,4 +1,10 @@
 import pytest
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from httpx import ASGITransport, AsyncClient
+
+from local_rag_backend.http.main import _get_cors_allow_origins
+from local_rag_backend.settings import Settings
 
 
 @pytest.mark.unit
@@ -15,3 +21,43 @@ async def test_cors_preflight_does_not_enable_credentials(asgi_client, in_memory
     assert r.status_code == 400
     assert "access-control-allow-origin" not in {k.lower() for k in r.headers}
     assert "access-control-allow-credentials" not in {k.lower() for k in r.headers}
+
+
+@pytest.mark.unit
+async def test_cors_preflight_allows_only_configured_production_origin():
+    settings_obj = Settings(
+        debug=False,
+        cors_allow_origins=["https://allowed.example"],
+    )
+    app = FastAPI()
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=_get_cors_allow_origins(settings_obj),
+        allow_credentials=False,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        allowed = await client.options(
+            "/",
+            headers={
+                "Origin": "https://allowed.example",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        denied = await client.options(
+            "/",
+            headers={
+                "Origin": "https://denied.example",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+
+    assert allowed.headers["access-control-allow-origin"] == "https://allowed.example"
+    assert "access-control-allow-origin" not in denied.headers
+
+
+@pytest.mark.unit
+def test_debug_cors_resolves_to_wildcard():
+    assert _get_cors_allow_origins(Settings(debug=True)) == ["*"]

--- a/tests/unit/http/test_error_sanitization.py
+++ b/tests/unit/http/test_error_sanitization.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+import pytest
 from starlette.requests import Request
 
-from local_rag_backend.core.use_cases.errors import InternalServerError
+from local_rag_backend.core.use_cases.errors import (
+    BadGatewayError,
+    GatewayTimeoutError,
+    InternalServerError,
+    ServiceUnavailableError,
+)
 from local_rag_backend.http.exception_handlers import handle_app_error
 from local_rag_backend.settings import settings
 
@@ -24,3 +30,24 @@ async def test_handle_app_error_keeps_500_details_in_debug(monkeypatch):
 
     assert response.status_code == 500
     assert b"debug-detail" in response.body
+
+
+@pytest.mark.parametrize(
+    ("error", "status_code", "public_detail"),
+    [
+        (BadGatewayError("secret-upstream"), 502, b"Bad gateway."),
+        (ServiceUnavailableError("secret-service"), 503, b"Service unavailable."),
+        (GatewayTimeoutError("secret-timeout"), 504, b"Gateway timeout."),
+    ],
+)
+async def test_handle_app_error_hides_all_production_5xx_details(
+    monkeypatch, error, status_code, public_detail
+):
+    monkeypatch.setattr(settings, "debug", False, raising=False)
+    request = Request({"type": "http", "method": "GET", "path": "/", "headers": []})
+
+    response = await handle_app_error(request, error)
+
+    assert response.status_code == status_code
+    assert b"secret-" not in response.body
+    assert public_detail in response.body

--- a/tests/unit/http/test_frontend_assets_security.py
+++ b/tests/unit/http/test_frontend_assets_security.py
@@ -1,0 +1,42 @@
+import pytest
+
+from local_rag_backend.core.use_cases.errors import NotFoundError
+from local_rag_backend.http import main
+
+
+@pytest.mark.parametrize(
+    "asset_path",
+    ["../secret.txt", "nested/../../secret.txt", r"..\secret.txt", "/secret.txt", "./app.js"],
+)
+def test_frontend_asset_rejects_unsafe_paths(asset_path):
+    with pytest.raises(NotFoundError):
+        main._get_frontend_asset(asset_path)
+
+
+def test_frontend_asset_allows_nested_file(tmp_path, monkeypatch):
+    root = tmp_path / "frontend"
+    nested = root / "nested"
+    nested.mkdir(parents=True)
+    (nested / "app.js").write_text("console.log('ok')", encoding="utf-8")
+    monkeypatch.setattr(main, "FRONTEND_DIR", root)
+
+    data, media_type = main._get_frontend_asset("nested/app.js")
+
+    assert data == b"console.log('ok')"
+    assert "javascript" in media_type
+
+
+def test_frontend_asset_rejects_symlink_escape(tmp_path, monkeypatch):
+    root = tmp_path / "frontend"
+    root.mkdir()
+    secret = tmp_path / "secret.txt"
+    secret.write_text("secret", encoding="utf-8")
+    link = root / "escape.txt"
+    try:
+        link.symlink_to(secret)
+    except OSError:
+        pytest.skip("Symlinks are unavailable on this platform")
+    monkeypatch.setattr(main, "FRONTEND_DIR", root)
+
+    with pytest.raises(NotFoundError):
+        main._get_frontend_asset("escape.txt")

--- a/tests/unit/http/test_health_endpoints.py
+++ b/tests/unit/http/test_health_endpoints.py
@@ -180,7 +180,9 @@ async def test_ready_endpoint_503_when_dense_manifest_missing(
     assert r.status_code == 503
     detail = r.json()
     assert detail["status"] == "not_ready"
-    assert "manifest" in detail["checks"]["retrieval_index_stats"].get("error", "")
+    assert detail["checks"]["retrieval_index_stats"]["error"] == "retrieval index unavailable"
+    assert str(idx) not in r.text
+    assert str(id_map) not in r.text
 
 
 async def test_ready_endpoint_503_when_dense_manifest_mismatch_embedding_model(

--- a/tests/unit/http/test_mutation_chaos.py
+++ b/tests/unit/http/test_mutation_chaos.py
@@ -57,7 +57,8 @@ async def test_mutation_fails_when_write_lock_unavailable_returns_503(
             json={"upserts": [{"external_id": "doc-1", "content": "hello"}]},
         )
         assert resp.status_code == 503
-        assert "lock unavailable" in resp.json()["detail"]
+        assert resp.json()["detail"] == "Service unavailable."
+        assert "lock unavailable" not in resp.text
         assert SqlDocumentStorage().get_all_documents() == []
     finally:
         factory.reset_app_context()

--- a/tests/unit/infrastructure/llms/test_ollama_generator.py
+++ b/tests/unit/infrastructure/llms/test_ollama_generator.py
@@ -3,7 +3,11 @@
 import httpx
 import pytest
 
-from local_rag_backend.core.errors import LLMResponseError, LLMTimeoutError
+from local_rag_backend.core.errors import (
+    LLMConnectionError,
+    LLMResponseError,
+    LLMTimeoutError,
+)
 from local_rag_backend.infrastructure.llms.ollama_chat import OllamaGenerator
 
 
@@ -50,5 +54,59 @@ def test_generate_timeout(monkeypatch):
 
     monkeypatch.setattr("local_rag_backend.infrastructure.llms.ollama_chat.httpx.post", _timeout)
     gen = OllamaGenerator()
-    with pytest.raises(LLMTimeoutError):
+    with pytest.raises(LLMTimeoutError) as exc:
         gen.generate("q", ["ctx"])
+    assert str(exc.value) == "Ollama request timed out"
+
+
+def test_generate_connection_error_does_not_expose_uri(monkeypatch):
+    request = httpx.Request("POST", "http://internal-host:11434/api/generate")
+
+    def _connect(*_, **__):
+        raise httpx.ConnectError("secret internal URI", request=request)
+
+    monkeypatch.setattr("local_rag_backend.infrastructure.llms.ollama_chat.httpx.post", _connect)
+    with pytest.raises(LLMConnectionError) as exc:
+        OllamaGenerator().generate("q", ["ctx"])
+    assert str(exc.value) == "Could not connect to Ollama"
+    assert "internal-host" not in str(exc.value)
+
+
+def test_generate_http_error_does_not_expose_response_body(monkeypatch):
+    request = httpx.Request("POST", "http://internal-host:11434/api/generate")
+    response = httpx.Response(500, request=request, text="secret upstream body")
+
+    def _http_error(*_, **__):
+        raise httpx.HTTPStatusError("secret status", request=request, response=response)
+
+    monkeypatch.setattr("local_rag_backend.infrastructure.llms.ollama_chat.httpx.post", _http_error)
+    with pytest.raises(LLMResponseError) as exc:
+        OllamaGenerator().generate("q", ["ctx"])
+    assert str(exc.value) == "Ollama returned an error response"
+    assert "secret" not in str(exc.value)
+
+
+def test_generate_request_error_does_not_expose_detail(monkeypatch):
+    request = httpx.Request("POST", "http://internal-host:11434/api/generate")
+
+    def _request_error(*_, **__):
+        raise httpx.RequestError("secret request detail", request=request)
+
+    monkeypatch.setattr(
+        "local_rag_backend.infrastructure.llms.ollama_chat.httpx.post", _request_error
+    )
+    with pytest.raises(LLMResponseError) as exc:
+        OllamaGenerator().generate("q", ["ctx"])
+    assert str(exc.value) == "Ollama request failed"
+    assert "secret" not in str(exc.value)
+
+
+def test_generate_unexpected_error_does_not_expose_detail(monkeypatch):
+    def _unexpected(*_, **__):
+        raise RuntimeError("secret unexpected detail")
+
+    monkeypatch.setattr("local_rag_backend.infrastructure.llms.ollama_chat.httpx.post", _unexpected)
+    with pytest.raises(LLMResponseError) as exc:
+        OllamaGenerator().generate("q", ["ctx"])
+    assert str(exc.value) == "Unexpected error calling Ollama"
+    assert "secret" not in str(exc.value)

--- a/tests/unit/settings/test_settings_validators.py
+++ b/tests/unit/settings/test_settings_validators.py
@@ -112,6 +112,22 @@ def test_debug_accepts_development_alias_from_string():
     assert s.debug is True
 
 
+def test_production_cors_rejects_wildcard_origin():
+    with pytest.raises(ValueError, match="explicit origins"):
+        Settings(debug=False, cors_allow_origins=["*"])
+
+
+def test_production_cors_accepts_explicit_and_empty_origins():
+    assert Settings(debug=False, cors_allow_origins=[]).cors_allow_origins == []
+    assert Settings(
+        debug=False, cors_allow_origins=["https://app.example.com"]
+    ).cors_allow_origins == ["https://app.example.com"]
+
+
+def test_debug_cors_accepts_wildcard_origin():
+    assert Settings(debug=True, cors_allow_origins="*").cors_allow_origins == ["*"]
+
+
 def test_data_dir_is_not_created_as_a_side_effect(tmp_path):
     d = tmp_path / "new-data-dir"
     assert not d.exists()


### PR DESCRIPTION
## What changed

- reject wildcard CORS origins when `debug=false`, while preserving debug-only wildcard behavior
- sanitize production 5xx responses and public health/readiness failures
- keep exception details in internal logs and remove Ollama URIs/response bodies from propagated errors
- contain frontend asset resolution under the configured frontend root across POSIX and Windows-style traversal inputs
- add focused coverage for the `rag-server` command
- document the production CORS migration

## Scanner disposition

Confirmed and fixed: production wildcard CORS, health-check exception leakage, Ollama/API exception leakage, and cross-platform frontend path containment.

Rejected as false positives: the two alleged SQLAlchemy N+1 findings (`Session.add()` is unit-of-work registration, not one query per call) and missing coverage for `_ingestion_planner.py` (94% through existing CLI tests). `server.py` had only 45% coverage and now has a focused test.

## User/developer impact

Production configurations using `cors_allow_origins: ["*"]` now fail validation and must list explicit origins or use an empty list. Production 5xx details are stable generic messages; debug may retain typed details, while public probes remain sanitized. Routes and success response codes are unchanged.

## Validation

- Ruff lint and format: passed
- import-linter: 5/5 contracts kept
- mypy: 165 files, no issues
- pytest: 762 passed, 4 skipped, 87.67% coverage
- pre-commit: all hooks passed, including Bandit and Gitleaks
- focused security regression suite: 76 passed

`make sec-hard` remains red on the unchanged remote lockfile: Safety reports 36 pre-existing dependency advisories, including `python-multipart==0.0.22` and `starlette==0.50.0`. Bandit itself passes. The remote branch does not yet contain the unpublished local `repo-contract.yaml`, so no contract-check result is claimed here.